### PR TITLE
feat(tracing): added tracing middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ fix:
 	@echo "✅ Lint fixing completed"
 
 .PHONY: buf-gen
+buf-gen:
 	buf generate
 	@echo "✅ Buf generation completed"
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-kratos-ecosystem/components/v2
 go 1.22
 
 require (
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.35.1-20240920164238-5a7b106cbb87.1
 	entgo.io/ent v0.14.0
 	github.com/bufbuild/protovalidate-go v0.7.2
 	github.com/cheggaaa/pb/v3 v3.1.5
@@ -29,13 +30,13 @@ require (
 	go.opentelemetry.io/otel/trace v1.31.0
 	golang.org/x/term v0.25.0
 	golang.org/x/text v0.19.0
+	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.1
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/gorm v1.25.12
 )
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.35.1-20240920164238-5a7b106cbb87.1 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
@@ -82,9 +83,9 @@ require (
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 // indirect
-	google.golang.org/grpc v1.67.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/middleware/tracing/README.md
+++ b/middleware/tracing/README.md
@@ -7,7 +7,30 @@ The package is forked from [tracing](https://github.com/go-kratos/kratos/tree/8b
 ## Usage Example
 
 ```go
-// todo
+package main
+
+import (
+	"github.com/go-kratos/kratos/v2"
+	"github.com/go-kratos/kratos/v2/transport/http"
+
+	"github.com/go-kratos-ecosystem/components/v2/middleware/tracing"
+)
+
+func main() {
+	app := kratos.New(
+		kratos.Name("tracing"),
+		kratos.Server(
+			http.NewServer(
+				http.Address(":8001"),
+				http.Middleware(tracing.Server()),
+			),
+		),
+	)
+
+	if err := app.Run(); err != nil {
+		panic(err)
+	}
+}
 ```
 
 ## License

--- a/middleware/tracing/README.md
+++ b/middleware/tracing/README.md
@@ -1,0 +1,16 @@
+# Tracing Middleware
+
+The tracing middleware provides a way to trace the execution of a request through the application. It is based on the [OpenTelemetry](http://opentelemetry.io/) standard and can be used with any tracer that implements this standard.
+
+The package is forked from [tracing](https://github.com/go-kratos/kratos/tree/8b8dc4b0f8bebb76939780f59734c20c265669c5/middleware/tracing) and optimized on this basis. Thanks to the original author for his contribution.
+
+## Usage Example
+
+```go
+// todo
+```
+
+## License
+
+- The MIT License ([MIT](https://github.com/go-kratos-ecosystem/components/blob/2.x/LICENSE)). 
+- [Kratos](https://github.com/go-kratos/kratos) License File: [License File](https://github.com/go-kratos/kratos/blob/8b8dc4b0f8bebb76939780f59734c20c265669c5/LICENSE)

--- a/middleware/tracing/metadata.go
+++ b/middleware/tracing/metadata.go
@@ -1,0 +1,44 @@
+package tracing
+
+import (
+	"context"
+
+	"github.com/go-kratos/kratos/v2"
+	"github.com/go-kratos/kratos/v2/metadata"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const serviceHeader = "x-md-service-name"
+
+// Metadata is tracing metadata propagator
+type Metadata struct{}
+
+var _ propagation.TextMapPropagator = Metadata{}
+
+// Inject sets metadata key-values from ctx into the carrier.
+func (b Metadata) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	app, ok := kratos.FromContext(ctx)
+	if ok {
+		carrier.Set(serviceHeader, app.Name())
+	}
+}
+
+// Extract returns a copy of parent with the metadata from the carrier added.
+func (b Metadata) Extract(parent context.Context, carrier propagation.TextMapCarrier) context.Context {
+	name := carrier.Get(serviceHeader)
+	if name == "" {
+		return parent
+	}
+	if md, ok := metadata.FromServerContext(parent); ok {
+		md.Set(serviceHeader, name)
+		return parent
+	}
+	md := metadata.New()
+	md.Set(serviceHeader, name)
+	return metadata.NewServerContext(parent, md)
+}
+
+// Fields returns the keys who's values are set with Inject.
+func (b Metadata) Fields() []string {
+	return []string{serviceHeader}
+}

--- a/middleware/tracing/metadata_test.go
+++ b/middleware/tracing/metadata_test.go
@@ -1,0 +1,106 @@
+package tracing
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2"
+	"github.com/go-kratos/kratos/v2/metadata"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TestMetadata_Inject(t *testing.T) {
+	type args struct {
+		appName string
+		carrier propagation.TextMapCarrier
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "https://go-kratos.dev",
+			args: args{"https://go-kratos.dev", propagation.HeaderCarrier{}},
+			want: "https://go-kratos.dev",
+		},
+		{
+			name: "https://github.com/go-kratos/kratos",
+			args: args{"https://github.com/go-kratos/kratos", propagation.HeaderCarrier{"mode": []string{"test"}}},
+			want: "https://github.com/go-kratos/kratos",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := kratos.New(kratos.Name(tt.args.appName))
+			ctx := kratos.NewContext(context.Background(), a)
+			m := new(Metadata)
+			m.Inject(ctx, tt.args.carrier)
+			if res := tt.args.carrier.Get(serviceHeader); tt.want != res {
+				t.Errorf("Get(serviceHeader) :%s want: %s", res, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetadata_Extract(t *testing.T) {
+	type args struct {
+		parent  context.Context
+		carrier propagation.TextMapCarrier
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		crash bool
+	}{
+		{
+			name: "https://go-kratos.dev",
+			args: args{
+				parent:  context.Background(),
+				carrier: propagation.HeaderCarrier{"X-Md-Service-Name": []string{"https://go-kratos.dev"}},
+			},
+			want: "https://go-kratos.dev",
+		},
+		{
+			name: "https://github.com/go-kratos/kratos",
+			args: args{
+				parent:  metadata.NewServerContext(context.Background(), metadata.Metadata{}),
+				carrier: propagation.HeaderCarrier{"X-Md-Service-Name": []string{"https://github.com/go-kratos/kratos"}},
+			},
+			want: "https://github.com/go-kratos/kratos",
+		},
+		{
+			name: "https://github.com/go-kratos/kratos",
+			args: args{
+				parent:  metadata.NewServerContext(context.Background(), metadata.Metadata{}),
+				carrier: propagation.HeaderCarrier{"X-Md-Service-Name": nil},
+			},
+			crash: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := Metadata{}
+			ctx := b.Extract(tt.args.parent, tt.args.carrier)
+			md, ok := metadata.FromServerContext(ctx)
+			if !ok {
+				if tt.crash {
+					return
+				}
+				t.Errorf("expect %v, got %v", true, ok)
+			}
+			if !reflect.DeepEqual(md.Get(serviceHeader), tt.want) {
+				t.Errorf("expect %v, got %v", tt.want, md.Get(serviceHeader))
+			}
+		})
+	}
+}
+
+func TestFields(t *testing.T) {
+	b := Metadata{}
+	if !reflect.DeepEqual(b.Fields(), []string{"x-md-service-name"}) {
+		t.Errorf("expect %v, got %v", []string{"x-md-service-name"}, b.Fields())
+	}
+}

--- a/middleware/tracing/span.go
+++ b/middleware/tracing/span.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func setClientSpan(ctx context.Context, span trace.Span, m interface{}) {
+func setClientSpan(ctx context.Context, span trace.Span, m any) {
 	var (
 		attrs     []attribute.KeyValue
 		remote    string
@@ -57,7 +57,7 @@ func setClientSpan(ctx context.Context, span trace.Span, m interface{}) {
 	span.SetAttributes(attrs...)
 }
 
-func setServerSpan(ctx context.Context, span trace.Span, m interface{}) {
+func setServerSpan(ctx context.Context, span trace.Span, m any) {
 	var (
 		attrs     []attribute.KeyValue
 		remote    string
@@ -105,8 +105,8 @@ func setServerSpan(ctx context.Context, span trace.Span, m interface{}) {
 // on a gRPC's FullMethod.
 func parseFullMethod(fullMethod string) (string, []attribute.KeyValue) {
 	name := strings.TrimLeft(fullMethod, "/")
-	parts := strings.SplitN(name, "/", 2)
-	if len(parts) != 2 { //nolint:gomnd
+	parts := strings.SplitN(name, "/", 2) //nolint:mnd
+	if len(parts) != 2 {                  //nolint:mnd
 		// Invalid format, does not follow `/package.service/method`.
 		return name, []attribute.KeyValue{attribute.Key("rpc.operation").String(fullMethod)}
 	}

--- a/middleware/tracing/span.go
+++ b/middleware/tracing/span.go
@@ -1,0 +1,158 @@
+package tracing
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/go-kratos/kratos/v2/metadata"
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/go-kratos/kratos/v2/transport/http"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/protobuf/proto"
+)
+
+func setClientSpan(ctx context.Context, span trace.Span, m interface{}) {
+	var (
+		attrs     []attribute.KeyValue
+		remote    string
+		operation string
+		rpcKind   string
+	)
+	tr, ok := transport.FromClientContext(ctx)
+	if ok {
+		operation = tr.Operation()
+		rpcKind = tr.Kind().String()
+		switch tr.Kind() {
+		case transport.KindHTTP:
+			if ht, ok := tr.(http.Transporter); ok {
+				attrs = append(attrs,
+					semconv.HTTPRequestMethodKey.String(ht.Request().Method),
+					semconv.HTTPRoute(ht.PathTemplate()),
+					semconv.URLPath(ht.Request().URL.Path),
+				)
+				remote = ht.Request().Host
+			}
+		case transport.KindGRPC:
+			remote, _ = parseTarget(tr.Endpoint())
+		}
+	}
+	attrs = append(attrs, semconv.RPCSystemKey.String(rpcKind))
+	_, mAttrs := parseFullMethod(operation)
+	attrs = append(attrs, mAttrs...)
+	if remote != "" {
+		attrs = append(attrs, peerAttr(remote)...)
+	}
+	if p, ok := m.(proto.Message); ok {
+		attrs = append(attrs, attribute.Key("send_msg.size").Int(proto.Size(p)))
+	}
+
+	span.SetAttributes(attrs...)
+}
+
+func setServerSpan(ctx context.Context, span trace.Span, m interface{}) {
+	var (
+		attrs     []attribute.KeyValue
+		remote    string
+		operation string
+		rpcKind   string
+	)
+	tr, ok := transport.FromServerContext(ctx)
+	if ok {
+		operation = tr.Operation()
+		rpcKind = tr.Kind().String()
+		switch tr.Kind() {
+		case transport.KindHTTP:
+			if ht, ok := tr.(http.Transporter); ok {
+				attrs = append(attrs,
+					semconv.HTTPRequestMethodKey.String(ht.Request().Method),
+					semconv.HTTPRoute(ht.PathTemplate()),
+					semconv.URLPath(ht.Request().URL.Path),
+				)
+				remote = ht.Request().RemoteAddr
+			}
+		case transport.KindGRPC:
+			if p, ok := peer.FromContext(ctx); ok {
+				remote = p.Addr.String()
+			}
+		}
+	}
+	attrs = append(attrs, semconv.RPCSystemKey.String(rpcKind))
+	_, mAttrs := parseFullMethod(operation)
+	attrs = append(attrs, mAttrs...)
+	attrs = append(attrs, peerAttr(remote)...)
+	if p, ok := m.(proto.Message); ok {
+		attrs = append(attrs, attribute.Key("recv_msg.size").Int(proto.Size(p)))
+	}
+	if md, ok := metadata.FromServerContext(ctx); ok {
+		attrs = append(attrs, semconv.PeerServiceKey.String(md.Get(serviceHeader)))
+	}
+
+	span.SetAttributes(attrs...)
+}
+
+// parseFullMethod returns a span name following the OpenTelemetry semantic
+// conventions as well as all applicable span attribute.KeyValue attributes based
+// on a gRPC's FullMethod.
+func parseFullMethod(fullMethod string) (string, []attribute.KeyValue) {
+	name := strings.TrimLeft(fullMethod, "/")
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 { //nolint:gomnd
+		// Invalid format, does not follow `/package.service/method`.
+		return name, []attribute.KeyValue{attribute.Key("rpc.operation").String(fullMethod)}
+	}
+
+	var attrs []attribute.KeyValue
+	if service := parts[0]; service != "" {
+		attrs = append(attrs, semconv.RPCServiceKey.String(service))
+	}
+	if method := parts[1]; method != "" {
+		attrs = append(attrs, semconv.RPCMethodKey.String(method))
+	}
+	return name, attrs
+}
+
+// peerAttr returns attributes about the peer address.
+func peerAttr(addr string) (attrs []attribute.KeyValue) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return
+	}
+
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	attrs = append(attrs,
+		semconv.NetworkPeerAddress(host),
+	)
+
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return
+	}
+	attrs = append(attrs,
+		semconv.NetworkPeerPort(portInt),
+	)
+
+	return
+}
+
+func parseTarget(endpoint string) (address string, err error) {
+	var u *url.URL
+	u, err = url.Parse(endpoint)
+	if err != nil {
+		if u, err = url.Parse("http://" + endpoint); err != nil {
+			return "", err
+		}
+		return u.Host, nil
+	}
+	if len(u.Path) > 1 {
+		return u.Path[1:], nil
+	}
+	return endpoint, nil
+}

--- a/middleware/tracing/span.go
+++ b/middleware/tracing/span.go
@@ -35,6 +35,8 @@ func setClientSpan(ctx context.Context, span trace.Span, m interface{}) {
 					semconv.HTTPRequestMethodKey.String(ht.Request().Method),
 					semconv.HTTPRoute(ht.PathTemplate()),
 					semconv.URLPath(ht.Request().URL.Path),
+					semconv.ClientAddress(ht.Request().RemoteAddr),
+					semconv.UserAgentOriginal(ht.Request().UserAgent()),
 				)
 				remote = ht.Request().Host
 			}
@@ -73,6 +75,8 @@ func setServerSpan(ctx context.Context, span trace.Span, m interface{}) {
 					semconv.HTTPRequestMethodKey.String(ht.Request().Method),
 					semconv.HTTPRoute(ht.PathTemplate()),
 					semconv.URLPath(ht.Request().URL.Path),
+					semconv.ClientAddress(ht.Request().RemoteAddr),
+					semconv.UserAgentOriginal(ht.Request().UserAgent()),
 				)
 				remote = ht.Request().RemoteAddr
 			}
@@ -90,7 +94,7 @@ func setServerSpan(ctx context.Context, span trace.Span, m interface{}) {
 		attrs = append(attrs, attribute.Key("recv_msg.size").Int(proto.Size(p)))
 	}
 	if md, ok := metadata.FromServerContext(ctx); ok {
-		attrs = append(attrs, semconv.PeerServiceKey.String(md.Get(serviceHeader)))
+		attrs = append(attrs, semconv.PeerService(md.Get(serviceHeader)))
 	}
 
 	span.SetAttributes(attrs...)

--- a/middleware/tracing/span_test.go
+++ b/middleware/tracing/span_test.go
@@ -1,0 +1,250 @@
+package tracing
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/metadata"
+	"github.com/go-kratos/kratos/v2/transport"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc/peer"
+
+	tracingpb "github.com/go-kratos-ecosystem/components/v2/genproto/tests/middleware/tracing/v1"
+)
+
+func Test_parseFullMethod(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullMethod string
+		want       string
+		wantAttr   []attribute.KeyValue
+	}{
+		{
+			name:       "/foo.bar/hello",
+			fullMethod: "/foo.bar/hello",
+			want:       "foo.bar/hello",
+			wantAttr: []attribute.KeyValue{
+				semconv.RPCServiceKey.String("foo.bar"),
+				semconv.RPCMethodKey.String("hello"),
+			},
+		},
+		{
+			name:       "/foo.bar/hello/world",
+			fullMethod: "/foo.bar/hello/world",
+			want:       "foo.bar/hello/world",
+			wantAttr: []attribute.KeyValue{
+				semconv.RPCServiceKey.String("foo.bar"),
+				semconv.RPCMethodKey.String("hello/world"),
+			},
+		},
+		{
+			name:       "/hello",
+			fullMethod: "/hello",
+			want:       "hello",
+			wantAttr:   []attribute.KeyValue{attribute.Key("rpc.operation").String("/hello")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := parseFullMethod(tt.fullMethod)
+			if got != tt.want {
+				t.Errorf("parseFullMethod() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.wantAttr) {
+				t.Errorf("parseFullMethod() got1 = %v, want %v", got1, tt.wantAttr)
+			}
+		})
+	}
+}
+
+func Test_peerAttr(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want []attribute.KeyValue
+	}{
+		{
+			name: "nil addr",
+			addr: ":8080",
+			want: []attribute.KeyValue{
+				semconv.NetworkPeerAddress("127.0.0.1"),
+				semconv.NetworkPeerPort(8080),
+			},
+		},
+		{
+			name: "normal addr without port",
+			addr: "192.168.0.1",
+			want: []attribute.KeyValue(nil),
+		},
+		{
+			name: "normal addr with port",
+			addr: "192.168.0.1:8080",
+			want: []attribute.KeyValue{
+				semconv.NetworkPeerAddress("192.168.0.1"),
+				semconv.NetworkPeerPort(8080),
+			},
+		},
+		{
+			name: "dns addr",
+			addr: "foo:8080",
+			want: []attribute.KeyValue{
+				semconv.NetworkPeerAddress("foo"),
+				semconv.NetworkPeerPort(8080),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := peerAttr(tt.addr); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("peerAttr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpoint    string
+		wantAddress string
+		wantErr     bool
+	}{
+		{
+			name:        "http",
+			endpoint:    "http://foo.bar:8080",
+			wantAddress: "http://foo.bar:8080",
+			wantErr:     false,
+		},
+		{
+			name:        "http",
+			endpoint:    "http://127.0.0.1:8080",
+			wantAddress: "http://127.0.0.1:8080",
+			wantErr:     false,
+		},
+		{
+			name:        "without protocol",
+			endpoint:    "foo.bar:8080",
+			wantAddress: "foo.bar:8080",
+			wantErr:     false,
+		},
+		{
+			name:        "grpc",
+			endpoint:    "grpc://foo.bar",
+			wantAddress: "grpc://foo.bar",
+			wantErr:     false,
+		},
+		{
+			name:        "with path",
+			endpoint:    "/foo",
+			wantAddress: "foo",
+			wantErr:     false,
+		},
+		{
+			name:        "with path",
+			endpoint:    "http://127.0.0.1/hello",
+			wantAddress: "hello",
+			wantErr:     false,
+		},
+		{
+			name:        "empty",
+			endpoint:    "%%",
+			wantAddress: "",
+			wantErr:     true,
+		},
+		{
+			name:        "invalid path",
+			endpoint:    "//%2F/#%2Fanother",
+			wantAddress: "",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAddress, err := parseTarget(tt.endpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseTarget() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotAddress != tt.wantAddress {
+				t.Errorf("parseTarget() = %v, want %v", gotAddress, tt.wantAddress)
+			}
+		})
+	}
+}
+
+func TestSetServerSpan(_ *testing.T) {
+	ctx := context.Background()
+	_, span := noop.NewTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
+
+	// Handle without Transport context
+	setServerSpan(ctx, span, nil)
+
+	// Handle with proto message
+	m := &tracingpb.HelloRequest{}
+	setServerSpan(ctx, span, m)
+
+	// Handle with metadata context
+	ctx = metadata.NewServerContext(ctx, metadata.New())
+	setServerSpan(ctx, span, m)
+
+	// Handle with KindHTTP transport context
+	mt := &mockTransport{
+		kind: transport.KindHTTP,
+	}
+	mt.request, _ = http.NewRequest(http.MethodGet, "/endpoint", nil)
+	ctx = transport.NewServerContext(ctx, mt)
+	setServerSpan(ctx, span, m)
+
+	// Handle with KindGRPC transport context
+	mt.kind = transport.KindGRPC
+	ctx = transport.NewServerContext(ctx, mt)
+	ip, _ := net.ResolveIPAddr("ip", "1.1.1.1")
+	ctx = peer.NewContext(ctx, &peer.Peer{
+		Addr: ip,
+	})
+	setServerSpan(ctx, span, m)
+}
+
+func TestSetClientSpan(_ *testing.T) {
+	ctx := context.Background()
+	_, span := noop.NewTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
+
+	// Handle without Transport context
+	setClientSpan(ctx, span, nil)
+
+	// Handle with proto message
+	m := &tracingpb.HelloRequest{}
+	setClientSpan(ctx, span, m)
+
+	// Handle with metadata context
+	ctx = metadata.NewClientContext(ctx, metadata.New())
+	setClientSpan(ctx, span, m)
+
+	// Handle with KindHTTP transport context
+	mt := &mockTransport{
+		kind: transport.KindHTTP,
+	}
+	mt.request, _ = http.NewRequest(http.MethodGet, "/endpoint", nil)
+	mt.request.Host = "MyServer"
+	ctx = transport.NewClientContext(ctx, mt)
+	setClientSpan(ctx, span, m)
+
+	// Handle with KindGRPC transport context
+	mt.kind = transport.KindGRPC
+	ctx = transport.NewClientContext(ctx, mt)
+	ip, _ := net.ResolveIPAddr("ip", "1.1.1.1")
+	ctx = peer.NewContext(ctx, &peer.Peer{
+		Addr: ip,
+	})
+	setClientSpan(ctx, span, m)
+
+	// Handle without Host request
+	ctx = transport.NewClientContext(ctx, mt)
+	setClientSpan(ctx, span, m)
+}

--- a/middleware/tracing/statshandler.go
+++ b/middleware/tracing/statshandler.go
@@ -1,0 +1,43 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/stats"
+)
+
+// ClientHandler is tracing ClientHandler
+type ClientHandler struct{}
+
+// HandleConn exists to satisfy gRPC stats.Handler.
+func (c *ClientHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
+	fmt.Println("Handle connection.")
+}
+
+// TagConn exists to satisfy gRPC stats.Handler.
+func (c *ClientHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// HandleRPC implements per-RPC tracing and stats instrumentation.
+func (c *ClientHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	if _, ok := rs.(*stats.OutHeader); !ok {
+		return
+	}
+	p, ok := peer.FromContext(ctx)
+	if !ok {
+		return
+	}
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().IsValid() {
+		span.SetAttributes(peerAttr(p.Addr.String())...)
+	}
+}
+
+// TagRPC implements per-RPC context management.
+func (c *ClientHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}

--- a/middleware/tracing/statshandler_test.go
+++ b/middleware/tracing/statshandler_test.go
@@ -1,0 +1,80 @@
+package tracing
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/stats"
+)
+
+type ctxKey string
+
+const testKey ctxKey = "MY_TEST_KEY"
+
+func TestClient_HandleConn(_ *testing.T) {
+	(&ClientHandler{}).HandleConn(context.Background(), nil)
+}
+
+func TestClient_TagConn(t *testing.T) {
+	client := &ClientHandler{}
+	ctx := context.WithValue(context.Background(), testKey, 123)
+
+	if client.TagConn(ctx, nil).Value(testKey) != 123 {
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value(testKey))
+	}
+}
+
+func TestClient_TagRPC(t *testing.T) {
+	client := &ClientHandler{}
+	ctx := context.WithValue(context.Background(), testKey, 123)
+
+	if client.TagRPC(ctx, nil).Value(testKey) != 123 {
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value(testKey))
+	}
+}
+
+type mockSpan struct {
+	trace.Span
+	mockSpanCtx *trace.SpanContext
+}
+
+func (m *mockSpan) SpanContext() trace.SpanContext {
+	return *m.mockSpanCtx
+}
+
+func TestClient_HandleRPC(_ *testing.T) {
+	client := &ClientHandler{}
+	ctx := context.Background()
+	rs := stats.OutHeader{}
+
+	// Handle stats.RPCStats is not type of stats.OutHeader case
+	client.HandleRPC(context.TODO(), nil)
+
+	// Handle context doesn't have the peerkey filled with a Peer instance
+	client.HandleRPC(ctx, &rs)
+
+	// Handle context with the peerkey filled with a Peer instance
+	ip, _ := net.ResolveIPAddr("ip", "1.1.1.1")
+	ctx = peer.NewContext(ctx, &peer.Peer{
+		Addr: ip,
+	})
+	client.HandleRPC(ctx, &rs)
+
+	// Handle context with Span
+	_, span := noop.NewTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
+	spanCtx := trace.SpanContext{}
+	spanID := [8]byte{12, 12, 12, 12, 12, 12, 12, 12}
+	traceID := [16]byte{12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12}
+	spanCtx = spanCtx.WithTraceID(traceID)
+	spanCtx = spanCtx.WithSpanID(spanID)
+	mSpan := mockSpan{
+		Span:        span,
+		mockSpanCtx: &spanCtx,
+	}
+	ctx = trace.ContextWithSpan(ctx, &mSpan)
+	client.HandleRPC(ctx, &rs)
+}

--- a/middleware/tracing/statshandler_test.go
+++ b/middleware/tracing/statshandler_test.go
@@ -24,7 +24,8 @@ func TestClient_TagConn(t *testing.T) {
 	ctx := context.WithValue(context.Background(), testKey, 123)
 
 	if client.TagConn(ctx, nil).Value(testKey) != 123 {
-		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value(testKey))
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`,
+			client.TagConn(ctx, nil).Value(testKey))
 	}
 }
 
@@ -33,7 +34,8 @@ func TestClient_TagRPC(t *testing.T) {
 	ctx := context.WithValue(context.Background(), testKey, 123)
 
 	if client.TagRPC(ctx, nil).Value(testKey) != 123 {
-		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value(testKey))
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`,
+			client.TagConn(ctx, nil).Value(testKey))
 	}
 }
 

--- a/middleware/tracing/tracer.go
+++ b/middleware/tracing/tracer.go
@@ -44,7 +44,9 @@ func NewTracer(kind trace.SpanKind, opts ...Option) *Tracer {
 }
 
 // Start start tracing span
-func (t *Tracer) Start(ctx context.Context, operation string, carrier propagation.TextMapCarrier) (context.Context, trace.Span) {
+func (t *Tracer) Start(
+	ctx context.Context, operation string, carrier propagation.TextMapCarrier,
+) (context.Context, trace.Span) {
 	if t.kind == trace.SpanKindServer {
 		ctx = t.opt.propagator.Extract(ctx, carrier)
 	}
@@ -59,7 +61,7 @@ func (t *Tracer) Start(ctx context.Context, operation string, carrier propagatio
 }
 
 // End finish tracing span
-func (t *Tracer) End(_ context.Context, span trace.Span, m interface{}, err error) {
+func (t *Tracer) End(_ context.Context, span trace.Span, m any, err error) {
 	if err != nil {
 		span.RecordError(err)
 		if e := errors.FromError(err); e != nil {

--- a/middleware/tracing/tracer.go
+++ b/middleware/tracing/tracer.go
@@ -1,0 +1,81 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kratos/kratos/v2/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
+)
+
+// Tracer is otel span tracer
+type Tracer struct {
+	tracer trace.Tracer
+	kind   trace.SpanKind
+	opt    *options
+}
+
+// NewTracer create tracer instance
+func NewTracer(kind trace.SpanKind, opts ...Option) *Tracer {
+	op := options{
+		propagator: propagation.NewCompositeTextMapPropagator(Metadata{}, propagation.Baggage{}, propagation.TraceContext{}),
+		tracerName: "kratos",
+	}
+	for _, o := range opts {
+		o(&op)
+	}
+	if op.tracerProvider == nil {
+		op.tracerProvider = otel.GetTracerProvider()
+	}
+
+	switch kind {
+	case trace.SpanKindClient:
+		return &Tracer{tracer: op.tracerProvider.Tracer(op.tracerName), kind: kind, opt: &op}
+	case trace.SpanKindServer:
+		return &Tracer{tracer: op.tracerProvider.Tracer(op.tracerName), kind: kind, opt: &op}
+	default:
+		panic(fmt.Sprintf("unsupported span kind: %v", kind))
+	}
+}
+
+// Start start tracing span
+func (t *Tracer) Start(ctx context.Context, operation string, carrier propagation.TextMapCarrier) (context.Context, trace.Span) {
+	if t.kind == trace.SpanKindServer {
+		ctx = t.opt.propagator.Extract(ctx, carrier)
+	}
+	ctx, span := t.tracer.Start(ctx,
+		operation,
+		trace.WithSpanKind(t.kind),
+	)
+	if t.kind == trace.SpanKindClient {
+		t.opt.propagator.Inject(ctx, carrier)
+	}
+	return ctx, span
+}
+
+// End finish tracing span
+func (t *Tracer) End(_ context.Context, span trace.Span, m interface{}, err error) {
+	if err != nil {
+		span.RecordError(err)
+		if e := errors.FromError(err); e != nil {
+			span.SetAttributes(attribute.Key("rpc.status_code").Int64(int64(e.Code)))
+		}
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "OK")
+	}
+
+	if p, ok := m.(proto.Message); ok {
+		if t.kind == trace.SpanKindServer {
+			span.SetAttributes(attribute.Key("send_msg.size").Int(proto.Size(p)))
+		} else {
+			span.SetAttributes(attribute.Key("recv_msg.size").Int(proto.Size(p)))
+		}
+	}
+	span.End()
+}

--- a/middleware/tracing/tracer_test.go
+++ b/middleware/tracing/tracer_test.go
@@ -1,0 +1,56 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	tracingpb "github.com/go-kratos-ecosystem/components/v2/genproto/tests/middleware/tracing/v1"
+)
+
+func TestNewTracer(t *testing.T) {
+	tracer := NewTracer(trace.SpanKindClient, func(o *options) {
+		o.tracerProvider = noop.NewTracerProvider()
+	})
+
+	if tracer.kind != trace.SpanKindClient {
+		t.Errorf("The tracer kind must be equal to trace.SpanKindClient, %v given.", tracer.kind)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("The NewTracer with an invalid SpanKindMustCrash must panic")
+		}
+	}()
+	_ = NewTracer(666, func(o *options) {
+		o.tracerProvider = noop.NewTracerProvider()
+	})
+}
+
+func TestTracer_End(_ *testing.T) {
+	tracer := NewTracer(trace.SpanKindClient, func(o *options) {
+		o.tracerProvider = noop.NewTracerProvider()
+	})
+	ctx, span := noop.NewTracerProvider().Tracer("noop").Start(context.Background(), "noopSpan")
+
+	// Handle with error case
+	tracer.End(ctx, span, nil, errors.New("dummy error"))
+
+	// Handle without error case
+	tracer.End(ctx, span, nil, nil)
+
+	m := &tracingpb.HelloRequest{}
+
+	// Handle the trace KindServer
+	tracer = NewTracer(trace.SpanKindServer, func(o *options) {
+		o.tracerProvider = noop.NewTracerProvider()
+	})
+	tracer.End(ctx, span, m, nil)
+	tracer = NewTracer(trace.SpanKindClient, func(o *options) {
+		o.tracerProvider = noop.NewTracerProvider()
+	})
+	tracer.End(ctx, span, m, nil)
+}

--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -1,0 +1,95 @@
+package tracing
+
+import (
+	"context"
+
+	"github.com/go-kratos/kratos/v2/log"
+
+	"github.com/go-kratos/kratos/v2/middleware"
+	"github.com/go-kratos/kratos/v2/transport"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Option is tracing option.
+type Option func(*options)
+
+type options struct {
+	tracerName     string
+	tracerProvider trace.TracerProvider
+	propagator     propagation.TextMapPropagator
+}
+
+// WithPropagator with tracer propagator.
+func WithPropagator(propagator propagation.TextMapPropagator) Option {
+	return func(opts *options) {
+		opts.propagator = propagator
+	}
+}
+
+// WithTracerProvider with tracer provider.
+// By default, it uses the global provider that is set by otel.SetTracerProvider(provider).
+func WithTracerProvider(provider trace.TracerProvider) Option {
+	return func(opts *options) {
+		opts.tracerProvider = provider
+	}
+}
+
+// WithTracerName with tracer name
+func WithTracerName(tracerName string) Option {
+	return func(opts *options) {
+		opts.tracerName = tracerName
+	}
+}
+
+// Server returns a new server middleware for OpenTelemetry.
+func Server(opts ...Option) middleware.Middleware {
+	tracer := NewTracer(trace.SpanKindServer, opts...)
+	return func(handler middleware.Handler) middleware.Handler {
+		return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
+			if tr, ok := transport.FromServerContext(ctx); ok {
+				var span trace.Span
+				ctx, span = tracer.Start(ctx, tr.Operation(), tr.RequestHeader())
+				setServerSpan(ctx, span, req)
+				defer func() { tracer.End(ctx, span, reply, err) }()
+			}
+			return handler(ctx, req)
+		}
+	}
+}
+
+// Client returns a new client middleware for OpenTelemetry.
+func Client(opts ...Option) middleware.Middleware {
+	tracer := NewTracer(trace.SpanKindClient, opts...)
+	return func(handler middleware.Handler) middleware.Handler {
+		return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
+			if tr, ok := transport.FromClientContext(ctx); ok {
+				var span trace.Span
+				ctx, span = tracer.Start(ctx, tr.Operation(), tr.RequestHeader())
+				setClientSpan(ctx, span, req)
+				defer func() { tracer.End(ctx, span, reply, err) }()
+			}
+			return handler(ctx, req)
+		}
+	}
+}
+
+// TraceID returns a traceid valuer.
+func TraceID() log.Valuer {
+	return func(ctx context.Context) interface{} {
+		if span := trace.SpanContextFromContext(ctx); span.HasTraceID() {
+			return span.TraceID().String()
+		}
+		return ""
+	}
+}
+
+// SpanID returns a spanid valuer.
+func SpanID() log.Valuer {
+	return func(ctx context.Context) interface{} {
+		if span := trace.SpanContextFromContext(ctx); span.HasSpanID() {
+			return span.SpanID().String()
+		}
+		return ""
+	}
+}

--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -46,7 +46,7 @@ func WithTracerName(tracerName string) Option {
 func Server(opts ...Option) middleware.Middleware {
 	tracer := NewTracer(trace.SpanKindServer, opts...)
 	return func(handler middleware.Handler) middleware.Handler {
-		return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
+		return func(ctx context.Context, req any) (reply any, err error) {
 			if tr, ok := transport.FromServerContext(ctx); ok {
 				var span trace.Span
 				ctx, span = tracer.Start(ctx, tr.Operation(), tr.RequestHeader())
@@ -62,7 +62,7 @@ func Server(opts ...Option) middleware.Middleware {
 func Client(opts ...Option) middleware.Middleware {
 	tracer := NewTracer(trace.SpanKindClient, opts...)
 	return func(handler middleware.Handler) middleware.Handler {
-		return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
+		return func(ctx context.Context, req any) (reply any, err error) {
 			if tr, ok := transport.FromClientContext(ctx); ok {
 				var span trace.Span
 				ctx, span = tracer.Start(ctx, tr.Operation(), tr.RequestHeader())
@@ -76,7 +76,7 @@ func Client(opts ...Option) middleware.Middleware {
 
 // TraceID returns a traceid valuer.
 func TraceID() log.Valuer {
-	return func(ctx context.Context) interface{} {
+	return func(ctx context.Context) any {
 		if span := trace.SpanContextFromContext(ctx); span.HasTraceID() {
 			return span.TraceID().String()
 		}
@@ -86,7 +86,7 @@ func TraceID() log.Valuer {
 
 // SpanID returns a spanid valuer.
 func SpanID() log.Valuer {
-	return func(ctx context.Context) interface{} {
+	return func(ctx context.Context) any {
 		if span := trace.SpanContextFromContext(ctx); span.HasSpanID() {
 			return span.SpanID().String()
 		}

--- a/middleware/tracing/tracing_test.go
+++ b/middleware/tracing/tracing_test.go
@@ -1,0 +1,234 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/go-kratos/kratos/v2/transport"
+	"go.opentelemetry.io/otel/propagation"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var _ transport.Transporter = (*mockTransport)(nil)
+
+type headerCarrier http.Header
+
+// Get returns the value associated with the passed key.
+func (hc headerCarrier) Get(key string) string {
+	return http.Header(hc).Get(key)
+}
+
+// Set stores the key-value pair.
+func (hc headerCarrier) Set(key string, value string) {
+	http.Header(hc).Set(key, value)
+}
+
+// Add value to the key-value pair.
+func (hc headerCarrier) Add(key string, value string) {
+	http.Header(hc).Add(key, value)
+}
+
+// Keys lists the keys stored in this carrier.
+func (hc headerCarrier) Keys() []string {
+	keys := make([]string, 0, len(hc))
+	for k := range http.Header(hc) {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Values returns a slice value associated with the passed key.
+func (hc headerCarrier) Values(key string) []string {
+	return http.Header(hc).Values(key)
+}
+
+type mockTransport struct {
+	kind      transport.Kind
+	endpoint  string
+	operation string
+	header    headerCarrier
+	request   *http.Request
+}
+
+func (tr *mockTransport) Kind() transport.Kind            { return tr.kind }
+func (tr *mockTransport) Endpoint() string                { return tr.endpoint }
+func (tr *mockTransport) Operation() string               { return tr.operation }
+func (tr *mockTransport) RequestHeader() transport.Header { return tr.header }
+func (tr *mockTransport) ReplyHeader() transport.Header   { return tr.header }
+func (tr *mockTransport) Request() *http.Request {
+	if tr.request == nil {
+		rq, _ := http.NewRequest(http.MethodGet, "/endpoint", nil)
+
+		return rq
+	}
+
+	return tr.request
+}
+func (tr *mockTransport) PathTemplate() string { return "" }
+
+func TestTracer(t *testing.T) {
+	carrier := headerCarrier{}
+	tp := tracesdk.NewTracerProvider(tracesdk.WithSampler(tracesdk.TraceIDRatioBased(0)))
+
+	// caller use Inject
+	cliTracer := NewTracer(
+		trace.SpanKindClient,
+		WithTracerProvider(tp),
+		WithPropagator(
+			propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{}),
+		),
+	)
+
+	ts := &mockTransport{kind: transport.KindHTTP, header: carrier}
+
+	ctx, aboveSpan := cliTracer.Start(transport.NewClientContext(context.Background(), ts), ts.Operation(), ts.RequestHeader())
+	defer cliTracer.End(ctx, aboveSpan, nil, nil)
+
+	// server use Extract fetch traceInfo from carrier
+	svrTracer := NewTracer(trace.SpanKindServer, WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})))
+	ts = &mockTransport{kind: transport.KindHTTP, header: carrier}
+
+	ctx, span := svrTracer.Start(transport.NewServerContext(ctx, ts), ts.Operation(), ts.RequestHeader())
+	defer svrTracer.End(ctx, span, nil, nil)
+
+	if aboveSpan.SpanContext().TraceID() != span.SpanContext().TraceID() {
+		t.Fatalf("TraceID failed to deliver")
+	}
+
+	if v, ok := transport.FromClientContext(ctx); !ok || len(v.RequestHeader().Keys()) == 0 {
+		t.Fatalf("traceHeader failed to deliver")
+	}
+}
+
+func TestServer(t *testing.T) {
+	tr := &mockTransport{
+		kind:      transport.KindHTTP,
+		endpoint:  "server:2233",
+		operation: "/test.server/hello",
+		header:    headerCarrier{},
+	}
+
+	tracer := NewTracer(
+		trace.SpanKindClient,
+		WithTracerProvider(tracesdk.NewTracerProvider()),
+	)
+
+	logger := log.NewStdLogger(os.Stdout)
+	logger = log.With(logger, "span_id", SpanID())
+	logger = log.With(logger, "trace_id", TraceID())
+
+	var (
+		childSpanID  string
+		childTraceID string
+	)
+	next := func(ctx context.Context, req interface{}) (interface{}, error) {
+		_ = log.WithContext(ctx, logger).Log(log.LevelInfo,
+			"kind", "server",
+		)
+		childSpanID = SpanID()(ctx).(string)
+		childTraceID = TraceID()(ctx).(string)
+		return req.(string) + "https://go-kratos.dev", nil
+	}
+
+	var ctx context.Context
+	ctx, span := tracer.Start(
+		transport.NewServerContext(context.Background(), tr),
+		tr.Operation(),
+		tr.RequestHeader(),
+	)
+
+	_, err := Server(
+		WithTracerProvider(tracesdk.NewTracerProvider()),
+		WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})),
+	)(next)(ctx, "test server: ")
+
+	span.End()
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if childSpanID == "" {
+		t.Errorf("expected empty, got %v", childSpanID)
+	}
+	if reflect.DeepEqual(span.SpanContext().SpanID().String(), childSpanID) {
+		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)", span.SpanContext().SpanID().String(), childSpanID)
+	}
+	if !reflect.DeepEqual(span.SpanContext().TraceID().String(), childTraceID) {
+		t.Errorf("expected %v, got %v", childTraceID, span.SpanContext().TraceID().String())
+	}
+
+	_, err = Server(
+		WithTracerProvider(tracesdk.NewTracerProvider()),
+		WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})),
+	)(next)(context.Background(), "test server: ")
+	if err != nil {
+		t.Errorf("expected error, got nil")
+	}
+	if childSpanID != "" {
+		t.Errorf("expected empty, got %v", childSpanID)
+	}
+	if childTraceID != "" {
+		t.Errorf("expected empty, got %v", childTraceID)
+	}
+}
+
+func TestClient(t *testing.T) {
+	tr := &mockTransport{
+		kind:      transport.KindHTTP,
+		endpoint:  "server:2233",
+		operation: "/test.server/hello",
+		header:    headerCarrier{},
+	}
+
+	tracer := NewTracer(
+		trace.SpanKindClient,
+		WithTracerProvider(tracesdk.NewTracerProvider()),
+	)
+
+	logger := log.NewStdLogger(os.Stdout)
+	logger = log.With(logger, "span_id", SpanID())
+	logger = log.With(logger, "trace_id", TraceID())
+
+	var (
+		childSpanID  string
+		childTraceID string
+	)
+	next := func(ctx context.Context, req interface{}) (interface{}, error) {
+		_ = log.WithContext(ctx, logger).Log(log.LevelInfo,
+			"kind", "client",
+		)
+		childSpanID = SpanID()(ctx).(string)
+		childTraceID = TraceID()(ctx).(string)
+		return req.(string) + "https://go-kratos.dev", nil
+	}
+
+	var ctx context.Context
+	ctx, span := tracer.Start(
+		transport.NewClientContext(context.Background(), tr),
+		tr.Operation(),
+		tr.RequestHeader(),
+	)
+
+	_, err := Client(
+		WithTracerProvider(tracesdk.NewTracerProvider()),
+		WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})),
+	)(next)(ctx, "test client: ")
+
+	span.End()
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if childSpanID == "" {
+		t.Errorf("expected empty, got %v", childSpanID)
+	}
+	if reflect.DeepEqual(span.SpanContext().SpanID().String(), childSpanID) {
+		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)", span.SpanContext().SpanID().String(), childSpanID)
+	}
+	if !reflect.DeepEqual(span.SpanContext().TraceID().String(), childTraceID) {
+		t.Errorf("expected %v, got %v", childTraceID, span.SpanContext().TraceID().String())
+	}
+}

--- a/middleware/tracing/tracing_test.go
+++ b/middleware/tracing/tracing_test.go
@@ -86,11 +86,15 @@ func TestTracer(t *testing.T) {
 
 	ts := &mockTransport{kind: transport.KindHTTP, header: carrier}
 
-	ctx, aboveSpan := cliTracer.Start(transport.NewClientContext(context.Background(), ts), ts.Operation(), ts.RequestHeader())
+	ctx, aboveSpan := cliTracer.Start(
+		transport.NewClientContext(context.Background(), ts),
+		ts.Operation(), ts.RequestHeader())
 	defer cliTracer.End(ctx, aboveSpan, nil, nil)
 
 	// server use Extract fetch traceInfo from carrier
-	svrTracer := NewTracer(trace.SpanKindServer, WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})))
+	svrTracer := NewTracer(trace.SpanKindServer,
+		WithPropagator(
+			propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})))
 	ts = &mockTransport{kind: transport.KindHTTP, header: carrier}
 
 	ctx, span := svrTracer.Start(transport.NewServerContext(ctx, ts), ts.Operation(), ts.RequestHeader())
@@ -126,7 +130,7 @@ func TestServer(t *testing.T) {
 		childSpanID  string
 		childTraceID string
 	)
-	next := func(ctx context.Context, req interface{}) (interface{}, error) {
+	next := func(ctx context.Context, req any) (any, error) {
 		_ = log.WithContext(ctx, logger).Log(log.LevelInfo,
 			"kind", "server",
 		)
@@ -155,7 +159,8 @@ func TestServer(t *testing.T) {
 		t.Errorf("expected empty, got %v", childSpanID)
 	}
 	if reflect.DeepEqual(span.SpanContext().SpanID().String(), childSpanID) {
-		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)", span.SpanContext().SpanID().String(), childSpanID)
+		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)",
+			span.SpanContext().SpanID().String(), childSpanID)
 	}
 	if !reflect.DeepEqual(span.SpanContext().TraceID().String(), childTraceID) {
 		t.Errorf("expected %v, got %v", childTraceID, span.SpanContext().TraceID().String())
@@ -197,7 +202,7 @@ func TestClient(t *testing.T) {
 		childSpanID  string
 		childTraceID string
 	)
-	next := func(ctx context.Context, req interface{}) (interface{}, error) {
+	next := func(ctx context.Context, req any) (any, error) {
 		_ = log.WithContext(ctx, logger).Log(log.LevelInfo,
 			"kind", "client",
 		)
@@ -226,7 +231,8 @@ func TestClient(t *testing.T) {
 		t.Errorf("expected empty, got %v", childSpanID)
 	}
 	if reflect.DeepEqual(span.SpanContext().SpanID().String(), childSpanID) {
-		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)", span.SpanContext().SpanID().String(), childSpanID)
+		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)",
+			span.SpanContext().SpanID().String(), childSpanID)
 	}
 	if !reflect.DeepEqual(span.SpanContext().TraceID().String(), childTraceID) {
 		t.Errorf("expected %v, got %v", childTraceID, span.SpanContext().TraceID().String())

--- a/proto/tests/middleware/tracing/v1/hello.proto
+++ b/proto/tests/middleware/tracing/v1/hello.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package tests.middleware.tracing.v1;
+
+option go_package = "tests/middleware/tracing/v1;tracingpb";
+
+message HelloRequest {
+  string name = 1;
+}


### PR DESCRIPTION
The tracing middleware provides a way to trace the execution of a request through the application. It is based on the [OpenTelemetry](http://opentelemetry.io/) standard and can be used with any tracer that implements this standard.

The package is forked from [tracing](https://github.com/go-kratos/kratos/tree/8b8dc4b0f8bebb76939780f59734c20c265669c5/middleware/tracing) and optimized on this basis. Thanks to the original author for his contribution.

----

**Change items:**

1. Upgraded the semconv specification from 1.4.0 to 1.26.0
2. Supplemented some attribute information 