### PR TITLE
fefeat(event): add Wait method to dispatcher 

### DIFF
--- a/event/README.md
+++ b/event/README.md
@@ -11,17 +11,23 @@ github.com/go-fries/fries/event/v3
 ## Usage
 
 ```go
-package event_test
+package main
 
 import (
 	"context"
 	"fmt"
 
+	"github.com/go-fries/fries/event/middleware/recovery/v3"
 	"github.com/go-fries/fries/event/v3"
 )
 
 func Example() {
 	dispatcher := event.NewDispatcher()
+
+	// Use middleware
+	dispatcher.Use(
+		recovery.New(),
+	)
 
 	dispatcher.RegisterListeners(
 		event.AdaptListener(event.ListenerFunc[*UserEvent](func(_ context.Context, event *UserEvent) error {
@@ -38,6 +44,9 @@ func Example() {
 	if err := dispatcher.Dispatch(context.Background(), &UserEvent{Name: "zhangsan"}); err != nil {
 		fmt.Println(err)
 	}
+
+	// Wait for all listeners to finish processing
+	dispatcher.Wait()
 }
 
 type UserEvent struct {

--- a/event/dispatcher.go
+++ b/event/dispatcher.go
@@ -11,6 +11,7 @@ type Dispatcher struct {
 	mu         sync.RWMutex
 	listeners  []AnyListener
 	middleware []Middleware
+	wg         sync.WaitGroup
 }
 
 func NewDispatcher() *Dispatcher {
@@ -35,7 +36,10 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event any) error {
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, l := range d.listeners {
+		d.wg.Add(1)
 		eg.Go(func() error {
+			defer d.wg.Done()
+
 			handler := Chain(d.middleware...)(func(ctx context.Context, event any) error {
 				return l.Handle(ctx, event)
 			})
@@ -49,4 +53,8 @@ func (d *Dispatcher) Reset() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.listeners = make([]AnyListener, 0)
+}
+
+func (d *Dispatcher) Wait() {
+	d.wg.Wait()
 }

--- a/event/dispatcher_test.go
+++ b/event/dispatcher_test.go
@@ -3,6 +3,7 @@ package event
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -71,6 +72,28 @@ func TestDispatcher(t *testing.T) {
 		)
 
 		assert.NoError(t, dispatcher.Dispatch(ctx, &UserEvent{Name: "zhangsan"}))
+		assert.NoError(t, dispatcher.Dispatch(ctx, &OrderEvent{OrderID: "123456"}))
+	})
+
+	t.Run("wait for all listeners to complete", func(t *testing.T) {
+		defer dispatcher.Reset()
+
+		ch := make(chan string, 1)
+
+		dispatcher.RegisterListeners(
+			AdaptListenerFunc(func(_ context.Context, event *OrderEvent) error {
+				assert.Equal(t, "123456", event.OrderID)
+				time.Sleep(1 * time.Second)
+				ch <- event.OrderID
+				return nil
+			}),
+		)
+
+		go func() {
+			dispatcher.Wait()
+			assert.Equal(t, "123456", <-ch)
+		}()
+
 		assert.NoError(t, dispatcher.Dispatch(ctx, &OrderEvent{OrderID: "123456"}))
 	})
 }

--- a/event/example/go.mod
+++ b/event/example/go.mod
@@ -1,0 +1,15 @@
+module github.com/go-fries/fries/event/example/v3
+
+go 1.23.0
+
+replace (
+	github.com/go-fries/fries/event/middleware/recovery/v3 => ../middleware/recovery/
+	github.com/go-fries/fries/event/v3 => ../
+)
+
+require (
+	github.com/go-fries/fries/event/middleware/recovery/v3 v3.0.0-00010101000000-000000000000
+	github.com/go-fries/fries/event/v3 v3.0.0-alpha.2
+)
+
+require golang.org/x/sync v0.11.0 // indirect

--- a/event/example/go.sum
+++ b/event/example/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/event/example/main.go
+++ b/event/example/main.go
@@ -1,14 +1,20 @@
-package event_test
+package main
 
 import (
 	"context"
 	"fmt"
 
+	"github.com/go-fries/fries/event/middleware/recovery/v3"
 	"github.com/go-fries/fries/event/v3"
 )
 
 func Example() {
 	dispatcher := event.NewDispatcher()
+
+	// Use middleware
+	dispatcher.Use(
+		recovery.New(),
+	)
 
 	dispatcher.RegisterListeners(
 		event.AdaptListener(event.ListenerFunc[*UserEvent](func(_ context.Context, event *UserEvent) error {
@@ -25,6 +31,9 @@ func Example() {
 	if err := dispatcher.Dispatch(context.Background(), &UserEvent{Name: "zhangsan"}); err != nil {
 		fmt.Println(err)
 	}
+
+	// Wait for all listeners to finish processing
+	dispatcher.Wait()
 }
 
 type UserEvent struct {

--- a/event/example/main.go
+++ b/event/example/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-fries/fries/event/v3"
 )
 
-func Example() {
+func main() {
 	dispatcher := event.NewDispatcher()
 
 	// Use middleware

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/middleware/recovery/v3
 
-go 1.23.6
+go 1.23.0
 
 replace github.com/go-fries/fries/event/v3 => ../../
 

--- a/event/provider.go
+++ b/event/provider.go
@@ -19,5 +19,6 @@ func (p *Provider) Bootstrap(ctx context.Context) (context.Context, error) {
 }
 
 func (p *Provider) Terminate(ctx context.Context) (context.Context, error) {
+	p.Wait()
 	return ctx, nil
 }


### PR DESCRIPTION
closed https://github.com/go-fries/fries/issues/812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated enhanced error-handling middleware and a waiting mechanism that ensures all event listeners complete processing before the application exits.

- **Documentation**
  - Updated usage examples to clearly demonstrate the improved event dispatch workflow and package structure.

- **Refactor**
  - Streamlined shutdown procedures to ensure graceful termination by synchronizing pending event operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->