### PR TITLE
feat(recovery): enhance panic recovery handler to include stack trace

### DIFF
--- a/event/middleware/recovery/recovery.go
+++ b/event/middleware/recovery/recovery.go
@@ -2,23 +2,30 @@ package recovery
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"runtime"
 
 	"github.com/go-fries/fries/event/v3"
 )
 
-type HandlerFunc func(ctx context.Context, event any, recovery any)
+// HandlerFunc defines a function to handle panic recovery
+type HandlerFunc func(ctx context.Context, event any, recovery any, stack []byte)
 
-var DefaultHandler = func(_ context.Context, event any, recovery any) {
-	log.Printf("panic recovery event: %v, recovery: %v", event, recovery)
+// DefaultHandler is the default panic recovery handler that logs the event and stack trace
+var DefaultHandler = func(_ context.Context, event any, recovery any, stack []byte) {
+	log.Printf("panic recovery event: %v\nrecovery: %v\nstack trace:\n%s", event, recovery, stack)
 }
 
 type options struct {
 	handler HandlerFunc
+	// stackSize is the size of the stack buffer to allocate
+	stackSize int
 }
 
 type Option func(*options)
 
+// WithHandler sets a custom panic recovery handler
 func WithHandler(h HandlerFunc) Option {
 	return func(o *options) {
 		if h != nil {
@@ -27,18 +34,35 @@ func WithHandler(h HandlerFunc) Option {
 	}
 }
 
+// WithStackSize sets the size of the stack trace buffer
+func WithStackSize(size int) Option {
+	return func(o *options) {
+		if size > 0 {
+			o.stackSize = size
+		}
+	}
+}
+
+// New creates a new recovery middleware
 func New(opts ...Option) event.Middleware {
 	o := &options{
-		handler: DefaultHandler,
+		handler:   DefaultHandler,
+		stackSize: 4 << 10, // nolint:mnd // 4KB default stack size
 	}
 	for _, opt := range opts {
 		opt(o)
 	}
+
 	return func(next event.Handler) event.Handler {
-		return func(ctx context.Context, event any) error {
+		return func(ctx context.Context, event any) (err error) {
 			defer func() {
 				if r := recover(); r != nil {
-					o.handler(ctx, event, r)
+					stack := make([]byte, o.stackSize)
+					stack = stack[:runtime.Stack(stack, false)]
+					o.handler(ctx, event, r, stack)
+
+					// Convert panic to error
+					err = fmt.Errorf("panic recovered: %v", r)
 				}
 			}()
 			return next(ctx, event)

--- a/event/middleware/recovery/recovery_test.go
+++ b/event/middleware/recovery/recovery_test.go
@@ -50,9 +50,10 @@ func TestMiddleware(t *testing.T) {
 
 	t.Run("recovery with custom handler", func(t *testing.T) {
 		dispatcher := event.NewDispatcher()
-		dispatcher.Use(New(WithHandler(func(_ context.Context, event any, recovery any) {
+		dispatcher.Use(New(WithHandler(func(_ context.Context, event any, recovery any, stack []byte) {
 			assert.Equal(t, "test", event.(userEvent).Name)
 			assert.Equal(t, "panic", recovery.(string))
+			assert.Contains(t, string(stack), "recovery_test.go")
 		})))
 
 		dispatcher.RegisterListeners(


### PR DESCRIPTION
- Updated HandlerFunc to accept a stack trace as an argument.
- Modified DefaultHandler to log the stack trace along with the event and recovery information.
- Added WithStackSize option to configure the size of the stack trace buffer.
- Updated middleware to capture and pass the stack trace during panic recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced panic recovery with detailed diagnostic logging that now captures stack trace information.
	- Added a configurable option to adjust the buffer size used for capturing error traces.
- **Tests**
	- Updated tests to verify that the detailed diagnostic information is correctly captured during error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->