### PR TITLE
chore: update renovate.json to group pingcap and golang.org/x packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,11 +21,11 @@
     },
     {
       "matchPackageNames": ["go.opentelemetry.io/build-tools/**"],
-      "groupName": "build-tools"
+      "groupName": "go.opentelemetry.io/build-tools"
     },
     {
       "matchPackageNames": ["github.com/pingcap/tidb/**"],
-      "groupName": "pingcap/tidb",
+      "groupName": "github.com/pingcap/tidb",
       "schedule": ["* * 1 * *"]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
       "enabled": true
     },
     {
-      "matchPackageNames": ["github.com/pingcap/..."],
+      "matchPackageNames": ["github.com/pingcap/**"],
       "groupName": "pingcap",
       "schedule": ["* * 1 * *"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "matchPackageNames": ["github.com/pingcap/tidb/**"],
       "groupName": "github.com/pingcap/tidb",
-      "schedule": ["* * 1 * *"]
+      "schedule": ["0 0 1 * *"]
     },
     {
       "matchPackageNames": ["golang.org/x/**"],

--- a/renovate.json
+++ b/renovate.json
@@ -20,13 +20,21 @@
       "enabled": true
     },
     {
-      "matchPackageNames": ["github.com/pingcap/**"],
-      "groupName": "pingcap",
+      "matchPackageNames": ["go.opentelemetry.io/build-tools/**"],
+      "groupName": "build-tools"
+    },
+    {
+      "matchPackageNames": ["github.com/pingcap/tidb/**"],
+      "groupName": "pingcap/tidb",
       "schedule": ["* * 1 * *"]
     },
     {
       "matchPackageNames": ["golang.org/x/**"],
       "groupName": "golang.org/x"
+    },
+    {
+      "matchPackageNames": ["go.opentelemetry.io/otel/**"],
+      "groupName": "go.opentelemetry.io/otel"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,13 +15,18 @@
   },
   "packageRules": [
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepTypes": [
-        "indirect"
-      ],
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["github.com/pingcap/..."],
+      "groupName": "pingcap",
+      "schedule": ["* * 1 * *"]
+    },
+    {
+      "matchPackageNames": ["golang.org/x/**"],
+      "groupName": "golang.org/x"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management configuration to add new grouping rules for "pingcap" and "golang.org/x" packages, enabling more organized and scheduled updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->