### PR TITLE
build(deps): add googleapis group to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,10 @@
     {
       "matchPackageNames": ["go.opentelemetry.io/otel/**"],
       "groupName": "go.opentelemetry.io/otel"
+    },
+    {
+      "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
+      "groupName": "googleapis"
     }
   ]
 }


### PR DESCRIPTION
- Add google.golang.org/genproto/googleapis/** to renovate.json
- Create "googleapis" group for better dependency management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management configuration to group all Google APIs-related packages together for streamlined updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->