### PR TITLE
chore: improve tag pushing efficiency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,4 +143,4 @@ add-tags: verify-mods
 	$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT}
 
 # push-tags
-# git tag -l | grep 'v3.0.0-rc.3$' | xargs -I {} git push origin {}
+# git tag -l | grep 'v3.0.0-rc.3$' | xargs -P 4 -I {} git push origin {}


### PR DESCRIPTION
- Update the git push command in the Makefile to use parallel processing
- Replace 'xargs -I {}' with 'xargs -P 4 -I {}' to push tags concurrently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal build process configuration (no impact on end-user functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->