### PR TITLE
build(deps): update opentelemetryio/semconv from v1.30.0 to v1.32.0

### DIFF
--- a/hyperf/jet/middleware/tracing/tracing.go
+++ b/hyperf/jet/middleware/tracing/tracing.go
@@ -102,7 +102,7 @@ func formatterAttributes(ctx context.Context) []attribute.KeyValue {
 	case jet.FormatterKindJSONRPC:
 		return []attribute.KeyValue{
 			semconv.RPCSystemKey.String("jsonrpc"),
-			semconv.RPCJsonrpcVersion(jet.JSONRPCVersion),
+			semconv.RPCJSONRPCVersion(jet.JSONRPCVersion),
 		}
 	default:
 		return []attribute.KeyValue{}

--- a/hyperf/jet/middleware/tracing/tracing.go
+++ b/hyperf/jet/middleware/tracing/tracing.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/hyperf/jet/middleware/tracing/tracing.go
+++ b/hyperf/jet/middleware/tracing/tracing.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const instrumentation = "github.com/go-kratos-ecosystem/components/v2/hyperf/jet/middleware/tracing"
+const instrumentation = "github.com/go-fries/fries/hyperf/jet/middleware/tracing/v3"
 
 type options struct {
 	mp    propagation.TextMapPropagator

--- a/kratos/middleware/tracing/span.go
+++ b/kratos/middleware/tracing/span.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-kratos/kratos/v2/transport"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"

--- a/kratos/middleware/tracing/span_test.go
+++ b/kratos/middleware/tracing/span_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-kratos/kratos/v2/metadata"
 	"github.com/go-kratos/kratos/v2/transport"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/peer"
 )

--- a/otel/otlp/client.go
+++ b/otel/otlp/client.go
@@ -17,7 +17,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
- Updated opentelemetryio/semconv package from version 1.30.0 to 1.32.0 in multiple files:
- otel/otlp/client.go 
- kratos/middleware/tracing/span.go
- kratos/middleware/tracing/span_test.go
- hyperf/jet/middleware/tracing/tracing.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the OpenTelemetry semantic conventions package to version v1.32.0 across the application. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->