### PR TITLE
ci(lint): improve cache strategy for Go modules and GolangCI-Lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - name: Go mod cache
+        uses: actions/cache@v4
         with:
-          go-version: stable
-          check-latest: true
-          cache-dependency-path: "**/go.sum"
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
 
       - name: Tools cache
         uses: actions/cache@v4
@@ -28,6 +31,19 @@ jobs:
         with:
           path: .tools
           key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('./internal/tools/**') }}
+
+      - name: GolangCI-Lint cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('**/.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+          cache: false
 
       - name: Run lint
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,8 +21,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-mod
 
       - name: Tools cache
         uses: actions/cache@v4


### PR DESCRIPTION
- Add separate cache steps for Go modules and GolangCI-Lint- Use actions/cache@v4 for Go mod cache
- Configure GolangCI-Lint cache to improve workflow efficiency
- Update actions/setup-go@v5 usage with cache: false to avoid conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved caching strategy in the Go linting workflow, including separate caches for Go modules, build tools, and GolangCI-Lint, to enhance workflow efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->