### PR TITLE
feat(snapshot): add Reset method to clear snapshot data

### DIFF
--- a/cache/snapshot.go
+++ b/cache/snapshot.go
@@ -34,6 +34,12 @@ func (s *Snapshot[K, V]) Lookup(key K, fn func() V) V {
 	return v
 }
 
+func (s *Snapshot[K, V]) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data = nil
+}
+
 // SnapshotWithErr is a thread-safe structure that holds a snapshot of data with error handling.
 // It ensures that the data for a key can be populated with an error if needed.
 type SnapshotWithErr[K comparable, V any] Snapshot[K, valueWithError[V]]
@@ -62,6 +68,12 @@ func (c *SnapshotWithErr[K, V]) Lookup(key K, fn func() (V, error)) (V, error) {
 	return v.value, v.err
 }
 
+func (c *SnapshotWithErr[K, V]) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = nil
+}
+
 type SnapshotWithExpireAndErr[K comparable, V any] Snapshot[K, valueWithExpireAndError[V]]
 
 type valueWithExpireAndError[V any] struct {
@@ -88,4 +100,10 @@ func (c *SnapshotWithExpireAndErr[K, V]) Lookup(key K, fn func() (V, error), exp
 		}
 	}
 	return v.value, v.err
+}
+
+func (c *SnapshotWithExpireAndErr[K, V]) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = nil
 }

--- a/cache/snapshot_test.go
+++ b/cache/snapshot_test.go
@@ -35,6 +35,35 @@ func TestSnapshot(t *testing.T) {
 	assert.Equal(t, int32(2), total.Load())
 }
 
+func TestSnapshot_Reset(t *testing.T) {
+	var (
+		snap  Snapshot[string, *snapshotValue]
+		total atomic.Int32
+	)
+
+	for i := 0; i < 100; i++ {
+		value := snap.Lookup("key", func() *snapshotValue {
+			total.Add(1)
+			return &snapshotValue{value: "value"}
+		})
+		assert.Equal(t, "value", value.value)
+	}
+
+	assert.Equal(t, int32(1), total.Load())
+
+	snap.Reset()
+
+	for i := 0; i < 100; i++ {
+		value := snap.Lookup("key", func() *snapshotValue {
+			total.Add(1)
+			return &snapshotValue{value: "new_value"}
+		})
+		assert.Equal(t, "new_value", value.value)
+	}
+
+	assert.Equal(t, int32(2), total.Load())
+}
+
 func TestSnapshotWithErr(t *testing.T) {
 	var (
 		snap  SnapshotWithErr[string, *snapshotValue]
@@ -78,6 +107,37 @@ func TestSnapshotWithErr(t *testing.T) {
 	assert.Equal(t, int32(len(tests)), total.Load())
 }
 
+func TestSnapshotWithErr_Reset(t *testing.T) {
+	var (
+		snap  SnapshotWithErr[string, *snapshotValue]
+		total atomic.Int32
+	)
+
+	for i := 0; i < 100; i++ {
+		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
+			total.Add(1)
+			return &snapshotValue{value: "value"}, nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "value", value.value)
+	}
+
+	assert.Equal(t, int32(1), total.Load())
+
+	snap.Reset()
+
+	for i := 0; i < 100; i++ {
+		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
+			total.Add(1)
+			return &snapshotValue{value: "new_value"}, nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "new_value", value.value)
+	}
+
+	assert.Equal(t, int32(2), total.Load())
+}
+
 func TestSnapshotWithExpireAndErr(t *testing.T) {
 	var (
 		snap  SnapshotWithExpireAndErr[string, *snapshotValue]
@@ -106,6 +166,37 @@ func TestSnapshotWithExpireAndErr(t *testing.T) {
 	}, time.Millisecond*10)
 	assert.NoError(t, err)
 	assert.Equal(t, "value2", value.value)
+
+	assert.Equal(t, int32(2), total.Load())
+}
+
+func TestSnapshotWithExpireAndErr_Reset(t *testing.T) {
+	var (
+		snap  SnapshotWithExpireAndErr[string, *snapshotValue]
+		total atomic.Int32
+	)
+
+	for i := 0; i < 100; i++ {
+		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
+			total.Add(1)
+			return &snapshotValue{value: "value"}, nil
+		}, time.Millisecond*10)
+		assert.NoError(t, err)
+		assert.Equal(t, "value", value.value)
+	}
+
+	assert.Equal(t, int32(1), total.Load())
+
+	snap.Reset()
+
+	for i := 0; i < 100; i++ {
+		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
+			total.Add(1)
+			return &snapshotValue{value: "new_value"}, nil
+		}, time.Millisecond*10)
+		assert.NoError(t, err)
+		assert.Equal(t, "new_value", value.value)
+	}
 
 	assert.Equal(t, int32(2), total.Load())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to reset and clear cached data for all snapshot types, allowing users to clear stored values and force recomputation on future access.

- **Tests**
  - Introduced tests to verify that resetting snapshots properly clears cached entries and ensures correct behavior after reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->