### PR TITLE
build(deps): update dependency opentelemetryio/semconv to v1.34.0

### DIFF
--- a/hyperf/jet/middleware/tracing/tracing.go
+++ b/hyperf/jet/middleware/tracing/tracing.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/kratos/middleware/tracing/span.go
+++ b/kratos/middleware/tracing/span.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-kratos/kratos/v2/transport"
 	"github.com/go-kratos/kratos/v2/transport/http"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"

--- a/kratos/middleware/tracing/span_test.go
+++ b/kratos/middleware/tracing/span_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-kratos/kratos/v2/metadata"
 	"github.com/go-kratos/kratos/v2/transport"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/peer"
 )

--- a/otel/otlp/client.go
+++ b/otel/otlp/client.go
@@ -17,7 +17,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
- Update opentelemetryio/semconv from v1.32.0 to v1.34.0 in multiple files:
  - otel/otlp/client.go
  - kratos/middleware/tracing/span.go  - kratos/middleware/tracing/span_test.go
  - hyperf/jet/middleware/tracing/tracing.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry semantic conventions package to version v1.34.0 across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->