### PR TITLE
fix: update README import path to correct package name

### DIFF
--- a/chi/README.md
+++ b/chi/README.md
@@ -13,7 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-kratos/kratos/v2"
 
-	chis "github.com/go-kratos-ecosystem/components/v2/chi"
+	chis "github.com/go-fries/fries/v3/chi"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
Fixed incorrect import path in README.md from `github.com/go-kratos-ecosystem/components/v2/chi` to `github.com/go-fries/fries/v3/chi` to match the current repository structure.

## Test plan
- [x] Verified the import path is correct in the current repository structure
- [x] Tested example code compiles with updated import path

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example code in the README to reflect a new import path for the `chis` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->