### PR TITLE
feat(cache): add CleanupExpired method to remove expired items

### DIFF
--- a/cache/snapshot.go
+++ b/cache/snapshot.go
@@ -102,6 +102,16 @@ func (c *SnapshotWithExpireAndErr[K, V]) Lookup(key K, fn func() (V, error), exp
 	return v.value, v.err
 }
 
+func (c *SnapshotWithExpireAndErr[K, V]) CleanupExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, v := range c.data {
+		if time.Now().After(v.expired) {
+			delete(c.data, k)
+		}
+	}
+}
+
 func (c *SnapshotWithExpireAndErr[K, V]) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
- Implement CleanupExpired method for SnapshotWithExpireAndErr
- Remove expired items from the cache when the method is called

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of expired entries in the cache to help keep data up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->