### PR TITLE
ci: update linter settings and fix related issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - goconst
     - mnd
     - gocyclo
+    - gocritic
     - ineffassign
     - prealloc
     - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,17 +24,27 @@ linters:
     - misspell
   settings:
     revive:
+      # see: https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
       rules:
         - name: package-comments
           disabled: true
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: '*testing.T,*testing.B,*testing.F'
+#        - name: context-keys-type
+        - name: duplicated-imports
+        - name: early-return
+        - name: error-naming
+        - name: errorf
+        - name: time-equal
+        - name: unnecessary-stmt
+        - name: waitgroup-by-value
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+        - name: use-any
 
 formatters:
   enable:
-    - gofmt
     - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,8 +26,6 @@ linters:
     revive:
       # see: https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
       rules:
-        - name: package-comments
-          disabled: true
         - name: context-as-argument
           arguments:
             - allowTypesBefore: '*testing.T,*testing.B,*testing.F'
@@ -36,13 +34,15 @@ linters:
         - name: early-return
         - name: error-naming
         - name: errorf
+        - name: package-comments
+          disabled: true
         - name: time-equal
         - name: unnecessary-stmt
-        - name: waitgroup-by-value
+        - name: use-any
         - name: useless-break
         - name: var-declaration
         - name: var-naming
-        - name: use-any
+        - name: waitgroup-by-value
 
 formatters:
   enable:

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -99,7 +99,7 @@ func TestUtils_Get(t *testing.T) {
 func TestUtils_Remember(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(newUtilMockStore())
-	var total int32 = 0
+	var total int32
 
 	rememberFunc := func(value string) (string, error) {
 		return Remember(ctx, repo, "test_key", time.Millisecond*100, func() (string, error) {

--- a/eino/components/embedding/cached/generator.go
+++ b/eino/components/embedding/cached/generator.go
@@ -72,6 +72,6 @@ func (g *HashGenerator) Generate(ctx context.Context, text string, opts Generato
 		hasher.Reset()
 		g.pool.Put(hasher)
 	}()
-	hasher.Write([]byte(plainText))
+	_, _ = hasher.Write([]byte(plainText))
 	return fmt.Sprintf("%x", hasher.Sum(nil))
 }

--- a/examples/cache/main.go
+++ b/examples/cache/main.go
@@ -37,7 +37,7 @@ func main() {
 		Age:  18, //nolint:mnd
 	}, time.Second*10) //nolint:mnd
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	_ = ok
 
@@ -45,7 +45,7 @@ func main() {
 	var user User
 	err = repository.Get(ctx, "key", &user)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	log.Printf("user: %+v", user)
 
@@ -57,7 +57,7 @@ func main() {
 		}, nil
 	})
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	log.Printf("user2: %+v", user2)
 }

--- a/examples/cloudevents/amqp091/main.go
+++ b/examples/cloudevents/amqp091/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	channel, err := conn.Channel()
 	if err != nil {
-		log.Fatal(channel)
+		panic(err)
 	}
 	defer channel.Close() //nolint:errcheck
 
@@ -31,12 +31,12 @@ func main() {
 		Queue:      "cloudevents-queue",
 	})
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	client, err := cloudevents.NewClient(protocol)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	event := cloudevents.NewEvent()
@@ -44,7 +44,7 @@ func main() {
 	event.SetSource("example/uri")
 	event.SetType("example.type")
 	if err := event.SetData(cloudevents.ApplicationJSON, map[string]string{"hello": "world"}); err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	go func() {

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -18,7 +18,7 @@ func TestMap(t *testing.T) {
 
 	t.Run("Map", func(t *testing.T) {
 		assert.Equal(t, []int{2, 4, 6, 8, 10}, Map(s1, func(n int) int { return n * 2 }))
-		assert.Equal(t, []string{"1", "2", "3", "4", "5"}, Map(s2, func(n int) string { return strconv.Itoa(n) }))
+		assert.Equal(t, []string{"1", "2", "3", "4", "5"}, Map(s2, strconv.Itoa))
 		assert.Equal(t, []T{{"1"}, {"2"}, {"3"}, {"4"}, {"5"}}, Map(s3, func(s string) T { return T{s} }))
 	})
 

--- a/support/values_test.go
+++ b/support/values_test.go
@@ -435,7 +435,7 @@ func TestIsType(t *testing.T) {
 	assert.False(t, IsType[*foo](nil))
 
 	assert.True(t, IsType[testInterface](testStruct{}))
-	assert.True(t, IsType[interface{}](testStruct{})) //nolint:gofmt
+	assert.True(t, IsType[interface{}](testStruct{})) //nolint:revive
 	assert.True(t, IsType[any](testStruct{}))
 
 	assert.True(t, IsType[error](errors.New("foo")))


### PR DESCRIPTION
- Update .golangci.yml to include new revive rules and disable gofumpt
- Fix revive linter warnings in affected files
- Update code to use more idiomatic error handling and variable declarations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration with additional rules and adjusted formatter settings.
  * Minor code cleanup to rely on Go's default zero value initialization.
  * Improved handling of method return values for clarity.
  * Updated linter directive comments in tests.
  * Modified error handling to use panic for immediate failure reporting.
  * Simplified test code by directly referencing existing functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->