### PR TITLE
makbuild: update Go version to 1.24.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.23.x, 1.24.x ]
+        go-version: [ 1.24.x, 1.25.x ]
         platform: [ ubuntu-latest ]
         mysql-version: [ 'mysql:latest', 'mysql:5.7' ]
     runs-on: ${{ matrix.platform }}

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,17 @@ check-clean-work-tree:
 	  exit 1; \
 	fi
 
+# Upgrade Go version in all go.mod files to the version specified in the GO_VERSION env var
+# Example: make upgrade-go-version GO_VERSION=1.24.0
+.PHONY: upgrade-go-version
+upgrade-go-version: $(ALL_GO_MOD_DIRS:%=upgrade-go-version/%)
+upgrade-go-version/%: DIR=$*
+upgrade-go-version/%:
+	@[ "${GO_VERSION}" ] || ( echo ">> env var GO_VERSION is not set"; exit 1 )
+	@echo "Upgrading Go version in $(DIR)" \
+		&& cd $(DIR) \
+		&& $(GO) mod edit -go=$(GO_VERSION)
+
 # Fix the "fixes" field of Codecov
 .PHONY: codecovfix
 codecovfix: $(CODECOVFIX)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Fries Components
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23.0-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.24.0-blue)
 [![Package Version](https://badgen.net/github/release/go-fries/fries/stable)](https://github.com/go-fries/fries/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/go-fries/fries/v3)](https://pkg.go.dev/github.com/go-fries/fries/v3)
 [![codecov](https://codecov.io/gh/go-fries/fries/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/go-fries/fries)

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cache/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/locker/v3 => ../locker
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cache/redis/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/cache/v3 => ../

--- a/chi/go.mod
+++ b/chi/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/chi/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.2

--- a/cloudevents/eventdispatcher/go.mod
+++ b/cloudevents/eventdispatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cloudevents/eventdispatcher/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.1

--- a/cloudevents/protocol/amqp091/go.mod
+++ b/cloudevents/protocol/amqp091/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cloudevents/protocol/amqp091/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.1

--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/codec/v3
 
-go 1.23.0
+go 1.24.0

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/json/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/msgpack/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/proto/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/sonic/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/xml/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/yaml/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/config/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/constraints/go.mod
+++ b/constraints/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/constraints/v3
 
-go 1.23.0
+go 1.24.0

--- a/contract/go.mod
+++ b/contract/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/contract/v3
 
-go 1.23.0
+go 1.24.0

--- a/coroutines/go.mod
+++ b/coroutines/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/coroutines/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/constraints/v3 => ./../constraints

--- a/crontab/example/go.mod
+++ b/crontab/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/crontab/example/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/crontab/v3 => ../
 

--- a/crontab/go.mod
+++ b/crontab/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/crontab/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/flc1125/go-cron/v4 v4.5.9

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/cacher/gorm/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/eino/components/embedding/cached/v3 => ../../
 

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/codec/sonic/v3 => ./../../../../../../codec/sonic

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/example/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/codec/sonic/v3 => ../../../../../codec/sonic

--- a/eino/components/embedding/cached/go.mod
+++ b/eino/components/embedding/cached/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cloudwego/eino v0.4.4

--- a/encrypter/go.mod
+++ b/encrypter/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/encrypter/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/ent/go.mod
+++ b/ent/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ent/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.8.4

--- a/ent/multidriver/go.mod
+++ b/ent/multidriver/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ent/multidriver/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	entgo.io/ent v0.14.5

--- a/env/go.mod
+++ b/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/env/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/errors/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.8.4

--- a/event/example/go.mod
+++ b/event/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/example/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/event/middleware/recovery/v3 => ../middleware/recovery/

--- a/event/go.mod
+++ b/event/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/middleware/recovery/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/event/v3 => ../../
 

--- a/eventbus/go.mod
+++ b/eventbus/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eventbus/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/examples/cache/go.mod
+++ b/examples/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/cache/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/cache/redis/v3 => ../../cache/redis/

--- a/examples/cloudevents/amqp091/go.mod
+++ b/examples/cloudevents/amqp091/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/cloudevents/amqp091/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/cloudevents/protocol/amqp091/v3 => ../../../cloudevents/protocol/amqp091/
 

--- a/examples/cloudevents/eventdispatcher/go.mod
+++ b/examples/cloudevents/eventdispatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/cloudevents/eventdispatcher/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/cloudevents/eventdispatcher/v3 => ../../../cloudevents/eventdispatcher/
 

--- a/examples/mysql/canal/go.mod
+++ b/examples/mysql/canal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/mysql/canal/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v3 => ../../../codec/json

--- a/examples/otel/otlp/go.mod
+++ b/examples/otel/otlp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/otel/otlp/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/foundation/v3 => ../../../foundation

--- a/filesystem/go.mod
+++ b/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/local/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/filesystem/v3 => ../
 

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/oss/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/filesystem/v3 => ../
 

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/s3/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/filesystem/v3 => ../
 

--- a/foundation/go.mod
+++ b/foundation/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/foundation/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/gin/go.mod
+++ b/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gin/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/gin-gonic/gin v1.10.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/gomod_test.go
+++ b/gomod_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var expectedVersion = "go 1.23.0"
+var expectedVersion = "go 1.24.0"
 
 func TestAllGoModVersions(t *testing.T) {
 	var modFiles []string

--- a/gorm/go.mod
+++ b/gorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/gorm/scope/go.mod
+++ b/gorm/scope/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/scope/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/hashing/go.mod
+++ b/hashing/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/hashing/v3
 
-go 1.23.0
+go 1.24.0

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hashing/md5/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/hashing/v3 => ../
 

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/http/server/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.8.4

--- a/hyperf/jet/go.mod
+++ b/hyperf/jet/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/hyperf/jet/middleware/logging/go.mod
+++ b/hyperf/jet/middleware/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/logging/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/recovery/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/retry/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v3 => ../timeout

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/timeout/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/hyperf/jet/middleware/tracing/go.mod
+++ b/hyperf/jet/middleware/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/tracing/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/internal/tools/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/bufbuild/buf v1.30.1

--- a/kratos/log/otel/go.mod
+++ b/kratos/log/otel/go.mod
@@ -1,6 +1,8 @@
 module github.com/go-fries/fries/kratos/log/otel/v3
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.24.4
 
 replace github.com/go-fries/fries/v3 => ../../../
 

--- a/kratos/log/otel/go.mod
+++ b/kratos/log/otel/go.mod
@@ -2,8 +2,6 @@ module github.com/go-fries/fries/kratos/log/otel/v3
 
 go 1.24.0
 
-toolchain go1.24.4
-
 replace github.com/go-fries/fries/v3 => ../../../
 
 require (

--- a/kratos/log/stack/go.mod
+++ b/kratos/log/stack/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/log/stack/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.8.4

--- a/kratos/log/syslog/go.mod
+++ b/kratos/log/syslog/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-fries/fries/kratos/log/syslog/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/go-kratos/kratos/v2 v2.8.4

--- a/kratos/middleware/cors/go.mod
+++ b/kratos/middleware/cors/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/cors/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/go-kratos/kratos/v2 v2.8.4
 

--- a/kratos/middleware/protovalidate/go.mod
+++ b/kratos/middleware/protovalidate/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/protovalidate/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250717165733-d22d418d82d8.1

--- a/kratos/middleware/slowlog/go.mod
+++ b/kratos/middleware/slowlog/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/slowlog/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.8.4

--- a/kratos/middleware/tracing/go.mod
+++ b/kratos/middleware/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/tracing/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.8.4

--- a/locker/go.mod
+++ b/locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/locker/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/locker/redis/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/locker/v3 => ../
 

--- a/mysql/canal/go.mod
+++ b/mysql/canal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-mysql-org/go-mysql v1.13.0

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/positioner/redis/v3
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v3 => ./../../../../codec/json

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/server/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/mysql/canal/v3 => ../
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/otel/otlp/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/foundation/v3 => ../../foundation
 

--- a/recovery/go.mod
+++ b/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/recovery/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/redis/go.mod
+++ b/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/redis/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/redis/go-redis/v9 v9.12.1

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "gomodTidy"
   ],
   "constraints": {
-    "go": "1.23.0"
+    "go": "1.24.0"
   },
   "packageRules": [
     {

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/signal/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/contract/v3 => ../contract
 

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/slices/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/constraints/v3 => ../constraints
 

--- a/strings/go.mod
+++ b/strings/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/strings/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/support/go.mod
+++ b/support/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/support/v3
 
-go 1.23.0
+go 1.24.0
 
 replace github.com/go-fries/fries/errors/v3 => ../errors
 

--- a/timezone/go.mod
+++ b/timezone/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/timezone/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/udp/go.mod
+++ b/udp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/udp/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/go-kratos/kratos/v2 v2.8.4
 

--- a/x/container/go.mod
+++ b/x/container/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/container/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/x/pagination/go.mod
+++ b/x/pagination/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/pagination/v3
 
-go 1.23.0
+go 1.24.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/x/prints/go.mod
+++ b/x/prints/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/prints/v3
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7


### PR DESCRIPTION
- Update Go version from 1.23.0 to 1.24.0 in multiple go.mod files
- This change affects various modules and components within the project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Raised minimum supported Go to 1.24 across modules and added a Makefile target to automate upgrading module Go versions; updated Renovate Go constraint.
- CI
  - Test matrix now runs on Go 1.24.x and 1.25.x.
- Tests
  - Updated test expectations for the new Go version.
- Documentation
  - Updated "Supported Go Versions" badge to Go >= 1.24.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->