### PR TITLE
Fix wildcard match to require full string

### DIFF
--- a/strings/strings.go
+++ b/strings/strings.go
@@ -27,18 +27,19 @@ const (
 //	Is("*.example.com", "www.example.com") // true
 //	Is("*.example.com", "example.com") // false
 func Is(pattern, value string) bool {
-	if pattern == value {
-		return true
-	}
+        if pattern == value {
+                return true
+        }
 
-	pattern = strings.ReplaceAll(pattern, "*", ".*")
+       pattern = strings.ReplaceAll(pattern, "*", ".*")
+       pattern = "^" + pattern + "$"
 
-	match, err := regexp.Match(pattern, []byte(value))
-	if err != nil {
-		return false
-	}
+       match, err := regexp.MatchString(pattern, value)
+        if err != nil {
+                return false
+        }
 
-	return match
+        return match
 }
 
 // InSlice checks if a string is in a string slice.

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 func TestIs(t *testing.T) {
-	assert.True(t, Is("abc", "abc"))
-	assert.False(t, Is("abcc", "abc"))
-	assert.True(t, Is("ab*", "abc"))
-	assert.True(t, Is("ab*", "ab"))
-	assert.True(t, Is("ab/*", "ab/cc"))
+        assert.True(t, Is("abc", "abc"))
+        assert.False(t, Is("abcc", "abc"))
+       assert.False(t, Is("ab", "abc"))
+        assert.True(t, Is("ab*", "abc"))
+        assert.True(t, Is("ab*", "ab"))
+        assert.True(t, Is("ab/*", "ab/cc"))
 	assert.True(t, Is("ab/*", "ab/"))
 	assert.True(t, Is("*", "ab"))
 	assert.True(t, Is("*", ""))


### PR DESCRIPTION
## Summary
- ensure `Is` matches entire string by anchoring the generated regex
- add regression test for partial matches like `Is("ab", "abc")`

## Testing
- `cd strings && go test`


------
https://chatgpt.com/codex/tasks/task_e_68b675ff0a1c832cbb3c1f00ddfbaca6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - String pattern matching now requires full-string matches, not substrings. The "*" wildcard remains supported (e.g., "ab" no longer matches "abc"). This delivers clearer, more predictable matching results.

- Tests
  - Added test coverage to confirm partial matches are rejected and full-string matching behavior is enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->