### PR TITLE
refactor: fix naked return statements in multiple files

### DIFF
--- a/foundation/kernel.go
+++ b/foundation/kernel.go
@@ -74,7 +74,7 @@ func (k *Kernel) bootstrap(ctx context.Context) (context.Context, error) {
 
 func (k *Kernel) Run(ctx context.Context) (err error) {
 	if ctx, err = k.bootstrap(ctx); err != nil {
-		return
+		return err
 	}
 
 	defer func() {

--- a/hyperf/jet/client.go
+++ b/hyperf/jet/client.go
@@ -108,7 +108,7 @@ func (c *Client) Invoke(ctx context.Context, method string, request any, respons
 	handler = Chain(append(c.middlewares, middlewares...)...)(handler)
 
 	response, err = handler(ContextWithClient(ctx, c), c.service, method, request)
-	return
+	return err
 }
 
 func (c *Client) invoke(ctx context.Context, service, method string, request any, response any) error {

--- a/hyperf/jet/middleware/retry/retry.go
+++ b/hyperf/jet/middleware/retry/retry.go
@@ -24,11 +24,11 @@ func New(opts ...Option) jet.Middleware {
 			for i := 1; i <= o.attempts; i++ {
 				response, err = next(ctx, service, method, request)
 				if err == nil {
-					return
+					return response, err
 				}
 
 				if !o.allow(err) {
-					return
+					return response, err
 				}
 
 				if i < o.attempts {

--- a/hyperf/jet/middleware/tracing/tracing.go
+++ b/hyperf/jet/middleware/tracing/tracing.go
@@ -87,7 +87,7 @@ func New(opts ...Option) jet.Middleware {
 				span.RecordError(err)
 			}
 
-			return
+			return response, err
 		}
 	}
 }

--- a/kratos/middleware/slowlog/slowlog.go
+++ b/kratos/middleware/slowlog/slowlog.go
@@ -62,7 +62,7 @@ func Server(logger log.Logger, opts ...Option) middleware.Middleware {
 			duration := time.Since(startTime)
 
 			if duration <= o.Threshold {
-				return
+				return reply, err
 			}
 
 			level, stack := extractError(err)
@@ -77,7 +77,7 @@ func Server(logger log.Logger, opts ...Option) middleware.Middleware {
 				"stack", stack,
 				"latency", time.Since(startTime).Seconds(),
 			)
-			return
+			return reply, err
 		}
 	}
 }
@@ -111,7 +111,7 @@ func Client(logger log.Logger, opts ...Option) middleware.Middleware {
 
 			duration := time.Since(startTime)
 			if duration <= o.Threshold {
-				return
+				return reply, err
 			}
 
 			level, stack := extractError(err)
@@ -126,7 +126,7 @@ func Client(logger log.Logger, opts ...Option) middleware.Middleware {
 				"stack", stack,
 				"latency", time.Since(startTime).Seconds(),
 			)
-			return
+			return reply, err
 		}
 	}
 }

--- a/kratos/middleware/tracing/span.go
+++ b/kratos/middleware/tracing/span.go
@@ -125,7 +125,7 @@ func parseFullMethod(fullMethod string) (string, []attribute.KeyValue) {
 func peerAttr(addr string) (attrs []attribute.KeyValue) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return
+		return attrs
 	}
 
 	if host == "" {
@@ -137,13 +137,13 @@ func peerAttr(addr string) (attrs []attribute.KeyValue) {
 
 	portInt, err := strconv.Atoi(port)
 	if err != nil {
-		return
+		return attrs
 	}
 	attrs = append(attrs,
 		semconv.NetworkPeerPort(portInt),
 	)
 
-	return
+	return attrs
 }
 
 func parseTarget(endpoint string) (address string, err error) {

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -351,7 +351,7 @@ func Partition[S ~[]E, E any](s S, fn func(E) bool) (yes, no S) {
 			no = append(no, item)
 		}
 	}
-	return
+	return yes, no
 }
 
 // PartitionN returns two new slices, the first containing the items of a given slice
@@ -367,7 +367,7 @@ func PartitionN[S ~[]E, E any](s S, fn func(E, int) bool) (yes, no S) {
 			no = append(no, item)
 		}
 	}
-	return
+	return yes, no
 }
 
 // Chunk returns a new slice containing the items of a given slice chunked into smaller slices of a given size.
@@ -383,7 +383,7 @@ func Chunk[S ~[]E, E any](s S, size int) (result []S) {
 		}
 		result = append(result, s[i:end])
 	}
-	return
+	return result
 }
 
 // GroupBy returns a new map containing the items of a given slice grouped by the result of the given function.

--- a/support/helpers.go
+++ b/support/helpers.go
@@ -30,7 +30,7 @@ func Retry(fn func() error, attempts int, sleeps ...time.Duration) (err error) {
 			time.Sleep(sleep)
 		}
 	}
-	return
+	return err
 }
 
 // Until retries the given function until it returns true.

--- a/udp/server.go
+++ b/udp/server.go
@@ -89,7 +89,7 @@ func NewServer(address string, opts ...Option) *Server {
 func (s *Server) Start(_ context.Context) (err error) {
 	s.conn, err = net.ListenPacket("udp", s.address)
 	if err != nil {
-		return
+		return err
 	}
 
 	log.Printf("udp server: listening on %s\n", s.address)


### PR DESCRIPTION
- Update naked return statements to explicitly return error or other values- Affected files:
  - hyperf/jet/client.go
  - support/helpers.go
  - foundation/kernel.go
  - hyperf/jet/middleware/retry/retry.go  - udp/server.go
  - slices/slices.go
  - kratos/middleware/slowlog/slowlog.go
  - kratos/middleware/tracing/span.go
  - hyperf/jet/middleware/tracing/tracing.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected error propagation across core runtime, client invocation, middlewares, helpers, and UDP server startup to prevent silent failures and improve reliability and diagnostics.

- Refactor
  - Replaced bare returns with explicit return values across networking, tracing, retry, slowlog, and slice utilities for clearer control flow and consistency.
  - No public APIs changed; behavior remains the same aside from more accurate error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->