### PR TITLE
Release v3.9.1

### DIFF
--- a/cache/go.mod
+++ b/cache/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/locker/v3 => ../locker
 
 require (
-	github.com/go-fries/fries/locker/v3 v3.9.0
+	github.com/go-fries/fries/locker/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -11,11 +11,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/v3 v3.9.0
-	github.com/go-fries/fries/codec/json/v3 v3.9.0
-	github.com/go-fries/fries/codec/v3 v3.9.0
-	github.com/go-fries/fries/locker/redis/v3 v3.9.0
-	github.com/go-fries/fries/locker/v3 v3.9.0
+	github.com/go-fries/fries/cache/v3 v3.9.1
+	github.com/go-fries/fries/codec/json/v3 v3.9.1
+	github.com/go-fries/fries/codec/v3 v3.9.1
+	github.com/go-fries/fries/locker/redis/v3 v3.9.1
+	github.com/go-fries/fries/locker/v3 v3.9.1
 	github.com/redis/go-redis/v9 v9.13.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/codec/v3 => ../
 
 require (
-	github.com/go-fries/fries/codec/v3 v3.9.0
+	github.com/go-fries/fries/codec/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/codec/v3 => ../
 
 require (
-	github.com/go-fries/fries/codec/v3 v3.9.0
+	github.com/go-fries/fries/codec/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/codec/v3 => ../
 
 require (
-	github.com/go-fries/fries/codec/v3 v3.9.0
+	github.com/go-fries/fries/codec/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.8
 )

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/codec/v3 => ../
 
 require (
 	github.com/bytedance/sonic v1.14.1
-	github.com/go-fries/fries/codec/v3 v3.9.0
+	github.com/go-fries/fries/codec/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/codec/v3 => ../
 
 require (
-	github.com/go-fries/fries/codec/v3 v3.9.0
+	github.com/go-fries/fries/codec/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/codec/v3 => ../
 
 require (
-	github.com/go-fries/fries/codec/v3 v3.9.0
+	github.com/go-fries/fries/codec/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/coroutines/go.mod
+++ b/coroutines/go.mod
@@ -9,13 +9,13 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/support/v3 v3.9.0
+	github.com/go-fries/fries/support/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/errors/v3 v3.9.0 // indirect
+	github.com/go-fries/fries/errors/v3 v3.9.1 // indirect
 	github.com/go-kratos/kratos/v2 v2.8.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect

--- a/crontab/example/go.mod
+++ b/crontab/example/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/crontab/v3 => ../
 
 require (
 	github.com/flc1125/go-cron/v4 v4.6.1
-	github.com/go-fries/fries/crontab/v3 v3.9.0
+	github.com/go-fries/fries/crontab/v3 v3.9.1
 	github.com/go-kratos/kratos/v2 v2.8.4
 )
 

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/eino/components/embedding/cached/v3 => ../../
 
 require (
-	github.com/go-fries/fries/eino/components/embedding/cached/v3 v3.9.0
+	github.com/go-fries/fries/eino/components/embedding/cached/v3 v3.9.1
 	gorm.io/datatypes v1.2.6
 	gorm.io/gorm v1.30.3
 )

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/sonic/v3 v3.9.0
-	github.com/go-fries/fries/codec/v3 v3.9.0
-	github.com/go-fries/fries/eino/components/embedding/cached/v3 v3.9.0
+	github.com/go-fries/fries/codec/sonic/v3 v3.9.1
+	github.com/go-fries/fries/codec/v3 v3.9.1
+	github.com/go-fries/fries/eino/components/embedding/cached/v3 v3.9.1
 	github.com/redis/go-redis/v9 v9.13.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	github.com/cloudwego/eino v0.4.8
-	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v3 v3.9.0
-	github.com/go-fries/fries/eino/components/embedding/cached/v3 v3.9.0
+	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v3 v3.9.1
+	github.com/go-fries/fries/eino/components/embedding/cached/v3 v3.9.1
 	github.com/redis/go-redis/v9 v9.13.0
 )
 
@@ -28,8 +28,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eino-contrib/jsonschema v1.0.0 // indirect
 	github.com/getkin/kin-openapi v0.118.0 // indirect
-	github.com/go-fries/fries/codec/sonic/v3 v3.9.0 // indirect
-	github.com/go-fries/fries/codec/v3 v3.9.0 // indirect
+	github.com/go-fries/fries/codec/sonic/v3 v3.9.1 // indirect
+	github.com/go-fries/fries/codec/v3 v3.9.1 // indirect
 	github.com/go-openapi/jsonpointer v0.22.0 // indirect
 	github.com/go-openapi/swag/jsonname v0.24.0 // indirect
 	github.com/goph/emperror v0.17.2 // indirect

--- a/event/example/go.mod
+++ b/event/example/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/event/middleware/recovery/v3 v3.9.0
-	github.com/go-fries/fries/event/v3 v3.9.0
+	github.com/go-fries/fries/event/middleware/recovery/v3 v3.9.1
+	github.com/go-fries/fries/event/v3 v3.9.1
 )
 
 require golang.org/x/sync v0.16.0 // indirect

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/event/v3 => ../../
 
 require (
-	github.com/go-fries/fries/event/v3 v3.9.0
+	github.com/go-fries/fries/event/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/examples/cache/go.mod
+++ b/examples/cache/go.mod
@@ -12,17 +12,17 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/redis/v3 v3.9.0
-	github.com/go-fries/fries/cache/v3 v3.9.0
+	github.com/go-fries/fries/cache/redis/v3 v3.9.1
+	github.com/go-fries/fries/cache/v3 v3.9.1
 	github.com/redis/go-redis/v9 v9.13.0
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/go-fries/fries/codec/json/v3 v3.9.0 // indirect
-	github.com/go-fries/fries/codec/v3 v3.9.0 // indirect
-	github.com/go-fries/fries/locker/redis/v3 v3.9.0 // indirect
-	github.com/go-fries/fries/locker/v3 v3.9.0 // indirect
+	github.com/go-fries/fries/codec/json/v3 v3.9.1 // indirect
+	github.com/go-fries/fries/codec/v3 v3.9.1 // indirect
+	github.com/go-fries/fries/locker/redis/v3 v3.9.1 // indirect
+	github.com/go-fries/fries/locker/v3 v3.9.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 )

--- a/examples/cloudevents/amqp091/go.mod
+++ b/examples/cloudevents/amqp091/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/cloudevents/protocol/amqp091/v3 => ../../../cl
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.1
-	github.com/go-fries/fries/cloudevents/protocol/amqp091/v3 v3.9.0
+	github.com/go-fries/fries/cloudevents/protocol/amqp091/v3 v3.9.1
 	github.com/google/uuid v1.6.0
 	github.com/rabbitmq/amqp091-go v1.10.0
 )

--- a/examples/cloudevents/eventdispatcher/go.mod
+++ b/examples/cloudevents/eventdispatcher/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/cloudevents/eventdispatcher/v3 => ../../../clo
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.1
-	github.com/go-fries/fries/cloudevents/eventdispatcher/v3 v3.9.0
+	github.com/go-fries/fries/cloudevents/eventdispatcher/v3 v3.9.1
 )
 
 require (

--- a/examples/mysql/canal/go.mod
+++ b/examples/mysql/canal/go.mod
@@ -10,8 +10,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/mysql/canal/positioner/redis/v3 v3.9.0
-	github.com/go-fries/fries/mysql/canal/v3 v3.9.0
+	github.com/go-fries/fries/mysql/canal/positioner/redis/v3 v3.9.1
+	github.com/go-fries/fries/mysql/canal/v3 v3.9.1
 )
 
 require (
@@ -19,8 +19,8 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/go-fries/fries/codec/json/v3 v3.9.0 // indirect
-	github.com/go-fries/fries/codec/v3 v3.9.0 // indirect
+	github.com/go-fries/fries/codec/json/v3 v3.9.1 // indirect
+	github.com/go-fries/fries/codec/v3 v3.9.1 // indirect
 	github.com/go-mysql-org/go-mysql v1.13.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/examples/otel/otlp/go.mod
+++ b/examples/otel/otlp/go.mod
@@ -8,14 +8,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/otel/otlp/v3 v3.9.0
+	github.com/go-fries/fries/otel/otlp/v3 v3.9.1
 	go.opentelemetry.io/otel v1.38.0
 )
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
-	github.com/go-fries/fries/foundation/v3 v3.9.0 // indirect
+	github.com/go-fries/fries/foundation/v3 v3.9.1 // indirect
 	github.com/go-kratos/kratos/v2 v2.8.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/filesystem/v3 => ../
 
 require (
-	github.com/go-fries/fries/filesystem/v3 v3.9.0
+	github.com/go-fries/fries/filesystem/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/filesystem/v3 => ../
 
 require (
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.2.3
-	github.com/go-fries/fries/filesystem/v3 v3.9.0
+	github.com/go-fries/fries/filesystem/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -7,7 +7,7 @@ replace github.com/go-fries/fries/filesystem/v3 => ../
 require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.3
 	github.com/aws/smithy-go v1.23.0
-	github.com/go-fries/fries/filesystem/v3 v3.9.0
+	github.com/go-fries/fries/filesystem/v3 v3.9.1
 )
 
 require (

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/hashing/v3 => ../
 
 require (
-	github.com/go-fries/fries/hashing/v3 v3.9.0
+	github.com/go-fries/fries/hashing/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/logging/go.mod
+++ b/hyperf/jet/middleware/logging/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v3 v3.9.0
+	github.com/go-fries/fries/hyperf/jet/v3 v3.9.1
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/stretchr/testify v1.11.1
 )

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v3 v3.9.0
+	github.com/go-fries/fries/hyperf/jet/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v3 v3.9.0
-	github.com/go-fries/fries/hyperf/jet/v3 v3.9.0
+	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v3 v3.9.1
+	github.com/go-fries/fries/hyperf/jet/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v3 v3.9.0
+	github.com/go-fries/fries/hyperf/jet/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/tracing/go.mod
+++ b/hyperf/jet/middleware/tracing/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v3 v3.9.0
+	github.com/go-fries/fries/hyperf/jet/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0

--- a/kratos/log/otel/go.mod
+++ b/kratos/log/otel/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/v3 => ../../../
 
 require (
-	github.com/go-fries/fries/v3 v3.9.0
+	github.com/go-fries/fries/v3 v3.9.1
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/log v0.14.0

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/locker/v3 => ../
 
 require (
-	github.com/go-fries/fries/locker/v3 v3.9.0
+	github.com/go-fries/fries/locker/v3 v3.9.1
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.13.0
 	github.com/stretchr/testify v1.11.1

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v3 v3.9.0
-	github.com/go-fries/fries/codec/v3 v3.9.0
-	github.com/go-fries/fries/mysql/canal/v3 v3.9.0
+	github.com/go-fries/fries/codec/json/v3 v3.9.1
+	github.com/go-fries/fries/codec/v3 v3.9.1
+	github.com/go-fries/fries/mysql/canal/v3 v3.9.1
 	github.com/go-mysql-org/go-mysql v1.13.0
 	github.com/redis/go-redis/v9 v9.13.0
 	github.com/stretchr/testify v1.11.1

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/mysql/canal/v3 => ../
 
 require (
-	github.com/go-fries/fries/mysql/canal/v3 v3.9.0
+	github.com/go-fries/fries/mysql/canal/v3 v3.9.1
 	github.com/go-kratos/kratos/v2 v2.8.4
 )
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/foundation/v3 => ../../foundation
 
 require (
-	github.com/go-fries/fries/foundation/v3 v3.9.0
+	github.com/go-fries/fries/foundation/v3 v3.9.1
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/host v0.63.0

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/contract/v3 => ../contract
 
 require (
-	github.com/go-fries/fries/contract/v3 v3.9.0
+	github.com/go-fries/fries/contract/v3 v3.9.1
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/stretchr/testify v1.11.1
 )

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 replace github.com/go-fries/fries/constraints/v3 => ../constraints
 
 require (
-	github.com/go-fries/fries/constraints/v3 v3.9.0
+	github.com/go-fries/fries/constraints/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/support/go.mod
+++ b/support/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/errors/v3 => ../errors
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/go-fries/fries/errors/v3 v3.9.0
+	github.com/go-fries/fries/errors/v3 v3.9.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package fries
 
 func Version() string {
-	return "3.9.0"
+	return "3.9.1"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v3.9.0
+    version: v3.9.1
     modules:
       - github.com/go-fries/fries/v3
       - github.com/go-fries/fries/errors/v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded Fries ecosystem dependencies to v3.9.1 across cache, codecs (JSON/MsgPack/Proto/Sonic/XML/YAML), filesystem (local/OSS/S3), hashing, eventing, OTEL, MySQL Canal, RPC/middleware, and example apps for consistency and compatibility.
  * Bumped global product version to 3.9.1 in metadata.
  * No public API changes or behavioral differences expected; this is a patch-level update aligning module versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->