### PR TITLE
docs(hyperf/jet): update import path to v3 version

### DIFF
--- a/hyperf/jet/README.md
+++ b/hyperf/jet/README.md
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/go-kratos-ecosystem/components/v2/hyperf/jet"
+	"github.com/go-fries/fries/hyperf/jet/v3"
 )
 
 func main() {


### PR DESCRIPTION
- Change the import path from "github.com/go-kratos-ecosystem/components/v2/hyperf/jet" to "github.com/go-fries/fries/hyperf/jet/v3"
- This update ensures compatibility with the latest version of the Hyperf Jet component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README usage example to use the new module path: github.com/go-fries/fries/hyperf/jet/v3.
  * Ensures users import the correct package version, reducing setup friction and avoiding build errors.
  * No changes to behavior or APIs; guidance only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->