### PR TITLE
test: replace `context.Background()` with `t.Context()`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - govet
     - goconst
     - mnd
+    - misspell
     - gocyclo
     - gocritic
     - ineffassign
@@ -22,7 +23,7 @@ linters:
     - whitespace
     - wastedassign
     - unconvert
-    - misspell
+    - usetesting
   settings:
     revive:
       # see: https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
@@ -44,6 +45,9 @@ linters:
         - name: var-declaration
         - name: var-naming
         - name: waitgroup-by-value
+    usetesting:
+      context-background: true
+      context-todo: true
 
 formatters:
   enable:

--- a/cache/redis/store_test.go
+++ b/cache/redis/store_test.go
@@ -147,7 +147,7 @@ func TestRedis_Lock(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err := r.Lock("test", 5*time.Second).Try(context.Background(), func() {
+			err := r.Lock("test", 5*time.Second).Try(t.Context(), func() {
 				time.Sleep(time.Second)
 			})
 			if err != nil {

--- a/cache/repository_test.go
+++ b/cache/repository_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +8,7 @@ import (
 
 func TestRepository(t *testing.T) {
 	repo := NewRepository(&NullStore{})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// -----store----
 

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -84,7 +84,7 @@ func setPointerValue(dest any, value any) error {
 }
 
 func TestUtils_Get(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	repo := NewRepository(newUtilMockStore())
 
 	ok, err := repo.Set(ctx, "test_key", "test_value", time.Second*10)
@@ -97,7 +97,7 @@ func TestUtils_Get(t *testing.T) {
 }
 
 func TestUtils_Remember(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	repo := NewRepository(newUtilMockStore())
 	var total int32
 

--- a/chi/server_test.go
+++ b/chi/server_test.go
@@ -19,7 +19,7 @@ func TestServer(t *testing.T) {
 		_, _ = w.Write([]byte("pong"))
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 
 	go func() {

--- a/cloudevents/eventdispatcher/context_test.go
+++ b/cloudevents/eventdispatcher/context_test.go
@@ -1,7 +1,6 @@
 package eventdispatcher
 
 import (
-	"context"
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -14,7 +13,7 @@ func TestContext(t *testing.T) {
 		event.SetID("test-event")
 		event.SetType("test.type")
 
-		ctx := NewContext(context.Background(), event)
+		ctx := NewContext(t.Context(), event)
 
 		retrievedEvent, ok := FromContext(ctx)
 		assert.True(t, ok)
@@ -23,7 +22,7 @@ func TestContext(t *testing.T) {
 	})
 
 	t.Run("empty context", func(t *testing.T) {
-		emptyCtx := context.Background()
+		emptyCtx := t.Context()
 		_, ok := FromContext(emptyCtx)
 		assert.False(t, ok)
 	})

--- a/cloudevents/eventdispatcher/dispatcher_test.go
+++ b/cloudevents/eventdispatcher/dispatcher_test.go
@@ -40,7 +40,7 @@ func TestDispatcher(t *testing.T) {
 		event.SetID("test-event")
 		event.SetType(eventType)
 
-		assert.NoError(t, dispatcher.Dispatch(context.Background(), event))
+		assert.NoError(t, dispatcher.Dispatch(t.Context(), event))
 	})
 
 	t.Run("Dispatch without listeners", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestDispatcher(t *testing.T) {
 		event.SetID("test-event")
 		event.SetType("non.existent.event")
 
-		err := dispatcher.Dispatch(context.Background(), event)
+		err := dispatcher.Dispatch(t.Context(), event)
 		assert.Equal(t, ErrNoListener, err)
 	})
 
@@ -72,7 +72,7 @@ func TestDispatcher(t *testing.T) {
 		event.SetID("test-event")
 		event.SetType(eventType)
 
-		assert.NoError(t, dispatcher.Dispatch(context.Background(), event))
+		assert.NoError(t, dispatcher.Dispatch(t.Context(), event))
 	})
 
 	t.Run("Dispatch with unmarshal error", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestDispatcher(t *testing.T) {
 		event.SetType(eventType)
 		assert.NoError(t, event.SetData(cloudevents.ApplicationJSON, "invalid data"))
 
-		err := dispatcher.Dispatch(context.Background(), event)
+		err := dispatcher.Dispatch(t.Context(), event)
 		assert.Equal(t, ErrFailedToUnmarshalEvent, err)
 	})
 
@@ -112,7 +112,7 @@ func TestDispatcher(t *testing.T) {
 		event.SetID("test-event")
 		event.SetType(eventType)
 
-		ctx := context.WithValue(context.Background(), "key", "value") //nolint:staticcheck
+		ctx := context.WithValue(t.Context(), "key", "value") //nolint:staticcheck
 
 		assert.NoError(t, dispatcher.Dispatch(ctx, event))
 	})
@@ -133,7 +133,7 @@ func TestDispatcher(t *testing.T) {
 		event.SetType(eventType)
 		assert.NoError(t, event.SetData(cloudevents.TextPlain, "test data"))
 
-		assert.NoError(t, dispatcher.Dispatch(context.Background(), event))
+		assert.NoError(t, dispatcher.Dispatch(t.Context(), event))
 	})
 
 	t.Run("Dispatch with listener adapter", func(t *testing.T) {
@@ -148,14 +148,14 @@ func TestDispatcher(t *testing.T) {
 		event.SetType(eventType)
 		assert.NoError(t, event.SetData(cloudevents.ApplicationJSON, TestEvent{User: "test-user"}))
 
-		assert.NoError(t, dispatcher.Dispatch(context.Background(), event))
+		assert.NoError(t, dispatcher.Dispatch(t.Context(), event))
 
 		// unmarshalling error
 		unmarshalEvent := cloudevents.NewEvent()
 		unmarshalEvent.SetID("test-event-unmarshal")
 		unmarshalEvent.SetType(eventType)
 		assert.NoError(t, unmarshalEvent.SetData(cloudevents.ApplicationJSON, "invalid data"))
-		err := dispatcher.Dispatch(context.Background(), unmarshalEvent)
+		err := dispatcher.Dispatch(t.Context(), unmarshalEvent)
 		assert.Equal(t, ErrFailedToUnmarshalEvent, err)
 	})
 
@@ -173,11 +173,11 @@ func TestDispatcher(t *testing.T) {
 		event.SetID("test-event")
 		event.SetType(eventType)
 
-		assert.NoError(t, dispatcher.Dispatch(context.Background(), event))
+		assert.NoError(t, dispatcher.Dispatch(t.Context(), event))
 
 		dispatcher.Reset()
 
-		err := dispatcher.Dispatch(context.Background(), event)
+		err := dispatcher.Dispatch(t.Context(), event)
 		assert.Equal(t, ErrNoListener, err)
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,7 @@ type config2 struct {
 }
 
 func TestConfig(t *testing.T) {
-	ctx := NewContext(context.Background(), &config{
+	ctx := NewContext(t.Context(), &config{
 		Host: "localhost",
 		Port: 8080,
 	})

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,7 @@ func TestProvider(t *testing.T) {
 	cfg := testConfig{Name: "test", Port: 1234}
 	provider := NewProvider(cfg)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	newCtx, err := provider.Bootstrap(ctx)
 	require.NoError(t, err)
 

--- a/crontab/server_test.go
+++ b/crontab/server_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCrontab(t *testing.T) {
 	var (
-		ctx  = context.Background()
+		ctx  = t.Context()
 		data = make(chan string, 1)
 		srv  = NewServer(cron.New(
 			cron.WithSeconds(),

--- a/eino/components/embedding/cached/cacher/redis/cacher_test.go
+++ b/eino/components/embedding/cached/cacher/redis/cacher_test.go
@@ -56,7 +56,7 @@ func (m *mockRedisClient) Get(ctx context.Context, key string) *redis.StringCmd 
 }
 
 func TestCacher(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	key := "test_key"
 	value := []float64{1.1, 2.2, 3.3}
 	expire := time.Second * 10

--- a/eino/components/embedding/cached/cacher_test.go
+++ b/eino/components/embedding/cached/cacher_test.go
@@ -1,7 +1,6 @@
 package cached
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +8,7 @@ import (
 
 func TestCacher_noCacher(t *testing.T) {
 	c := &noCacher{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NoError(t, c.Set(ctx, "key", []float64{1.0, 2.0}, 0))
 	value, err := c.Get(ctx, "key")

--- a/eino/components/embedding/cached/embedding_test.go
+++ b/eino/components/embedding/cached/embedding_test.go
@@ -45,7 +45,7 @@ func (m *mockCacher) Set(ctx context.Context, key string, value []float64, expir
 }
 
 func TestEmbedder_EmbedStrings(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	texts := []string{"foo", "bar"}
 	embeddings := [][]float64{{1.1, 2.2}, {3.3, 4.4}}
 	expiration := time.Minute
@@ -196,7 +196,7 @@ func (c *contextMockCacher) Set(ctx context.Context, _ string, _ []float64, _ ti
 }
 
 func TestEmbedder_ContextWithText(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	embeddings := [][]float64{{1.1, 2.2}, {3.3, 4.4}}
 
 	mc := &contextMockCacher{

--- a/eino/components/embedding/cached/generator_test.go
+++ b/eino/components/embedding/cached/generator_test.go
@@ -1,7 +1,6 @@
 package cached
 
 import (
-	"context"
 	"crypto/md5"
 	"crypto/sha256"
 	"fmt"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestGenerator_UniquenessAndDifference(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := GeneratorOptions{}
 
 	for _, tt := range []struct {
@@ -46,7 +45,7 @@ func TestGenerator_UniquenessAndDifference(t *testing.T) {
 func TestGenerator_SimpleGenerator(t *testing.T) {
 	text := "test text"
 	model := "test-model"
-	ctx := context.Background()
+	ctx := t.Context()
 	opt := GeneratorOptions{}
 
 	generator := NewSimpleGenerator()
@@ -58,7 +57,7 @@ func TestGenerator_SimpleGenerator(t *testing.T) {
 func TestGenerator_HashGenerator(t *testing.T) {
 	text := "test text"
 	model := "test-model"
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, tt := range []struct {
 		name   string
@@ -75,7 +74,7 @@ func TestGenerator_HashGenerator(t *testing.T) {
 }
 
 func TestGenerator_HashGenerator_Concurrent(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	generator := NewHashGenerator(sha256.New)
 	results := make(chan string, 100)
 

--- a/eino/components/embedding/cached/texts_test.go
+++ b/eino/components/embedding/cached/texts_test.go
@@ -1,7 +1,6 @@
 package cached
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,7 @@ func TestTextContext(t *testing.T) {
 		{"text3"},
 	} {
 		t.Run(tt.text, func(t *testing.T) {
-			ctx := contextWithText(context.Background(), tt.text)
+			ctx := contextWithText(t.Context(), tt.text)
 
 			retrievedText, ok := TextFromContext(ctx)
 			assert.True(t, ok, "expected text to be present in context")

--- a/env/context_test.go
+++ b/env/context_test.go
@@ -1,14 +1,13 @@
 package env
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContext(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	env1, ok1 := FromContext(ctx)
 	assert.NotEqual(t, Dev, env1)

--- a/env/provider_test.go
+++ b/env/provider_test.go
@@ -1,7 +1,6 @@
 package env
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,7 @@ func TestProvider(t *testing.T) {
 	assert.False(t, Is(Debug))
 
 	p := NewProvider(Debug)
-	ctx, err := p.Bootstrap(context.Background())
+	ctx, err := p.Bootstrap(t.Context())
 	assert.NoError(t, err)
 
 	e1, ok := FromContext(ctx)

--- a/event/context_test.go
+++ b/event/context_test.go
@@ -1,19 +1,18 @@
 package event
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContext(t *testing.T) {
-	d1, ok1 := FromContext(context.Background())
+	d1, ok1 := FromContext(t.Context())
 	assert.False(t, ok1)
 	assert.Nil(t, d1)
 
 	var d *Dispatcher
-	ctx := NewContext(context.Background(), d)
+	ctx := NewContext(t.Context(), d)
 
 	d2, ok2 := FromContext(ctx)
 	assert.True(t, ok2)

--- a/event/provider_test.go
+++ b/event/provider_test.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +11,7 @@ func TestProvider(t *testing.T) {
 	p := NewProvider(d)
 	p.RegisterListeners(nil)
 
-	ctx, err := p.Bootstrap(context.Background())
+	ctx, err := p.Bootstrap(t.Context())
 	assert.NoError(t, err)
 
 	d1, ok := FromContext(ctx)

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -1,7 +1,6 @@
 package filesystem
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +9,7 @@ import (
 func TestStorage(t *testing.T) {
 	var (
 		noop = NoopFilesystem{}
-		ctx  = context.Background()
+		ctx  = t.Context()
 	)
 
 	_, err := noop.Read(ctx, "test")

--- a/filesystem/repository_test.go
+++ b/filesystem/repository_test.go
@@ -1,7 +1,6 @@
 package filesystem
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +8,7 @@ import (
 
 func TestNoopRepository(t *testing.T) {
 	repo := NewRepository(NoopFilesystem{})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NoError(t, repo.Put(ctx, "noop", []byte("noop")))
 	assert.NoError(t, repo.Destroy(ctx, "noop"))

--- a/foundation/kernel_test.go
+++ b/foundation/kernel_test.go
@@ -63,6 +63,6 @@ func TestKernel(t *testing.T) {
 	k.Register(
 		newProvider(t, contextKey2{}, "value2"),
 	)
-	assert.NoError(t, k.Run(context.Background()))
+	assert.NoError(t, k.Run(t.Context()))
 	assert.Equal(t, "done", <-ch)
 }

--- a/foundation/provider_test.go
+++ b/foundation/provider_test.go
@@ -14,7 +14,7 @@ func TestProvider_BootstrapFunc(t *testing.T) {
 		return context.WithValue(ctx, providerFuncKey{}, "test"), nil
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, err := p.Bootstrap(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "test", ctx.Value(providerFuncKey{}))
@@ -29,7 +29,7 @@ func TestProvider_BootstrapFuncError(t *testing.T) {
 		return context.WithValue(ctx, providerFuncKey{}, "test"), nil
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, err := p.Bootstrap(ctx)
 	assert.NoError(t, err)
 	assert.Nil(t, ctx.Value(providerFuncKey{}))
@@ -51,7 +51,7 @@ func TestProvider_Chain(t *testing.T) {
 	})
 
 	c := NewChain(p1, p2, p3)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ctx, err := c.Bootstrap(ctx)
 	assert.NoError(t, err)

--- a/gin/server_test.go
+++ b/gin/server_test.go
@@ -1,7 +1,6 @@
 package gin
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -53,7 +52,7 @@ func TestServer(t *testing.T) {
 	})
 
 	go func() {
-		srv.Start(context.Background()) // nolint: errcheck
+		srv.Start(t.Context()) // nolint: errcheck
 	}()
 
 	resp, err := http.Get("http://localhost:8080/ping")
@@ -68,6 +67,6 @@ func TestServer(t *testing.T) {
 
 	assert.Equal(t, "pong", <-ch)
 
-	err = srv.Stop(context.Background())
+	err = srv.Stop(t.Context())
 	assert.NoError(t, err)
 }

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	srv := NewWithHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "server", r.URL.Query().Get("name"))
 

--- a/hyperf/jet/client_test.go
+++ b/hyperf/jet/client_test.go
@@ -94,7 +94,7 @@ func TestClient_Invoke(t *testing.T) {
 
 	// call service
 	var balance float64
-	err = client.Invoke(context.Background(), "balance", testParams, &balance)
+	err = client.Invoke(t.Context(), "balance", testParams, &balance)
 	assert.NoError(t, err)
 	assert.Equal(t, testBalance, balance)
 }

--- a/hyperf/jet/context_test.go
+++ b/hyperf/jet/context_test.go
@@ -1,21 +1,20 @@
 package jet
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContext_Client(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	got1, ok1 := ClientFromContext(ctx)
 	assert.False(t, ok1)
 	assert.Nil(t, got1)
 
 	client := &Client{}
-	ctx = ContextWithClient(context.Background(), client)
+	ctx = ContextWithClient(t.Context(), client)
 
 	got2, ok2 := ClientFromContext(ctx)
 	assert.True(t, ok2)

--- a/hyperf/jet/middleware/logging/logging_test.go
+++ b/hyperf/jet/middleware/logging/logging_test.go
@@ -62,12 +62,12 @@ func TestLogging(t *testing.T) {
 		assert.Equal(t, "service", service)
 		assert.Equal(t, "no-error", method)
 		return "response", nil
-	})(context.Background(), "service", "no-error", nil)
+	})(t.Context(), "service", "no-error", nil)
 
 	// with error
 	_, _ = logging(func(_ context.Context, service, method string, _ any) (response any, err error) {
 		assert.Equal(t, "service", service)
 		assert.Equal(t, "with-error", method)
 		return nil, assert.AnError
-	})(context.Background(), "service", "with-error", nil)
+	})(t.Context(), "service", "with-error", nil)
 }

--- a/hyperf/jet/middleware/recovery/recovery_test.go
+++ b/hyperf/jet/middleware/recovery/recovery_test.go
@@ -26,7 +26,7 @@ func TestRecovery(t *testing.T) {
 
 	response, err := recovery(func(context.Context, string, string, any) (response any, err error) {
 		panic(testError)
-	})(context.Background(), testService, testMethod, testRequest)
+	})(t.Context(), testService, testMethod, testRequest)
 	assert.Error(t, err)
 	assert.Nil(t, response)
 }
@@ -36,7 +36,7 @@ func TestRecovery_DefaultHandler(t *testing.T) {
 
 	response, err := recovery(func(context.Context, string, string, any) (response any, err error) {
 		panic("error")
-	})(context.Background(), "service", "method", "request")
+	})(t.Context(), "service", "method", "request")
 	assert.Error(t, err)
 	assert.Nil(t, response)
 }

--- a/hyperf/jet/middleware/retry/retry_test.go
+++ b/hyperf/jet/middleware/retry/retry_test.go
@@ -54,7 +54,7 @@ func TestRetry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := retry(tt.handler)(context.Background(), "service", "test", nil)
+			_, err := retry(tt.handler)(t.Context(), "service", "test", nil)
 			tt.want(t, err)
 		})
 	}

--- a/hyperf/jet/middleware/timeout/timeout_test.go
+++ b/hyperf/jet/middleware/timeout/timeout_test.go
@@ -46,7 +46,7 @@ func TestTimeout(t *testing.T) {
 				time.Sleep(tt.sleep)
 				return "test", nil
 			})
-			response, err := handler(context.Background(), "service", "test", "request")
+			response, err := handler(t.Context(), "service", "test", "request")
 			tt.want(t, response, err)
 		})
 	}

--- a/hyperf/jet/middleware/tracing/tracing_test.go
+++ b/hyperf/jet/middleware/tracing/tracing_test.go
@@ -36,7 +36,7 @@ func TestTracing(t *testing.T) {
 				assert.Nil(t, request)
 				return nil, tt.err
 			})
-			_, err := handler(context.Background(), "service", "method", nil)
+			_, err := handler(t.Context(), "service", "method", nil)
 			require.Equal(t, tt.err, err)
 
 			spans := imsb.GetSpans()

--- a/hyperf/jet/middleware_test.go
+++ b/hyperf/jet/middleware_test.go
@@ -40,7 +40,7 @@ func TestMiddleware_Chain(t *testing.T) {
 
 		return "response", nil
 	})
-	response, err := chain(context.Background(), "service", "method", "request")
+	response, err := chain(t.Context(), "service", "method", "request")
 	assert.NoError(t, err)
 	assert.Equal(t, "response", response)
 

--- a/hyperf/jet/transporter_test.go
+++ b/hyperf/jet/transporter_test.go
@@ -2,7 +2,6 @@ package jet
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +29,7 @@ func TestTransporter_HTTPTransporter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// send a request
-	response, err := transport.Send(context.Background(), testRequest)
+	response, err := transport.Send(t.Context(), testRequest)
 	assert.NoError(t, err)
 	assert.Equal(t, testResponse, response)
 }

--- a/kratos/log/otel/convert_test.go
+++ b/kratos/log/otel/convert_test.go
@@ -1,7 +1,6 @@
 package otel
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -235,7 +234,7 @@ func TestConvertValue(t *testing.T) {
 		},
 		{
 			name:      "ctx",
-			value:     context.Background(),
+			value:     t.Context(),
 			wantValue: log.StringValue("context.Background"),
 		},
 		{

--- a/kratos/log/otel/convert_test.go
+++ b/kratos/log/otel/convert_test.go
@@ -1,6 +1,7 @@
 package otel
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -234,7 +235,7 @@ func TestConvertValue(t *testing.T) {
 		},
 		{
 			name:      "ctx",
-			value:     t.Context(),
+			value:     context.Background(), //nolint:usetesting
 			wantValue: log.StringValue("context.Background"),
 		},
 		{

--- a/kratos/middleware/protovalidate/validator_test.go
+++ b/kratos/middleware/protovalidate/validator_test.go
@@ -70,7 +70,7 @@ func TestValidator(t *testing.T) {
 			reply, err := Server(
 				Validator(tt.validator(t)),
 				Handler(defaultHandler),
-			)(next)(context.Background(), tt.req)
+			)(next)(t.Context(), tt.req)
 			tt.want(t, reply, err)
 		})
 	}

--- a/kratos/middleware/slowlog/slowlog_test.go
+++ b/kratos/middleware/slowlog/slowlog_test.go
@@ -62,7 +62,7 @@ func TestHTTP(t *testing.T) {
 			err,
 			func() context.Context {
 				return transport.NewServerContext(
-					context.Background(),
+					t.Context(),
 					&Transport{kind: transport.KindHTTP, endpoint: "endpoint", operation: "/package.service/method"},
 				)
 			}(),
@@ -73,7 +73,7 @@ func TestHTTP(t *testing.T) {
 			nil,
 			func() context.Context {
 				return transport.NewServerContext(
-					context.Background(),
+					t.Context(),
 					&Transport{kind: transport.KindHTTP, endpoint: "endpoint", operation: "/package.service/method"},
 				)
 			}(),
@@ -84,7 +84,7 @@ func TestHTTP(t *testing.T) {
 			nil,
 			func() context.Context {
 				return transport.NewClientContext(
-					context.Background(),
+					t.Context(),
 					&Transport{kind: transport.KindHTTP, endpoint: "endpoint", operation: "/package.service/method"},
 				)
 			}(),
@@ -95,7 +95,7 @@ func TestHTTP(t *testing.T) {
 			err,
 			func() context.Context {
 				return transport.NewClientContext(
-					context.Background(),
+					t.Context(),
 					&Transport{kind: transport.KindHTTP, endpoint: "endpoint", operation: "/package.service/method"},
 				)
 			}(),

--- a/kratos/middleware/tracing/metadata_test.go
+++ b/kratos/middleware/tracing/metadata_test.go
@@ -34,7 +34,7 @@ func TestMetadata_Inject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := kratos.New(kratos.Name(tt.args.appName))
-			ctx := kratos.NewContext(context.Background(), a)
+			ctx := kratos.NewContext(t.Context(), a)
 			m := new(Metadata)
 			m.Inject(ctx, tt.args.carrier)
 			if res := tt.args.carrier.Get(serviceHeader); tt.want != res {
@@ -58,7 +58,7 @@ func TestMetadata_Extract(t *testing.T) {
 		{
 			name: "https://go-kratos.dev",
 			args: args{
-				parent:  context.Background(),
+				parent:  t.Context(),
 				carrier: propagation.HeaderCarrier{"X-Md-Service-Name": []string{"https://go-kratos.dev"}},
 			},
 			want: "https://go-kratos.dev",
@@ -66,7 +66,7 @@ func TestMetadata_Extract(t *testing.T) {
 		{
 			name: "https://github.com/go-kratos/kratos",
 			args: args{
-				parent:  metadata.NewServerContext(context.Background(), metadata.Metadata{}),
+				parent:  metadata.NewServerContext(t.Context(), metadata.Metadata{}),
 				carrier: propagation.HeaderCarrier{"X-Md-Service-Name": []string{"https://github.com/go-kratos/kratos"}},
 			},
 			want: "https://github.com/go-kratos/kratos",
@@ -74,7 +74,7 @@ func TestMetadata_Extract(t *testing.T) {
 		{
 			name: "https://github.com/go-kratos/kratos",
 			args: args{
-				parent:  metadata.NewServerContext(context.Background(), metadata.Metadata{}),
+				parent:  metadata.NewServerContext(t.Context(), metadata.Metadata{}),
 				carrier: propagation.HeaderCarrier{"X-Md-Service-Name": nil},
 			},
 			crash: true,

--- a/kratos/middleware/tracing/span_test.go
+++ b/kratos/middleware/tracing/span_test.go
@@ -1,7 +1,6 @@
 package tracing
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"reflect"
@@ -178,8 +177,8 @@ func Test_parseTarget(t *testing.T) {
 	}
 }
 
-func TestSetServerSpan(_ *testing.T) {
-	ctx := context.Background()
+func TestSetServerSpan(t *testing.T) {
+	ctx := t.Context()
 	_, span := noop.NewTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
 
 	// Handle without Transport context
@@ -211,8 +210,8 @@ func TestSetServerSpan(_ *testing.T) {
 	setServerSpan(ctx, span, m)
 }
 
-func TestSetClientSpan(_ *testing.T) {
-	ctx := context.Background()
+func TestSetClientSpan(t *testing.T) {
+	ctx := t.Context()
 	_, span := noop.NewTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
 
 	// Handle without Transport context

--- a/kratos/middleware/tracing/statshandler_test.go
+++ b/kratos/middleware/tracing/statshandler_test.go
@@ -15,13 +15,13 @@ type ctxKey string
 
 const testKey ctxKey = "MY_TEST_KEY"
 
-func TestClient_HandleConn(_ *testing.T) {
-	(&ClientHandler{}).HandleConn(context.Background(), nil)
+func TestClient_HandleConn(t *testing.T) {
+	(&ClientHandler{}).HandleConn(t.Context(), nil)
 }
 
 func TestClient_TagConn(t *testing.T) {
 	client := &ClientHandler{}
-	ctx := context.WithValue(context.Background(), testKey, 123)
+	ctx := context.WithValue(t.Context(), testKey, 123)
 
 	if client.TagConn(ctx, nil).Value(testKey) != 123 {
 		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`,
@@ -31,7 +31,7 @@ func TestClient_TagConn(t *testing.T) {
 
 func TestClient_TagRPC(t *testing.T) {
 	client := &ClientHandler{}
-	ctx := context.WithValue(context.Background(), testKey, 123)
+	ctx := context.WithValue(t.Context(), testKey, 123)
 
 	if client.TagRPC(ctx, nil).Value(testKey) != 123 {
 		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`,
@@ -48,13 +48,13 @@ func (m *mockSpan) SpanContext() trace.SpanContext {
 	return *m.mockSpanCtx
 }
 
-func TestClient_HandleRPC(_ *testing.T) {
+func TestClient_HandleRPC(t *testing.T) {
 	client := &ClientHandler{}
-	ctx := context.Background()
+	ctx := t.Context()
 	rs := stats.OutHeader{}
 
 	// Handle stats.RPCStats is not type of stats.OutHeader case
-	client.HandleRPC(context.TODO(), nil)
+	client.HandleRPC(t.Context(), nil)
 
 	// Handle context doesn't have the peerkey filled with a Peer instance
 	client.HandleRPC(ctx, &rs)

--- a/kratos/middleware/tracing/tracer_test.go
+++ b/kratos/middleware/tracing/tracer_test.go
@@ -1,7 +1,6 @@
 package tracing
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -30,11 +29,11 @@ func TestNewTracer(t *testing.T) {
 	})
 }
 
-func TestTracer_End(_ *testing.T) {
+func TestTracer_End(t *testing.T) {
 	tracer := NewTracer(trace.SpanKindClient, func(o *options) {
 		o.tracerProvider = noop.NewTracerProvider()
 	})
-	ctx, span := noop.NewTracerProvider().Tracer("noop").Start(context.Background(), "noopSpan")
+	ctx, span := noop.NewTracerProvider().Tracer("noop").Start(t.Context(), "noopSpan")
 
 	// Handle with error case
 	tracer.End(ctx, span, nil, errors.New("dummy error"))

--- a/kratos/middleware/tracing/tracing_test.go
+++ b/kratos/middleware/tracing/tracing_test.go
@@ -87,7 +87,7 @@ func TestTracer(t *testing.T) {
 	ts := &mockTransport{kind: transport.KindHTTP, header: carrier}
 
 	ctx, aboveSpan := cliTracer.Start(
-		transport.NewClientContext(context.Background(), ts),
+		transport.NewClientContext(t.Context(), ts),
 		ts.Operation(), ts.RequestHeader())
 	defer cliTracer.End(ctx, aboveSpan, nil, nil)
 
@@ -141,7 +141,7 @@ func TestServer(t *testing.T) {
 
 	var ctx context.Context
 	ctx, span := tracer.Start(
-		transport.NewServerContext(context.Background(), tr),
+		transport.NewServerContext(t.Context(), tr),
 		tr.Operation(),
 		tr.RequestHeader(),
 	)
@@ -169,7 +169,7 @@ func TestServer(t *testing.T) {
 	_, err = Server(
 		WithTracerProvider(tracesdk.NewTracerProvider()),
 		WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})),
-	)(next)(context.Background(), "test server: ")
+	)(next)(t.Context(), "test server: ")
 	if err != nil {
 		t.Errorf("expected error, got nil")
 	}
@@ -213,7 +213,7 @@ func TestClient(t *testing.T) {
 
 	var ctx context.Context
 	ctx, span := tracer.Start(
-		transport.NewClientContext(context.Background(), tr),
+		transport.NewClientContext(t.Context(), tr),
 		tr.Operation(),
 		tr.RequestHeader(),
 	)

--- a/locker/locker_test.go
+++ b/locker/locker_test.go
@@ -1,7 +1,6 @@
 package locker
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -10,7 +9,7 @@ import (
 
 func TestLocker_NoopLocker(t *testing.T) {
 	l := NoopLocker{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	assert.NoError(t, l.Try(ctx, func() {}))
 	assert.NoError(t, l.Until(ctx, time.Second, func() {}))

--- a/locker/owner_test.go
+++ b/locker/owner_test.go
@@ -1,7 +1,6 @@
 package locker
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,5 +9,5 @@ import (
 func TestOwner_owner(t *testing.T) {
 	o := NewOwner(NoopLocker{}, WithOwnerName("test"))
 	assert.Equal(t, "test", o.Name())
-	assert.NoError(t, o.Release(context.Background()))
+	assert.NoError(t, o.Release(t.Context()))
 }

--- a/otel/otlp/transport_test.go
+++ b/otel/otlp/transport_test.go
@@ -1,7 +1,6 @@
 package otlp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +13,7 @@ func TestGRPCTransport(t *testing.T) {
 	assert.Equal(t, endpoint, transport.endpoint)
 	assert.True(t, transport.insecure)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	traceExporter, err := transport.GetTraceSpanExporter(ctx)
 	assert.NoError(t, err)
@@ -36,7 +35,7 @@ func TestHTTPTransport(t *testing.T) {
 	assert.Equal(t, endpoint, transport.endpoint)
 	assert.True(t, transport.insecure)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	traceExporter, err := transport.GetTraceSpanExporter(ctx)
 	assert.NoError(t, err)

--- a/redis/manager_test.go
+++ b/redis/manager_test.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -10,7 +9,7 @@ import (
 )
 
 func TestManager(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	rdb := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -2,7 +2,6 @@ package signal
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -21,7 +20,7 @@ var (
 func TestServer(t *testing.T) {
 	srv := newServer()
 
-	go srv.Start(context.Background()) //nolint:errcheck
+	go srv.Start(t.Context()) //nolint:errcheck
 
 	time.Sleep(2 * time.Second)
 
@@ -37,7 +36,7 @@ exampleHandler signal: user defined signal 2
 `, buffer.String())
 	mu.Unlock()
 
-	srv.Stop(context.Background()) //nolint:errcheck
+	srv.Stop(t.Context()) //nolint:errcheck
 }
 
 func newServer() *Server {

--- a/support/contexts/contexts_test.go
+++ b/support/contexts/contexts_test.go
@@ -36,7 +36,7 @@ var (
 func TestPipe(t *testing.T) {
 	result = make(chan string, 2)
 	ctx1, err1 := Pipe(
-		context.Background(),
+		t.Context(),
 		mockProvider1, mockProvider2,
 	)
 	assert.NoError(t, err1)
@@ -46,7 +46,7 @@ func TestPipe(t *testing.T) {
 	assert.Equal(t, "mockProvider2", <-result)
 
 	ctx2, err2 := Pipe(
-		context.Background(),
+		t.Context(),
 		mockProvider1, mockProvider3,
 	)
 	assert.Error(t, err2)
@@ -59,7 +59,7 @@ func TestPipe(t *testing.T) {
 func TestChain(t *testing.T) {
 	result = make(chan string, 2)
 	ctx1, err1 := Chain(
-		context.Background(),
+		t.Context(),
 		mockProvider1, mockProvider2,
 	)
 	assert.NoError(t, err1)
@@ -69,7 +69,7 @@ func TestChain(t *testing.T) {
 	assert.Equal(t, "mockProvider1", <-result)
 
 	ctx2, err2 := Chain(
-		context.Background(),
+		t.Context(),
 		mockProvider3, mockProvider1,
 	)
 	assert.Error(t, err2)

--- a/support/contexts/values_test.go
+++ b/support/contexts/values_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestValue(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	type (
 		key1 struct{}

--- a/support/helpers_test.go
+++ b/support/helpers_test.go
@@ -193,7 +193,7 @@ func TestPipeWithErr(t *testing.T) {
 		},
 	)
 
-	ctx, err := pipe3(context.Background())
+	ctx, err := pipe3(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, "bar", ctx.Value("foo"))
 	assert.Equal(t, "baz", ctx.Value("bar"))
@@ -208,7 +208,7 @@ func TestPipeWithErr(t *testing.T) {
 		},
 	)
 
-	ctx, err = pipe4(context.Background())
+	ctx, err = pipe4(t.Context())
 	assert.Error(t, err)
 	assert.Nil(t, ctx)
 }

--- a/timezone/provider_test.go
+++ b/timezone/provider_test.go
@@ -1,7 +1,6 @@
 package timezone
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -26,7 +25,7 @@ func TestProvider(t *testing.T) {
 
 	p := NewProvider(PRC)
 
-	ctx, err := p.Bootstrap(context.Background())
+	ctx, err := p.Bootstrap(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, "Asia/Shanghai", time.Local.String())
 

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -1,7 +1,6 @@
 package udp
 
 import (
-	"context"
 	"net"
 	"sync"
 	"testing"
@@ -26,10 +25,10 @@ func TestServer(t *testing.T) {
 			t.Log(err)
 		}), WithBufSize(1024))
 
-		go server.Start(context.Background()) //nolint:errcheck
+		go server.Start(t.Context()) //nolint:errcheck
 
 		time.Sleep(time.Second * 5)
-		_ = server.Stop(context.Background())
+		_ = server.Stop(t.Context())
 	}()
 
 	go func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Switched tests to use test-scoped contexts for better cancellation and timeout handling.
  - Cleaned up unused imports and streamlined test signatures.
  - Added small assertions and scenarios in tracing-related tests to improve coverage.
  - Applied a targeted lint suppression in a test where appropriate.

- Chores
  - Updated linting configuration: replaced the misspelling checker with a testing-context linter and enabled its rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->