### PR TITLE
chore(deps): group renovate package updates for better dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,16 @@
       "enabled": true
     },
     {
-      "matchPackageNames": ["go.opentelemetry.io/build-tools/**"],
+      "matchPackageNames": ["go.opentelemetry.io/build-tools/**", "go.opentelemetry.io/build-tools"],
       "groupName": "go.opentelemetry.io/build-tools"
+    },
+    {
+      "matchPackageNames": ["google.golang.org/api", "google.golang.org/grpc", "google.golang.org/protobuf"],
+      "groupName": "google.golang.org"
+    },
+    {
+      "matchPackageNames": ["github.com/docker/cli", "github.com/docker/docker"],
+      "groupName": "github.com/docker"
     },
     {
       "matchPackageNames": ["github.com/pingcap/tidb/**"],


### PR DESCRIPTION
- Add grouping for google.golang.org packages
- Add grouping for github.com/docker packages- Update go.opentelemetry.io/build-tools package matching pattern
- Maintain existing pingcap/tidb grouping with schedule configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved dependency update configuration to streamline Renovate behavior.
  - Broadened matching for OpenTelemetry build tool updates to ensure more comprehensive coverage.
  - Introduced grouped updates for select Google and Docker Go modules to reduce PR noise and simplify reviews.
  - Users can expect more consistent, batched dependency PRs with clearer visibility into related updates, resulting in a smoother maintenance flow without impacting runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->