### PR TITLE
refactor(core): improve code style and replace loops with range

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - goconst
     - mnd
     - misspell
+    - modernize
     - gocyclo
     - gocritic
     - ineffassign
@@ -48,6 +49,9 @@ linters:
     usetesting:
       context-background: true
       context-todo: true
+    modernize:
+      disable:
+        - omitzero
 
 formatters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,13 @@ lint/%: DIR=$*
 lint/%: go-mod-tidy/% golangci-lint/%
 	@echo "linted $(DIR)"
 
+.PHONY: lint-fix
+lint-fix: go-mod-tidy golangci-lint-fix
+lint-fix/%: DIR=$*
+lint-fix/%: go-mod-tidy/% golangci-lint-fix/%
+	@echo "lint-fixed $(DIR)"
+
+
 .PHONY: clean
 clean:
 	rm -rf $(TOOLS)

--- a/cache/redis/store_test.go
+++ b/cache/redis/store_test.go
@@ -143,7 +143,7 @@ func TestRedis_Lock(t *testing.T) {
 	var wg sync.WaitGroup
 	var s int64
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cache/snapshot_test.go
+++ b/cache/snapshot_test.go
@@ -18,7 +18,7 @@ func TestSnapshot(t *testing.T) {
 		total atomic.Int32
 	)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value := snap.Lookup("key", func() *snapshotValue {
 			total.Add(1)
 			return &snapshotValue{value: "value"}
@@ -41,7 +41,7 @@ func TestSnapshot_Reset(t *testing.T) {
 		total atomic.Int32
 	)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value := snap.Lookup("key", func() *snapshotValue {
 			total.Add(1)
 			return &snapshotValue{value: "value"}
@@ -53,7 +53,7 @@ func TestSnapshot_Reset(t *testing.T) {
 
 	snap.Reset()
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value := snap.Lookup("key", func() *snapshotValue {
 			total.Add(1)
 			return &snapshotValue{value: "new_value"}
@@ -96,7 +96,7 @@ func TestSnapshotWithErr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				value, err := snap.Lookup(tt.name, tt.fn)
 				assert.Equal(t, tt.wantErr, err)
 				assert.Equal(t, tt.wantValue, value)
@@ -113,7 +113,7 @@ func TestSnapshotWithErr_Reset(t *testing.T) {
 		total atomic.Int32
 	)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
 			total.Add(1)
 			return &snapshotValue{value: "value"}, nil
@@ -126,7 +126,7 @@ func TestSnapshotWithErr_Reset(t *testing.T) {
 
 	snap.Reset()
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
 			total.Add(1)
 			return &snapshotValue{value: "new_value"}, nil
@@ -176,7 +176,7 @@ func TestSnapshotWithExpireAndErr_Reset(t *testing.T) {
 		total atomic.Int32
 	)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
 			total.Add(1)
 			return &snapshotValue{value: "value"}, nil
@@ -189,7 +189,7 @@ func TestSnapshotWithExpireAndErr_Reset(t *testing.T) {
 
 	snap.Reset()
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		value, err := snap.Lookup("key", func() (*snapshotValue, error) {
 			total.Add(1)
 			return &snapshotValue{value: "new_value"}, nil

--- a/cloudevents/protocol/amqp091/message.go
+++ b/cloudevents/protocol/amqp091/message.go
@@ -52,8 +52,8 @@ func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) 
 	}
 
 	for k, v := range m.delivery.Headers {
-		if strings.HasPrefix(k, prefix) {
-			attribute := m.version.Attribute(strings.TrimPrefix(k, prefix))
+		if after, ok := strings.CutPrefix(k, prefix); ok {
+			attribute := m.version.Attribute(after)
 			if attribute != nil {
 				if err := encoder.SetAttribute(attribute, v); err != nil {
 					return err

--- a/eino/components/embedding/cached/generator_test.go
+++ b/eino/components/embedding/cached/generator_test.go
@@ -79,7 +79,7 @@ func TestGenerator_HashGenerator_Concurrent(t *testing.T) {
 	results := make(chan string, 100)
 
 	// Start multiple goroutines to test concurrent generation
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		go func(i int) {
 			key := generator.Generate(ctx, fmt.Sprintf("%d", i), GeneratorOptions{})
 			results <- key
@@ -88,7 +88,7 @@ func TestGenerator_HashGenerator_Concurrent(t *testing.T) {
 
 	// Collect results and ensure uniqueness
 	keys := make(map[string]struct{})
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		key := <-results
 		_, exists := keys[key]
 		assert.False(t, exists, "Duplicate key found: %s", key)

--- a/ent/multidriver/policy_test.go
+++ b/ent/multidriver/policy_test.go
@@ -22,7 +22,7 @@ func TestPolicy_RoundRobinPolicy(t *testing.T) {
 	p2 := StrictRoundRobinPolicy()
 	drivers := []dialect.Driver{driver1, driver2, driver3}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		assert.Same(t, drivers[(i+1)%len(drivers)], p1.Resolve(drivers))
 		assert.Same(t, drivers[(i+1)%len(drivers)], p2.Resolve(drivers))
 	}
@@ -32,7 +32,7 @@ func TestPolicy_RandomPolicy(t *testing.T) {
 	p := RandomPolicy()
 	drivers := []dialect.Driver{driver1, driver2, driver3}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		assert.Contains(t, drivers, p.Resolve(drivers))
 	}
 }

--- a/env/env.go
+++ b/env/env.go
@@ -1,5 +1,7 @@
 package env
 
+import "slices"
+
 type Env string
 
 var (
@@ -14,13 +16,7 @@ func (e Env) String() string {
 }
 
 func (e Env) Is(envs ...Env) bool {
-	for _, env := range envs {
-		if e == env {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(envs, e)
 }
 
 var currentEnv = Prod

--- a/event/dispatcher_test.go
+++ b/event/dispatcher_test.go
@@ -179,7 +179,7 @@ func TestDispatcher(t *testing.T) {
 		parallel := 3
 		d := NewDispatcher(WithoutError(), WithParallel(parallel))
 		startedCount := runtime.NumGoroutine()
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			d.RegisterListeners(
 				AdaptListenerFunc(func(_ context.Context, _ *UserEvent) error {
 					<-time.After(200 * time.Millisecond)

--- a/locker/redis/locker_test.go
+++ b/locker/redis/locker_test.go
@@ -35,7 +35,7 @@ func TestLocker_Try(t *testing.T) {
 	ch := make(chan struct{}, 2)
 	wg := sync.WaitGroup{}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -67,7 +67,7 @@ func TestLocker_Until(t *testing.T) {
 	wg := sync.WaitGroup{}
 	start := time.Now()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -94,7 +94,7 @@ func TestLocker_Until_Timeout(t *testing.T) {
 	ch := make(chan struct{}, 2)
 	wg := sync.WaitGroup{}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -173,7 +173,7 @@ func TestLocker_Multi(t *testing.T) {
 	wg := sync.WaitGroup{}
 	ii := int64(0)
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -2,6 +2,7 @@ package slices
 
 import (
 	"math/rand"
+	"slices"
 
 	"github.com/go-fries/fries/constraints/v3"
 )
@@ -187,12 +188,7 @@ func IsNotEmpty[S ~[]E, E any](s S) bool {
 //	Contains([]int{1, 2, 3}, 2) // true
 //	Contains([]string{"a", "b", "c"}, "d") // false
 func Contains[S ~[]E, E comparable](s S, e E) bool {
-	for _, item := range s {
-		if item == e {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, e)
 }
 
 // IndexOf returns the index of the first occurrence of the given item in a given slice, or -1 if the item is not found.
@@ -382,10 +378,7 @@ func PartitionN[S ~[]E, E any](s S, fn func(E, int) bool) (yes, no S) {
 func Chunk[S ~[]E, E any](s S, size int) (result []S) {
 	length := len(s)
 	for i := 0; i < length; i += size {
-		end := i + size
-		if end > length {
-			end = length
-		}
+		end := min(i+size, length)
 		result = append(result, s[i:end])
 	}
 	return result

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -47,13 +48,7 @@ func Is(pattern, value string) bool {
 //
 //	InSlice([]string{"1", "2"}, "1") // true
 func InSlice(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(slice, s)
 }
 
 // MD5 returns the md5 hash of a string.
@@ -165,11 +160,11 @@ func After(subject, search string) string {
 	if search == "" {
 		return subject
 	}
-	index := strings.Index(subject, search)
-	if index == -1 {
+	_, after, ok := strings.Cut(subject, search)
+	if !ok {
 		return subject
 	}
-	return subject[index+len(search):]
+	return after
 }
 
 // Before Get the portion of a string before the first occurrence of a given value.
@@ -183,11 +178,11 @@ func Before(subject, search string) string {
 	if search == "" {
 		return subject
 	}
-	index := strings.Index(subject, search)
-	if index == -1 {
+	before, _, ok := strings.Cut(subject, search)
+	if !ok {
 		return subject
 	}
-	return subject[:index]
+	return before
 }
 
 // SubstrCount Returns the number of substring occurrences.
@@ -203,10 +198,7 @@ func SubstrCount(haystack, needle string, offset int, lengths ...int) int {
 
 	var end int
 	if len(lengths) > 0 {
-		end = offset + lengths[0]
-		if end > len(haystack) {
-			end = len(haystack)
-		}
+		end = min(offset+lengths[0], len(haystack))
 	} else {
 		end = len(haystack)
 	}

--- a/support/collection/collection.go
+++ b/support/collection/collection.go
@@ -1,6 +1,7 @@
 package collection
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/davecgh/go-spew/spew"
@@ -97,12 +98,7 @@ func (c *Collection[T]) Index(fn func(T, int) bool) (int, bool) {
 }
 
 func (c *Collection[T]) Contains(item T) bool {
-	for _, i := range c.items {
-		if i == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.items, item)
 }
 
 func (c *Collection[T]) Has(item T) bool {

--- a/support/helpers.go
+++ b/support/helpers.go
@@ -22,7 +22,7 @@ func Retry(fn func() error, attempts int, sleeps ...time.Duration) (err error) {
 		sleep = sleeps[0]
 	}
 
-	for i := 0; i < attempts; i++ {
+	for range attempts {
 		if err = fn(); err == nil {
 			return nil
 		}
@@ -98,7 +98,7 @@ func Timeout(fn func() error, timeout time.Duration) error {
 //	Repeat(func() error { fmt.Println("hello"); return nil }, 3) => prints hello 3 times and returns nil
 //	Repeat(func() error { return fmt.Errorf("error") }, 3) => returns error
 func Repeat(fn func() error, times int) error {
-	for i := 0; i < times; i++ {
+	for range times {
 		if err := fn(); err != nil {
 			return err
 		}

--- a/support/maps/maps.go
+++ b/support/maps/maps.go
@@ -2,6 +2,7 @@ package maps
 
 import (
 	"fmt"
+	"maps"
 )
 
 type M map[string]any
@@ -15,17 +16,13 @@ func (m M) All() map[string]any {
 }
 
 func (m M) Merge(n M) M {
-	for k, v := range n {
-		m[k] = v
-	}
+	maps.Copy(m, n)
 	return m
 }
 
 func (m M) Clone() M {
 	n := make(M, len(m))
-	for k, v := range m {
-		n[k] = v
-	}
+	maps.Copy(n, m)
 	return n
 }
 

--- a/support/values_test.go
+++ b/support/values_test.go
@@ -435,7 +435,7 @@ func TestIsType(t *testing.T) {
 	assert.False(t, IsType[*foo](nil))
 
 	assert.True(t, IsType[testInterface](testStruct{}))
-	assert.True(t, IsType[interface{}](testStruct{})) //nolint:revive
+	assert.True(t, IsType[any](testStruct{})) //nolint:revive
 	assert.True(t, IsType[any](testStruct{}))
 
 	assert.True(t, IsType[error](errors.New("foo")))

--- a/x/pagination/paginator.go
+++ b/x/pagination/paginator.go
@@ -57,10 +57,7 @@ func (p *Paginator) setPrePage() {
 }
 
 func (p *Paginator) setLastPage() {
-	p.lastPage = (p.total + p.prePage - 1) / p.prePage
-	if p.lastPage < 1 {
-		p.lastPage = 1
-	}
+	p.lastPage = max((p.total+p.prePage-1)/p.prePage, 1)
 }
 
 func (p *Paginator) setPage() {


### PR DESCRIPTION
- Replace manual loops with range-based loops for better readability
- Use standard library slices.Contains to simplify Contains methods
- Import and use new Go 1.21 helpers like slices and maps for clean code
- Refactor string manipulation to use strings.Cut instead of Index + slicing
- Update .golangci.yml to include modernize linter with specific disables
- Add lint-fix Makefile target to automate lint fixing
- Simplify pagination lastPage calculation using max helper
- Fix type assertion test to use any instead of interface{} keyword
- Remove redundant manual map copying by using maps.Copy utility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated lint-fixing workflow for development processes.

* **Chores**
  * Modernized code patterns to align with current Go standards.
  * Enhanced linting configuration and tooling.
  * Simplified internal utility functions using standard library helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->