### PR TITLE
chore(go): support go 1.25 and 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.24.x, 1.25.x ]
+        go-version: [ 1.25.x, 1.26.x ]
         platform: [ ubuntu-latest ]
         mysql-version: [ 'mysql:latest', 'mysql:5.7' ]
     runs-on: ${{ matrix.platform }}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@
 
 **Fries** (formerly `go-kratos-ecosystem/components`) is a modular collection of Go libraries and components designed to build robust applications. It follows a toolkit approach where developers can pick and choose specific packages (like `event`, `cache`, `filesystem`) or use the `foundation` package to structure an entire application using a Service Provider pattern.
 
-*   **Language:** Go (>= 1.24.0)
+*   **Language:** Go (>= 1.25.0)
 *   **Architecture:** Modular, Component-based, Service Provider (DI) pattern.
 *   **Key Pattern:** The `foundation.Kernel` manages application lifecycle via `Bootstrap` and `Terminate` methods defined in `Provider` interfaces.
 
@@ -26,7 +26,7 @@ This project uses a `Makefile` to manage the build, test, and lint workflows acr
 
 ### Prerequisites
 
-*   Go >= 1.24.0
+*   Go >= 1.25.0
 *   `make`
 
 ### Common Commands

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ check-clean-work-tree:
 	fi
 
 # Upgrade Go version in all go.mod files to the version specified in the GO_VERSION env var
-# Example: make upgrade-go-version GO_VERSION=1.24.0
+# Example: make upgrade-go-version GO_VERSION=1.25.0
 .PHONY: upgrade-go-version
 upgrade-go-version: $(ALL_GO_MOD_DIRS:%=upgrade-go-version/%)
 upgrade-go-version/%: DIR=$*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Fries Components
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.24.0-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.25.0-blue)
 [![Package Version](https://badgen.net/github/release/go-fries/fries/stable)](https://github.com/go-fries/fries/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/go-fries/fries/v3)](https://pkg.go.dev/github.com/go-fries/fries/v3)
 [![codecov](https://codecov.io/gh/go-fries/fries/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/go-fries/fries)

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cache/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/locker/v3 => ../locker
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cache/redis/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/cache/v3 => ../

--- a/cache/redis/store_test.go
+++ b/cache/redis/store_test.go
@@ -144,9 +144,7 @@ func TestRedis_Lock(t *testing.T) {
 	var s int64
 
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := r.Lock("test", 5*time.Second).Try(t.Context(), func() {
 				time.Sleep(time.Second)
 			})
@@ -155,7 +153,7 @@ func TestRedis_Lock(t *testing.T) {
 			} else {
 				atomic.AddInt64(&s, 1)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	assert.True(t, s > 0)

--- a/chi/go.mod
+++ b/chi/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/chi/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/cloudevents/eventdispatcher/go.mod
+++ b/cloudevents/eventdispatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cloudevents/eventdispatcher/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2

--- a/cloudevents/protocol/amqp091/go.mod
+++ b/cloudevents/protocol/amqp091/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cloudevents/protocol/amqp091/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2

--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/codec/v3
 
-go 1.24.0
+go 1.25.0

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/json/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/msgpack/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/proto/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/sonic/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/xml/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/yaml/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/codec/v3 => ../
 

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/config/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/constraints/go.mod
+++ b/constraints/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/constraints/v3
 
-go 1.24.0
+go 1.25.0

--- a/contract/go.mod
+++ b/contract/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/contract/v3
 
-go 1.24.0
+go 1.25.0

--- a/coroutines/go.mod
+++ b/coroutines/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/coroutines/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/constraints/v3 => ./../constraints

--- a/crontab/example/go.mod
+++ b/crontab/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/crontab/example/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/crontab/v3 => ../
 

--- a/crontab/go.mod
+++ b/crontab/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/crontab/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/flc1125/go-cron/v4 v4.7.2

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/cacher/gorm/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/eino/components/embedding/cached/v3 => ../../
 

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/codec/sonic/v3 => ./../../../../../../codec/sonic

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/example/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/codec/sonic/v3 => ../../../../../codec/sonic

--- a/eino/components/embedding/cached/go.mod
+++ b/eino/components/embedding/cached/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cloudwego/eino v0.7.34

--- a/encrypter/go.mod
+++ b/encrypter/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/encrypter/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/ent/go.mod
+++ b/ent/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ent/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.9.2

--- a/ent/multidriver/go.mod
+++ b/ent/multidriver/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ent/multidriver/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	entgo.io/ent v0.14.5

--- a/env/go.mod
+++ b/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/env/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/errors/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.9.2

--- a/event/example/go.mod
+++ b/event/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/example/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/event/middleware/recovery/v3 => ../middleware/recovery/

--- a/event/go.mod
+++ b/event/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/middleware/recovery/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/event/v3 => ../../
 

--- a/eventbus/go.mod
+++ b/eventbus/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eventbus/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/examples/cache/go.mod
+++ b/examples/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/cache/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/cache/redis/v3 => ../../cache/redis/

--- a/examples/cloudevents/amqp091/go.mod
+++ b/examples/cloudevents/amqp091/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/cloudevents/amqp091/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/cloudevents/protocol/amqp091/v3 => ../../../cloudevents/protocol/amqp091/
 

--- a/examples/cloudevents/eventdispatcher/go.mod
+++ b/examples/cloudevents/eventdispatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/cloudevents/eventdispatcher/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/cloudevents/eventdispatcher/v3 => ../../../cloudevents/eventdispatcher/
 

--- a/examples/mysql/canal/go.mod
+++ b/examples/mysql/canal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/mysql/canal/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v3 => ../../../codec/json

--- a/examples/otel/otlp/go.mod
+++ b/examples/otel/otlp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/examples/otel/otlp/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/foundation/v3 => ../../../foundation

--- a/filesystem/go.mod
+++ b/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/local/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/filesystem/v3 => ../
 

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/oss/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/filesystem/v3 => ../
 

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/s3/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/filesystem/v3 => ../
 

--- a/foundation/go.mod
+++ b/foundation/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/foundation/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/gin/go.mod
+++ b/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gin/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gin-gonic/gin v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/gomod_test.go
+++ b/gomod_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var expectedVersion = "go 1.24.0"
+var expectedVersion = "go 1.25.0"
 
 func TestAllGoModVersions(t *testing.T) {
 	var modFiles []string

--- a/gorm/go.mod
+++ b/gorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/gorm/scope/go.mod
+++ b/gorm/scope/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/scope/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/hashing/go.mod
+++ b/hashing/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/hashing/v3
 
-go 1.24.0
+go 1.25.0

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hashing/md5/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/hashing/v3 => ../
 

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/http/server/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.9.2

--- a/hyperf/jet/go.mod
+++ b/hyperf/jet/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/hyperf/jet/middleware/logging/go.mod
+++ b/hyperf/jet/middleware/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/logging/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/recovery/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/retry/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v3 => ../timeout

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/timeout/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/hyperf/jet/middleware/tracing/go.mod
+++ b/hyperf/jet/middleware/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/tracing/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/hyperf/jet/v3 => ../../
 

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/internal/tools/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/bufbuild/buf v1.65.0

--- a/jsonrpc/go.mod
+++ b/jsonrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/jsonrpc/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v3 => ../codec/json

--- a/kratos/log/otel/go.mod
+++ b/kratos/log/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/log/otel/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/v3 => ../../../
 

--- a/kratos/log/stack/go.mod
+++ b/kratos/log/stack/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/log/stack/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.9.2

--- a/kratos/log/syslog/go.mod
+++ b/kratos/log/syslog/go.mod
@@ -1,5 +1,5 @@
 module github.com/go-fries/fries/kratos/log/syslog/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/go-kratos/kratos/v2 v2.9.2

--- a/kratos/middleware/cors/go.mod
+++ b/kratos/middleware/cors/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/cors/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/go-kratos/kratos/v2 v2.9.2
 

--- a/kratos/middleware/protovalidate/go.mod
+++ b/kratos/middleware/protovalidate/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/protovalidate/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1

--- a/kratos/middleware/slowlog/go.mod
+++ b/kratos/middleware/slowlog/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/slowlog/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.9.2

--- a/kratos/middleware/tracing/go.mod
+++ b/kratos/middleware/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/tracing/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v2 v2.9.2

--- a/locker/go.mod
+++ b/locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/locker/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/locker/redis/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/locker/v3 => ../
 

--- a/locker/redis/locker_test.go
+++ b/locker/redis/locker_test.go
@@ -36,14 +36,12 @@ func TestLocker_Try(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			errs <- l.Try(ctx, func() {
 				ch <- struct{}{}
 				time.Sleep(time.Millisecond * 10)
 			})
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -68,14 +66,12 @@ func TestLocker_Until(t *testing.T) {
 	start := time.Now()
 
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			assert.NoError(t, l.Until(ctx, time.Second, func() {
 				ch <- struct{}{}
 				time.Sleep(time.Millisecond * 10)
 			}))
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -95,14 +91,12 @@ func TestLocker_Until_Timeout(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			errs <- l.Until(ctx, time.Millisecond*100, func() {
 				ch <- struct{}{}
 				time.Sleep(time.Millisecond * 200)
 			})
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -174,9 +168,7 @@ func TestLocker_Multi(t *testing.T) {
 	ii := int64(0)
 
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if atomic.AddInt64(&ii, 1) == 2 {
 				time.Sleep(time.Millisecond * 105)
 			}
@@ -184,7 +176,7 @@ func TestLocker_Multi(t *testing.T) {
 				ch <- struct{}{}
 				time.Sleep(time.Millisecond * 200)
 			}))
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/mysql/canal/go.mod
+++ b/mysql/canal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-mysql-org/go-mysql v1.13.0

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/positioner/redis/v3
 
-go 1.24.0
+go 1.25.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v3 => ./../../../../codec/json

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/server/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/mysql/canal/v3 => ../
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/otel/otlp/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/foundation/v3 => ../../foundation
 

--- a/recovery/go.mod
+++ b/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/recovery/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/redis/go.mod
+++ b/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/redis/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/redis/go-redis/v9 v9.17.3

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "gomodTidy"
   ],
   "constraints": {
-    "go": "1.24.0"
+    "go": "1.25.0"
   },
   "packageRules": [
     {

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/signal/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/contract/v3 => ../contract
 

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/slices/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/constraints/v3 => ../constraints
 

--- a/strings/go.mod
+++ b/strings/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/strings/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/support/coordinator/coordinator_test.go
+++ b/support/coordinator/coordinator_test.go
@@ -10,11 +10,7 @@ func TestCoordinator(t *testing.T) {
 	c := NewCoordinator()
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		timer := time.NewTimer(1 * time.Second)
 		defer timer.Stop()
 
@@ -27,7 +23,7 @@ func TestCoordinator(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	c.Close()
 	wg.Wait()
@@ -37,11 +33,7 @@ func TestCoordinator2(t *testing.T) {
 	c := NewCoordinator()
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		timer := time.NewTimer(1 * time.Second)
 		defer timer.Stop()
 
@@ -54,7 +46,7 @@ func TestCoordinator2(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	time.Sleep(2 * time.Second)
 

--- a/support/coordinator/manager_test.go
+++ b/support/coordinator/manager_test.go
@@ -47,15 +47,12 @@ func TestManager(t *testing.T) {
 	assert.NotSame(t, c1, c3)
 
 	// Close foo coordinators
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		if <-c3.Done(); true {
 			ch <- struct{}{}
 			return
 		}
-	}()
+	})
 	assert.Equal(t, 2, len(ch))
 	Close("foo")
 	wg.Wait()

--- a/support/go.mod
+++ b/support/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/support/v3
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/go-fries/fries/errors/v3 => ../errors
 

--- a/timezone/go.mod
+++ b/timezone/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/timezone/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/udp/go.mod
+++ b/udp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/udp/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/go-kratos/kratos/v2 v2.9.2
 

--- a/x/container/go.mod
+++ b/x/container/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/container/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/x/pagination/go.mod
+++ b/x/pagination/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/pagination/v3
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/x/prints/go.mod
+++ b/x/prints/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/prints/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped project-wide minimum Go toolchain requirement from 1.24 to 1.25.

* **Tests**
  * CI test matrix updated to run against Go 1.25.x and 1.26.x.

* **Documentation**
  * Updated docs, examples and README badges to reflect the new Go version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->