### PR TITLE
Remove concurrency from lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
Removed concurrency settings from the lint workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to allow concurrent workflow runs to proceed without automatic interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->