### PR TITLE
Go fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,14 @@ go-mod-tidy/%:
 		&& cd $(DIR) \
 		&& $(GO) mod tidy -compat=1.22.0
 
+.PHONY: go-fix
+go-fix: $(ROOT_GO_MOD_DIRS:%=go-fix/%)
+go-fix/%: DIR=$*
+go-fix/%:
+	@echo 'go fix $(DIR)' \
+		&& cd $(DIR) \
+		&& $(GO) fix ./...
+
 .PHONY: lint
 lint: go-mod-tidy golangci-lint
 lint/%: DIR=$*

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -66,7 +66,7 @@ func (t *utilMockStore) Put(_ context.Context, key string, value any, ttl time.D
 func setPointerValue(dest any, value any) error {
 	v := reflect.ValueOf(dest)
 
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		return fmt.Errorf("dest must be a pointer type")
 	}
 	elem := v.Elem()

--- a/kratos/log/otel/convert.go
+++ b/kratos/log/otel/convert.go
@@ -96,7 +96,7 @@ func convertValue(v any) log.Value { // nolint:gocyclo
 			})
 		}
 		return log.MapValue(kvs...)
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if val.IsNil() {
 			return log.Value{}
 		}


### PR DESCRIPTION
```shell
make go-fix
```

output:

```
go fix .
go fix ./cache
go fix ./cache/redis
go fix ./chi
go fix ./cloudevents/eventdispatcher
go fix ./cloudevents/protocol/amqp091
go fix ./codec
go fix ./codec/json
go fix ./codec/msgpack
go fix ./codec/proto
go fix ./codec/sonic
go fix ./codec/xml
go fix ./codec/yaml
go fix ./config
go fix ./constraints
go fix ./contract
go fix ./coroutines
go fix ./crontab
go fix ./crontab/example
go fix ./eino/components/embedding/cached
go fix ./eino/components/embedding/cached/cacher/gorm
go fix ./eino/components/embedding/cached/cacher/redis
go fix ./eino/components/embedding/cached/example
go fix ./encrypter
go fix ./ent
go fix ./ent/multidriver
go fix ./env
go fix ./errors
go fix ./event
go fix ./event/example
go fix ./event/middleware/recovery
go fix ./eventbus
go fix ./examples/cache
go fix ./examples/cloudevents/amqp091
go fix ./examples/cloudevents/eventdispatcher
go fix ./examples/mysql/canal
go fix ./examples/otel/otlp
go fix ./filesystem
go fix ./filesystem/local
go fix ./filesystem/oss
go fix ./filesystem/s3
go fix ./foundation
go fix ./gin
go fix ./gorm
go fix ./gorm/scope
go fix ./hashing
go fix ./hashing/md5
go fix ./http/server
go fix ./hyperf/jet
go fix ./hyperf/jet/middleware/logging
go fix ./hyperf/jet/middleware/recovery
go fix ./hyperf/jet/middleware/retry
go fix ./hyperf/jet/middleware/timeout
go fix ./hyperf/jet/middleware/tracing
go fix ./jsonrpc
go fix ./kratos/log/otel
go fix ./kratos/log/stack
go fix ./kratos/log/syslog
go fix ./kratos/middleware/cors
go fix ./kratos/middleware/protovalidate
go fix ./kratos/middleware/slowlog
go fix ./kratos/middleware/tracing
go fix ./locker
go fix ./locker/redis
go fix ./mysql/canal
go fix ./mysql/canal/positioner/redis
go fix ./mysql/canal/server
go fix ./otel/otlp
go fix ./recovery
go fix ./redis
go fix ./signal
go fix ./slices
go fix ./strings
go fix ./support
go fix ./timezone
go fix ./udp
go fix ./x/container
go fix ./x/pagination
go fix ./x/prints
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced new Makefile `go-fix` target enabling automated code maintenance across module directories

* **Bug Fixes**
  * Updated pointer type validation in utility and logging conversion functions for proper type handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->