### PR TITLE
docs: update repository guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,28 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This is a multi-module Go repository. The root module lives at `./go.mod`, and many top-level component folders contain their own `go.mod` files. Common areas include:
-- Component packages such as `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`.
-- `examples/` for runnable samples and integration demos.
-- `internal/tools/` for pinned developer tooling used by the Makefile.
-- `contract/` plus `buf.yaml`/`buf.gen.yaml` for protobuf contracts and generation.
+This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`. Runnable samples and integration demos are under `examples/`. Protobuf contracts live in `contract/`, with root Buf configuration in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
 
 ## Build, Test, and Development Commands
-Run these from the repository root:
-- `make build` to compile all modules (`go build ./...` per module).
-- `make test` for the default test suite across modules.
-- `make test-short` for faster, `-short`-mode tests.
-- `make test-race` to enable the race detector.
-- `make test-coverage` to generate merged coverage (`coverage.txt`).
-- `make lint` to run `go mod tidy` and `golangci-lint`.
-- `make buf-lint` / `make buf-generate` for protobuf linting and codegen.
+Run commands from the repository root unless working in a specific module.
+
+- `make tools` builds pinned local tools into `.tools/`.
+- `make build` runs `go build ./...` for each repository module.
+- `make test` runs the default test suite across modules.
+- `make test-short` runs tests with `-short`.
+- `make test-race` runs tests with the race detector.
+- `make test-coverage` writes merged coverage to `coverage.txt`.
+- `make lint` runs `go mod tidy` for all modules and `golangci-lint`.
+- `make lint-fix` applies supported lint fixes.
+- `make buf-lint`, `make buf-build`, `make buf-validate`, and `make buf-generate` validate or regenerate protobuf assets.
+
+For focused work, use module-specific Make targets instead of manually changing directories. For example, `make test/cache` tests `cache/`, `make lint/cache` runs tidy plus lint, and `make lint-fix/cache` applies supported fixes.
 
 ## Coding Style & Naming Conventions
-- Formatting follows Go conventions (tabs for indentation); `golangci-lint` enables `gofumpt` and `goimports`.
-- Package names are short, lowercase; exported identifiers use `CamelCase`.
-- Tests use `*_test.go` files and `TestXxx`, `BenchmarkXxx`, `FuzzXxx` naming.
+Follow standard Go formatting with tabs and idiomatic package layout. Package names should be short and lowercase; exported identifiers use `CamelCase`. The linter configuration enables formatting checks including `gofumpt` and `goimports`, so run `make lint` before submitting. Keep module boundaries clear: update the nearest `go.mod` and avoid introducing unnecessary dependencies across components.
 
 ## Testing Guidelines
-- Use `go test` via `make test` or per-module (e.g., `cd redis && go test ./...`).
-- Race-sensitive changes should run `make test-race`.
-- Long-running tests should honor `-short`.
-- `github.com/stretchr/testify` is available for assertions when helpful.
+Place tests beside the package under test using `*_test.go`. Use Go test naming conventions: `TestXxx`, `BenchmarkXxx`, and `FuzzXxx`. `github.com/stretchr/testify` is available when assertions improve readability. Long-running or integration-style tests should honor `testing.Short()`. Race-sensitive changes should be verified with `make test-race`.
 
 ## Commit & Pull Request Guidelines
-- Recent history follows Conventional Commits, e.g. `fix(deps): update ...` or `chore(deps): ...` (often with PR numbers).
-- Keep commit subjects imperative and scoped when relevant.
-- PRs should include: a concise summary, linked issue (if any), and test evidence (commands run).
-- Ensure `make lint` and `make test` are clean before opening a PR.
+Recent history follows Conventional Commits, often with scopes, such as `fix(deps): update module ...` and `chore(deps): update ...`. Keep subjects imperative and scoped when useful. Pull requests should include a concise summary, linked issue when applicable, and test evidence listing commands run. For contract or generated-code changes, mention the Buf command used and include generated files in the same PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`. Runnable samples and integration demos are under `examples/`. Protobuf contracts live in `contract/`, with root Buf configuration in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
+This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `foundation/`, `event/`, `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`. Runnable samples and integration demos are under `examples/`. Protobuf contracts live in `contract/`, with root Buf configuration in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
 
 ## Build, Test, and Development Commands
 Run commands from the repository root unless working in a specific module.


### PR DESCRIPTION
## Summary
Update the repository contributor guide with clearer guidance for the multi-module Go layout and Makefile-based workflows.

## Changes
- Clarify the root module, component directories, examples, contracts, and pinned tools
- Document key build, test, lint, coverage, and Buf commands
- Add module-specific Make target examples such as `make test/cache`, `make lint/cache`, and `make lint-fix/cache`

## Motivation
- Keep contributor instructions aligned with this repository's actual Makefile and module structure

## Testing
- Not run; documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation of Go module layout and import path structure
  * Expanded development command guidance with new targets and Buf command references
  * Clarified coding and testing conventions with explicit formatting and module boundary expectations
  * Updated PR and commit contribution guidelines requiring Conventional Commits format and test evidence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->