### PR TITLE
fix(redis): clear ttl when storing forever

### DIFF
--- a/cache/redis/store.go
+++ b/cache/redis/store.go
@@ -111,7 +111,7 @@ func (s *Store) Forever(ctx context.Context, key string, value any) (bool, error
 		return false, err
 	}
 
-	r := s.redis.Set(ctx, s.prefix+key, valued, redis.KeepTTL)
+	r := s.redis.Set(ctx, s.prefix+key, valued, 0)
 	if r.Err() != nil {
 		return false, r.Err()
 	}

--- a/cache/redis/store_test.go
+++ b/cache/redis/store_test.go
@@ -93,7 +93,7 @@ func TestRedis_IncrAndDecr(t *testing.T) {
 
 func TestRedis_Forever(t *testing.T) {
 	client := createRedis(t)
-	store := New(createRedis(t), Prefix("cache:redis"))
+	store := New(client, Prefix("cache:redis"))
 
 	ok1, err := store.Forever(ctx, "test:forever", "test")
 	assert.Nil(t, err)
@@ -101,6 +101,22 @@ func TestRedis_Forever(t *testing.T) {
 
 	// ttl
 	ttl, err := client.TTL(ctx, "cache:redis:test:forever").Result()
+	assert.Nil(t, err)
+	assert.Equal(t, time.Duration(redis.KeepTTL), ttl)
+
+	ok2, err := store.Put(ctx, "test:forever:ttl", "test", time.Minute)
+	assert.Nil(t, err)
+	assert.True(t, ok2)
+
+	ttl, err = client.TTL(ctx, "cache:redis:test:forever:ttl").Result()
+	assert.Nil(t, err)
+	assert.True(t, ttl > 0)
+
+	ok3, err := store.Forever(ctx, "test:forever:ttl", "test")
+	assert.Nil(t, err)
+	assert.True(t, ok3)
+
+	ttl, err = client.TTL(ctx, "cache:redis:test:forever:ttl").Result()
 	assert.Nil(t, err)
 	assert.Equal(t, time.Duration(redis.KeepTTL), ttl)
 }

--- a/cache/redis/store_test.go
+++ b/cache/redis/store_test.go
@@ -17,6 +17,8 @@ import (
 
 var ctx = context.Background()
 
+const noExpiration = -1 * time.Nanosecond
+
 func createRedis(t *testing.T) redis.UniversalClient {
 	client := redis.NewClient(&redis.Options{
 		Addr: ":6379",
@@ -102,7 +104,7 @@ func TestRedis_Forever(t *testing.T) {
 	// ttl
 	ttl, err := client.TTL(ctx, "cache:redis:test:forever").Result()
 	assert.Nil(t, err)
-	assert.Equal(t, time.Duration(redis.KeepTTL), ttl)
+	assert.Equal(t, noExpiration, ttl)
 
 	ok2, err := store.Put(ctx, "test:forever:ttl", "test", time.Minute)
 	assert.Nil(t, err)
@@ -112,13 +114,17 @@ func TestRedis_Forever(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, ttl > 0)
 
-	ok3, err := store.Forever(ctx, "test:forever:ttl", "test")
+	ok3, err := store.Forever(ctx, "test:forever:ttl", "forever-value")
 	assert.Nil(t, err)
 	assert.True(t, ok3)
 
+	var v string
+	assert.Nil(t, store.Get(ctx, "test:forever:ttl", &v))
+	assert.Equal(t, "forever-value", v)
+
 	ttl, err = client.TTL(ctx, "cache:redis:test:forever:ttl").Result()
 	assert.Nil(t, err)
-	assert.Equal(t, time.Duration(redis.KeepTTL), ttl)
+	assert.Equal(t, noExpiration, ttl)
 }
 
 func TestRedis_Flush(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix Redis cache `Forever` so it removes any existing expiration instead of preserving the old TTL.

## Changes
- Use Redis `SET` with no expiration for `Store.Forever`
- Reuse the same Redis client in the `Forever` test so TTL assertions inspect the written key
- Add coverage for converting an expiring key into a permanent key

## Motivation
- `Forever` promises permanent storage until explicit removal, but `redis.KeepTTL` kept an existing expiration on previously expiring keys

## Testing
- `go test ./...` in `cache/redis`
- `go test ./...` in `cache`
- `go test -race ./...` in `cache`