### PR TITLE
docs(cache): clarify remember atomicity

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -1,6 +1,6 @@
 # Cache Component
 
-A flexible caching library for Go applications, providing a unified API for various storage backends (like Redis) with support for serialization.
+A flexible caching library for Go applications, providing a unified API for various storage backends (like Redis) with support for serialization, atomic counters, and locking primitives.
 
 ## Installation
 

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,6 +1,6 @@
 # Cache Component
 
-A flexible caching library for Go applications, providing a unified API for various storage backends (like Redis) with support for serialization and atomic operations.
+A flexible caching library for Go applications, providing a unified API for various storage backends (like Redis) with support for serialization.
 
 ## Installation
 
@@ -13,7 +13,7 @@ go get github.com/go-fries/fries/cache/v3
 *   **Unified Interface:** Consistent API for different cache stores.
 *   **Redis Support:** Built-in support for Redis via `go-redis`.
 *   **Automatic Serialization:** seamless handling of complex Go types using JSON (or other codecs).
-*   **Atomic `Remember`:** preventing cache stampedes by atomically fetching and setting values if missing.
+*   **Cache-aside `Remember`:** fetches cached values, or calls a callback and stores the result on cache miss.
 
 ## Usage
 

--- a/cache/utils.go
+++ b/cache/utils.go
@@ -13,9 +13,10 @@ func Get[T any](ctx context.Context, repository Repository, key string) (T, erro
 	return result, repository.Get(ctx, key, &result)
 }
 
-// Remember is a utility function that retrieves a value from the cache using the provided key.
-// If the value is not found, it calls the provided callback function to generate the value,
+// Remember retrieves a value from the cache using the provided key.
+// If the value is not found, it calls the callback, stores the result, and returns it.
 // If the value is found in the cache, it returns the cached value and a nil error.
+// Remember is not atomic; concurrent cache misses for the same key may call the callback more than once.
 func Remember[T any](ctx context.Context, repository Repository, key string, ttl time.Duration, callback func() (T, error)) (T, error) {
 	var result T
 	err := repository.Get(ctx, key, &result)


### PR DESCRIPTION
## Summary
Clarify that cache Remember follows a cache-aside flow and does not provide atomic stampede prevention.

## Changes
- Remove the README claim that the cache package supports atomic operations through Remember
- Document that concurrent cache misses for the same key may call the callback more than once

## Motivation
- The current implementation uses Get -> callback -> Put, so the previous atomic wording overstated the concurrency behavior

## Testing
- GOCACHE=/Users/flc/data/www/open-source/go-fries/fries/.tmp/go-cache GOTMPDIR=/Users/flc/data/www/open-source/go-fries/fries/.tmp/go-tmp go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified cache library wording to specify atomic counters and locking primitives support.
  * Rewrote cache usage docs to describe a cache-aside workflow and explicit cache-miss behavior (call callback, store result with TTL, return).
  * Added concurrency notes explaining cache-miss handling is not atomic and may allow concurrent callback executions.
  * Fixed Markdown formatting in the README (code block newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->