### PR TITLE
refactor(otlp): remove metric temporality selector

### DIFF
--- a/otel/otlp/transport.go
+++ b/otel/otlp/transport.go
@@ -11,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -19,17 +18,6 @@ type Transport interface {
 	GetTraceSpanExporter(ctx context.Context) (trace.SpanExporter, error)
 	GetMetricExporter(ctx context.Context) (metric.Exporter, error)
 	GetLogExporter(ctx context.Context) (log.Exporter, error)
-}
-
-func metricTemporalitySelector(kind metric.InstrumentKind) metricdata.Temporality {
-	switch kind {
-	case metric.InstrumentKindCounter,
-		metric.InstrumentKindObservableCounter,
-		metric.InstrumentKindHistogram:
-		return metricdata.DeltaTemporality
-	default:
-		return metricdata.CumulativeTemporality
-	}
 }
 
 type GRPCTransport struct {
@@ -88,7 +76,6 @@ func (t *GRPCTransport) GetMetricExporter(ctx context.Context) (metric.Exporter,
 	opts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(t.endpoint),
 		otlpmetricgrpc.WithCompressor("gzip"),
-		otlpmetricgrpc.WithTemporalitySelector(metricTemporalitySelector),
 	}
 
 	if t.insecure {
@@ -175,7 +162,6 @@ func (t *HTTPTransport) GetMetricExporter(ctx context.Context) (metric.Exporter,
 	opts := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithEndpoint(t.endpoint),
 		otlpmetrichttp.WithCompression(otlpmetrichttp.GzipCompression),
-		otlpmetrichttp.WithTemporalitySelector(metricTemporalitySelector),
 	}
 
 	if t.insecure {

--- a/otel/otlp/transport_test.go
+++ b/otel/otlp/transport_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestTransport(t *testing.T) {
@@ -103,41 +101,6 @@ func TestTransportOptions(t *testing.T) {
 
 		assert.Equal(t, headers, transport.headers)
 	})
-}
-
-func TestMetricTemporalitySelector(t *testing.T) {
-	tests := []struct {
-		name string
-		kind metric.InstrumentKind
-		want metricdata.Temporality
-	}{
-		{
-			name: "counter uses delta",
-			kind: metric.InstrumentKindCounter,
-			want: metricdata.DeltaTemporality,
-		},
-		{
-			name: "observable counter uses delta",
-			kind: metric.InstrumentKindObservableCounter,
-			want: metricdata.DeltaTemporality,
-		},
-		{
-			name: "histogram uses delta",
-			kind: metric.InstrumentKindHistogram,
-			want: metricdata.DeltaTemporality,
-		},
-		{
-			name: "up down counter uses cumulative",
-			kind: metric.InstrumentKindUpDownCounter,
-			want: metricdata.CumulativeTemporality,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, metricTemporalitySelector(tt.kind))
-		})
-	}
 }
 
 type transportTarget struct {


### PR DESCRIPTION
## Summary
Remove the custom OTLP metric temporality selector so gRPC and HTTP exporters use the upstream default behavior.

## Changes
- Remove `WithTemporalitySelector(...)` from the gRPC metric exporter options
- Remove `WithTemporalitySelector(...)` from the HTTP metric exporter options
- Delete the now-unused selector helper and its dedicated unit test

## Motivation
- Avoid overriding OpenTelemetry exporter temporality selection in the OTLP transport layer

## Testing
- `gofmt -w otel/otlp/transport.go otel/otlp/transport_test.go`
- `git diff --check`
- `GOCACHE=/private/tmp/go-build go test -run 'TestTransport' -count=1 -v`\n- `GOCACHE=/private/tmp/go-build go test ./...` fails in existing `client_test.go` shutdown lifecycle cases with `exit status 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified OpenTelemetry OTLP metric exporter configuration to rely on default temporality behavior.

* **Tests**
  * Removed associated unit tests validating custom temporality behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/go-fries/fries/pull/2356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->