### PR TITLE
fix(env): make current env concurrency-safe

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -1,6 +1,9 @@
 package env
 
-import "slices"
+import (
+	"slices"
+	"sync/atomic"
+)
 
 type Env string
 
@@ -19,18 +22,29 @@ func (e Env) Is(envs ...Env) bool {
 	return slices.Contains(envs, e)
 }
 
-var currentEnv = Prod
+var (
+	defaultCurrentEnv = Prod
+	currentEnv        atomic.Pointer[Env]
+)
+
+func init() {
+	currentEnv.Store(&defaultCurrentEnv)
+}
 
 func SetEnv(env Env) {
-	currentEnv = env
+	currentEnv.Store(&env)
 }
 
 func GetEnv() Env {
-	return currentEnv
+	if env := currentEnv.Load(); env != nil {
+		return *env
+	}
+
+	return Prod
 }
 
 func Is(envs ...Env) bool {
-	return currentEnv.Is(envs...)
+	return GetEnv().Is(envs...)
 }
 
 func IsDev() bool {
@@ -50,8 +64,9 @@ func IsStage() bool {
 }
 
 func IsUseString(envs ...string) bool {
+	envSnapshot := GetEnv()
 	for _, env := range envs {
-		if currentEnv == Env(env) {
+		if envSnapshot == Env(env) {
 			return true
 		}
 	}

--- a/env/env.go
+++ b/env/env.go
@@ -22,25 +22,18 @@ func (e Env) Is(envs ...Env) bool {
 	return slices.Contains(envs, e)
 }
 
-var (
-	defaultCurrentEnv = Prod
-	currentEnv        atomic.Pointer[Env]
-)
+var currentEnv atomic.Value
 
 func init() {
-	currentEnv.Store(&defaultCurrentEnv)
+	currentEnv.Store(Prod)
 }
 
 func SetEnv(env Env) {
-	currentEnv.Store(&env)
+	currentEnv.Store(env)
 }
 
 func GetEnv() Env {
-	if env := currentEnv.Load(); env != nil {
-		return *env
-	}
-
-	return Prod
+	return currentEnv.Load().(Env)
 }
 
 func Is(envs ...Env) bool {

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -61,21 +61,15 @@ func TestConcurrentSafe(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := range 64 {
-		wg.Add(1)
-		go func(offset int) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			for j := range 1000 {
-				SetEnv(envs[(offset+j)%len(envs)])
+				SetEnv(envs[(i+j)%len(envs)])
 			}
-		}(i)
+		})
 	}
 
 	for range 64 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			for range 1000 {
 				_ = GetEnv()
 				_ = Is(Dev, Prod, Debug, Stage, "online")
@@ -85,7 +79,7 @@ func TestConcurrentSafe(t *testing.T) {
 				_ = IsStage()
 				_ = IsUseString("dev", "prod", "debug", "stage", "online")
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,43 @@ func TestCustom(t *testing.T) {
 
 	assert.True(t, Is("online"))
 	assert.False(t, Is("dev"))
+}
+
+func TestConcurrentSafe(t *testing.T) {
+	t.Cleanup(func() {
+		SetEnv(Prod)
+	})
+
+	envs := []Env{Dev, Prod, Debug, Stage, "online"}
+
+	var wg sync.WaitGroup
+	for i := range 64 {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+
+			for j := range 1000 {
+				SetEnv(envs[(offset+j)%len(envs)])
+			}
+		}(i)
+	}
+
+	for range 64 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for range 1000 {
+				_ = GetEnv()
+				_ = Is(Dev, Prod, Debug, Stage, "online")
+				_ = IsDev()
+				_ = IsProd()
+				_ = IsDebug()
+				_ = IsStage()
+				_ = IsUseString("dev", "prod", "debug", "stage", "online")
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
Make the env package's process-wide current environment safe for concurrent readers and writers without changing the public API.

## Changes
- Store the current environment through an atomic pointer instead of a plain package variable
- Route helpers through GetEnv so reads use a consistent snapshot
- Add a race-focused concurrent read/write test

## Motivation
- Avoid data races when SetEnv is called while other goroutines read environment state

## Testing
- go test -race ./... (from env/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced environment management with improved concurrent access support and thread-safety mechanisms.

* **Tests**
  * Added comprehensive testing for concurrent environment state operations and access patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/go-fries/fries/pull/2366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->