### PR TITLE
fix(strings): anchor wildcard pattern matching

### DIFF
--- a/strings/strings.go
+++ b/strings/strings.go
@@ -32,9 +32,10 @@ func Is(pattern, value string) bool {
 		return true
 	}
 
-	pattern = strings.ReplaceAll(pattern, "*", ".*")
+	pattern = regexp.QuoteMeta(pattern)
+	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
 
-	match, err := regexp.Match(pattern, []byte(value))
+	match, err := regexp.MatchString("^"+pattern+"$", value)
 	if err != nil {
 		return false
 	}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -9,6 +9,7 @@ import (
 func TestIs(t *testing.T) {
 	assert.True(t, Is("abc", "abc"))
 	assert.False(t, Is("abcc", "abc"))
+	assert.False(t, Is("abc", "abcc"))
 	assert.True(t, Is("ab*", "abc"))
 	assert.True(t, Is("ab*", "ab"))
 	assert.True(t, Is("ab/*", "ab/cc"))
@@ -18,6 +19,8 @@ func TestIs(t *testing.T) {
 	assert.True(t, Is("ab/*", "ab/cc/dd"))
 	assert.True(t, Is("*dd/", "ab/cc/dd/"))
 	assert.False(t, Is("*dd/d", "dd/"))
+	assert.True(t, Is("v1.2.*", "v1.2.3"))
+	assert.False(t, Is("v1.2.*", "v1x2x3"))
 }
 
 func TestInSlice(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix strings.Is so wildcard patterns match the full value and treat non-wildcard characters as literals.

## Changes
- Escape pattern characters before converting * into a wildcard
- Anchor the generated pattern to require a full-string match
- Add tests for partial matches and literal dots in patterns

## Motivation
- strings.Is documents * as the wildcard, but the previous regexp conversion could match substrings and treat regexp metacharacters as pattern syntax

## Testing
- go test ./... in strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved wildcard pattern matching to properly handle special characters in patterns and ensure complete string value matching.
  * Enhanced support for version-like wildcard patterns (e.g., "v1.2.*").

* **Tests**
  * Added comprehensive test coverage for wildcard pattern matching edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->