### PR TITLE
fix(eventbus): return listener slice copy

### DIFF
--- a/eventbus/eventbus.go
+++ b/eventbus/eventbus.go
@@ -117,7 +117,9 @@ func (t *Event[T]) Listeners() []*Listener[T] {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	return append([]*Listener[T](nil), t.listeners...)
+	listeners := make([]*Listener[T], len(t.listeners))
+	copy(listeners, t.listeners)
+	return listeners
 }
 
 func (t *Event[T]) ListenersCount() int {

--- a/eventbus/eventbus.go
+++ b/eventbus/eventbus.go
@@ -117,7 +117,7 @@ func (t *Event[T]) Listeners() []*Listener[T] {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	return t.listeners
+	return append([]*Listener[T](nil), t.listeners...)
 }
 
 func (t *Event[T]) ListenersCount() int {

--- a/eventbus/eventbus_test.go
+++ b/eventbus/eventbus_test.go
@@ -58,6 +58,23 @@ func TestEventBus_Struct(t *testing.T) {
 	assert.ErrorIs(t, listener.Off(), ErrListenerNotFound)
 }
 
+func TestEventBus_ListenersReturnsCopy(t *testing.T) {
+	topic := NewEvent[int]()
+
+	first := topic.On(HandlerFunc[int](func(context.Context, int) error {
+		return nil
+	}))
+	second := topic.On(HandlerFunc[int](func(context.Context, int) error {
+		return nil
+	}))
+
+	listeners := topic.Listeners()
+	assert.Equal(t, []*Listener[int]{first, second}, listeners)
+
+	listeners[0] = nil
+	assert.Equal(t, []*Listener[int]{first, second}, topic.Listeners())
+}
+
 func TestEventBus_SkipErrors(t *testing.T) {
 	topic := NewEvent[int]()
 	ch := make(chan int, 1)

--- a/eventbus/eventbus_test.go
+++ b/eventbus/eventbus_test.go
@@ -61,6 +61,10 @@ func TestEventBus_Struct(t *testing.T) {
 func TestEventBus_ListenersReturnsCopy(t *testing.T) {
 	topic := NewEvent[int]()
 
+	listeners := topic.Listeners()
+	assert.NotNil(t, listeners)
+	assert.Empty(t, listeners)
+
 	first := topic.On(HandlerFunc[int](func(context.Context, int) error {
 		return nil
 	}))
@@ -68,11 +72,16 @@ func TestEventBus_ListenersReturnsCopy(t *testing.T) {
 		return nil
 	}))
 
-	listeners := topic.Listeners()
+	listeners = topic.Listeners()
 	assert.Equal(t, []*Listener[int]{first, second}, listeners)
 
 	listeners[0] = nil
 	assert.Equal(t, []*Listener[int]{first, second}, topic.Listeners())
+
+	topic.OffAll()
+	listeners = topic.Listeners()
+	assert.NotNil(t, listeners)
+	assert.Empty(t, listeners)
 }
 
 func TestEventBus_SkipErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
Protect eventbus listener state by returning a copy from Listeners instead of exposing the internal slice.

## Changes
- Return a shallow copy of the listener slice from Event.Listeners
- Add a regression test that mutating the returned slice does not alter the event's registered listeners

## Motivation
- Callers could previously mutate the returned slice and bypass Event's locking and listener management methods

## Testing
- go test ./... in eventbus