### PR TITLE
fix(errors): return group errors copy

### DIFF
--- a/errors/group.go
+++ b/errors/group.go
@@ -38,8 +38,8 @@ func (g *Group) Error() string {
 }
 
 func (g *Group) Errors() []error {
-	if g.errors == nil {
-		return nil
+	if len(g.errors) == 0 {
+		return g.errors
 	}
 
 	errs := make([]error, len(g.errors))

--- a/errors/group.go
+++ b/errors/group.go
@@ -38,7 +38,13 @@ func (g *Group) Error() string {
 }
 
 func (g *Group) Errors() []error {
-	return g.errors
+	if g.errors == nil {
+		return nil
+	}
+
+	errs := make([]error, len(g.errors))
+	copy(errs, g.errors)
+	return errs
 }
 
 func (g *Group) Len() int {

--- a/errors/group_test.go
+++ b/errors/group_test.go
@@ -54,7 +54,11 @@ func TestGroup_ErrorsReturnsCopy(t *testing.T) {
 	var zero Group
 	assert.Nil(t, zero.Errors())
 
-	g := NewGroup().Add(err1, err2)
+	g := NewGroup()
+	assert.NotNil(t, g.Errors())
+	assert.Empty(t, g.Errors())
+
+	g.Add(err1, err2)
 
 	errs := g.Errors()
 	assert.Equal(t, []error{err1, err2}, errs)

--- a/errors/group_test.go
+++ b/errors/group_test.go
@@ -50,6 +50,22 @@ func TestGroup_First(t *testing.T) {
 	assert.Equal(t, err1, g.First())
 }
 
+func TestGroup_ErrorsReturnsCopy(t *testing.T) {
+	var zero Group
+	assert.Nil(t, zero.Errors())
+
+	g := NewGroup().Add(err1, err2)
+
+	errs := g.Errors()
+	assert.Equal(t, []error{err1, err2}, errs)
+
+	errs[0] = err3
+	assert.Equal(t, []error{err1, err2}, g.Errors())
+	assert.Equal(t, err1, g.First())
+	assert.True(t, g.Has(err1))
+	assert.False(t, g.Has(err3))
+}
+
 func TestGroup_IsNil(t *testing.T) {
 	g := NewGroup()
 	assert.True(t, g.IsNil())

--- a/errors/group_test.go
+++ b/errors/group_test.go
@@ -58,7 +58,7 @@ func TestGroup_ErrorsReturnsCopy(t *testing.T) {
 	assert.NotNil(t, g.Errors())
 	assert.Empty(t, g.Errors())
 
-	g.Add(err1, err2)
+	assert.Equal(t, g, g.Add(err1, err2))
 
 	errs := g.Errors()
 	assert.Equal(t, []error{err1, err2}, errs)


### PR DESCRIPTION
## Summary
Protect Group's internal error slice by returning a copy from Errors instead of exposing the stored slice.

## Changes
- Return a copied error slice from Group.Errors
- Preserve nil behavior for zero-value Group instances
- Add a regression test that mutating the returned slice does not alter the Group state

## Motivation
- Callers could previously mutate the returned slice and change First, Has, and later Errors results without using Group APIs

## Testing
- go test ./... in errors