### PR TITLE
refactor(signal)!: improve server lifecycle and handler APIs

### DIFF
--- a/signal/README.md
+++ b/signal/README.md
@@ -52,9 +52,7 @@ func (h *exampleHandler) Handle(ctx context.Context, sig os.Signal) {
 
 type example2Handler struct{}
 
-func (h *example2Handler) Async() bool {
-	return true
-}
+func (h *example2Handler) Async() {}
 
 func (h *example2Handler) Listen() []os.Signal {
 	return []os.Signal{syscall.SIGUSR1}
@@ -86,5 +84,5 @@ ERROR msg=[Signal] handler panic (user defined signal 1): example2Handler panic
 - `Start` blocks until the context is canceled or `Stop` is called.
 - `Stop` is idempotent and can be called more than once.
 - `WithHandlers` registers handlers during construction. `Register` can add handlers before `Start` builds its signal routes.
-- Handlers that implement `Async() bool` and return `true` run in their own goroutine.
+- Handlers that implement `Async()` run in their own goroutine.
 - `WithRecovery` handles panics raised by handlers. Use `signal.WithRecovery(signal.DefaultRecovery)` to log handler panics.

--- a/signal/README.md
+++ b/signal/README.md
@@ -50,9 +50,9 @@ func (h *exampleHandler) Handle(ctx context.Context, sig os.Signal) {
 	println("exampleHandler signal:", sig)
 }
 
-type example2Handler struct{}
-
-func (h *example2Handler) Async() {}
+type example2Handler struct {
+	signal.AsyncHandler
+}
 
 func (h *example2Handler) Listen() []os.Signal {
 	return []os.Signal{syscall.SIGUSR1}
@@ -84,5 +84,5 @@ ERROR msg=[Signal] handler panic (user defined signal 1): example2Handler panic
 - `Start` blocks until the context is canceled or `Stop` is called.
 - `Stop` is idempotent and can be called more than once.
 - `WithHandlers` registers handlers during construction. `Register` can add handlers before `Start` builds its signal routes.
-- Handlers that implement `Async()` run in their own goroutine.
+- Handlers that embed `signal.AsyncHandler` run in their own goroutine.
 - `WithRecovery` handles panics raised by handlers. Use `signal.WithRecovery(signal.DefaultRecovery)` to log handler panics.

--- a/signal/README.md
+++ b/signal/README.md
@@ -18,7 +18,6 @@ import (
 
 	"github.com/go-kratos/kratos/v2"
 
-	"github.com/go-fries/fries/contract/v3"
 	"github.com/go-fries/fries/signal/v3"
 )
 
@@ -51,9 +50,7 @@ func (h *exampleHandler) Handle(ctx context.Context, sig os.Signal) {
 	println("exampleHandler signal:", sig)
 }
 
-type example2Handler struct {
-	contract.AsyncFeature // async feature
-}
+type example2Handler struct{}
 
 func (h *example2Handler) Listen() []os.Signal {
 	return []os.Signal{syscall.SIGUSR1}
@@ -85,5 +82,4 @@ ERROR msg=[Signal] handler panic (user defined signal 1): example2Handler panic
 - `Start` blocks until the context is canceled or `Stop` is called.
 - `Stop` is idempotent and can be called more than once.
 - `WithHandlers` registers handlers during construction. `Register` can add handlers before `Start` builds its signal routes.
-- Handlers that implement `contract.Asyncable` and return `true` from `Async` run in their own goroutine.
 - `WithRecovery` handles panics raised by handlers. Use `signal.WithRecovery(signal.DefaultRecovery)` to log handler panics.

--- a/signal/README.md
+++ b/signal/README.md
@@ -52,6 +52,10 @@ func (h *exampleHandler) Handle(ctx context.Context, sig os.Signal) {
 
 type example2Handler struct{}
 
+func (h *example2Handler) Async() bool {
+	return true
+}
+
 func (h *example2Handler) Listen() []os.Signal {
 	return []os.Signal{syscall.SIGUSR1}
 }
@@ -82,4 +86,5 @@ ERROR msg=[Signal] handler panic (user defined signal 1): example2Handler panic
 - `Start` blocks until the context is canceled or `Stop` is called.
 - `Stop` is idempotent and can be called more than once.
 - `WithHandlers` registers handlers during construction. `Register` can add handlers before `Start` builds its signal routes.
+- Handlers that implement `Async() bool` and return `true` run in their own goroutine.
 - `WithRecovery` handles panics raised by handlers. Use `signal.WithRecovery(signal.DefaultRecovery)` to log handler panics.

--- a/signal/README.md
+++ b/signal/README.md
@@ -12,6 +12,7 @@ go get github.com/go-fries/fries/signal/v3
 package main
 
 import (
+	"context"
 	"os"
 	"syscall"
 
@@ -33,10 +34,9 @@ func main() {
 
 func newSignalServer() *signal.Server {
 	srv := signal.NewServer(
+		signal.WithHandlers(&exampleHandler{}, &example2Handler{}),
 		signal.WithRecovery(signal.DefaultRecovery),
 	)
-
-	srv.Register(&exampleHandler{}, &example2Handler{})
 
 	return srv
 }
@@ -47,7 +47,7 @@ func (h *exampleHandler) Listen() []os.Signal {
 	return []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2}
 }
 
-func (h *exampleHandler) Handle(sig os.Signal) {
+func (h *exampleHandler) Handle(ctx context.Context, sig os.Signal) {
 	println("exampleHandler signal:", sig)
 }
 
@@ -59,7 +59,7 @@ func (h *example2Handler) Listen() []os.Signal {
 	return []os.Signal{syscall.SIGUSR1}
 }
 
-func (h *example2Handler) Handle(os.Signal) {
+func (h *example2Handler) Handle(context.Context, os.Signal) {
 	panic("example2Handler panic")
 }
 ```
@@ -84,5 +84,6 @@ ERROR msg=[Signal] handler panic (user defined signal 1): example2Handler panic
 
 - `Start` blocks until the context is canceled or `Stop` is called.
 - `Stop` is idempotent and can be called more than once.
+- `WithHandlers` registers handlers during construction. `Register` can add handlers before `Start` builds its signal routes.
 - Handlers that implement `contract.Asyncable` and return `true` from `Async` run in their own goroutine.
 - `WithRecovery` handles panics raised by handlers. Use `signal.WithRecovery(signal.DefaultRecovery)` to log handler panics.

--- a/signal/README.md
+++ b/signal/README.md
@@ -1,5 +1,11 @@
 # Signal Server
 
+## Installation
+
+```bash
+go get github.com/go-fries/fries/signal/v3
+```
+
 ## Example
 
 ```go
@@ -11,8 +17,8 @@ import (
 
 	"github.com/go-kratos/kratos/v2"
 
-	"github.com/go-kratos-ecosystem/components/v2/feature"
-	"github.com/go-kratos-ecosystem/components/v2/signal"
+	"github.com/go-fries/fries/contract/v3"
+	"github.com/go-fries/fries/signal/v3"
 )
 
 func main() {
@@ -45,8 +51,8 @@ func (h *exampleHandler) Handle(sig os.Signal) {
 	println("exampleHandler signal:", sig)
 }
 
-type example2Handler struct{
-	feature.AsyncFeature // async feature
+type example2Handler struct {
+	contract.AsyncFeature // async feature
 }
 
 func (h *example2Handler) Listen() []os.Signal {
@@ -73,3 +79,10 @@ exampleHandler signal: (0x104ff0240,0x1051875b8)
 exampleHandler signal: (0x104ff0240,0x1051875b0)
 ERROR msg=[Signal] handler panic (user defined signal 1): example2Handler panic
 ```
+
+## Behavior
+
+- `Start` blocks until the context is canceled or `Stop` is called.
+- `Stop` is idempotent and can be called more than once.
+- Handlers that implement `contract.Asyncable` and return `true` from `Async` run in their own goroutine.
+- `WithRecovery` handles panics raised by handlers. Use `signal.WithRecovery(signal.DefaultRecovery)` to log handler panics.

--- a/signal/config.go
+++ b/signal/config.go
@@ -3,6 +3,8 @@ package signal
 import (
 	"context"
 	"os"
+
+	"github.com/go-kratos/kratos/v2/log"
 )
 
 // Option configures a Server.
@@ -13,6 +15,19 @@ type Option interface {
 type config struct {
 	handlers []Handler
 	recovery RecoveryHandler
+}
+
+func newConfig(opts ...Option) config {
+	cfg := config{
+		handlers: make([]Handler, 0),
+		recovery: defaultRecovery,
+	}
+
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+
+	return cfg
 }
 
 type optionFunc func(*config)
@@ -39,3 +54,12 @@ func WithRecovery(handler RecoveryHandler) Option {
 
 // RecoveryHandler handles panics raised by signal handlers.
 type RecoveryHandler func(context.Context, os.Signal, Handler, any)
+
+// DefaultRecovery logs panics raised by signal handlers.
+func DefaultRecovery(ctx context.Context, sig os.Signal, handler Handler, recovered any) {
+	defaultRecovery(ctx, sig, handler, recovered)
+}
+
+var defaultRecovery RecoveryHandler = func(ctx context.Context, sig os.Signal, _ Handler, recovered any) {
+	log.Context(ctx).Errorf("[Signal] handler panic (%s): %v", sig, recovered)
+}

--- a/signal/config.go
+++ b/signal/config.go
@@ -1,6 +1,9 @@
 package signal
 
-import "os"
+import (
+	"context"
+	"os"
+)
 
 // Option configures a Server.
 type Option interface {
@@ -9,7 +12,7 @@ type Option interface {
 
 type config struct {
 	handlers []Handler
-	recovery func(any, os.Signal, Handler)
+	recovery RecoveryHandler
 }
 
 type optionFunc func(*config)
@@ -26,10 +29,13 @@ func WithHandlers(handlers ...Handler) Option {
 }
 
 // WithRecovery configures a panic recovery hook for handler execution.
-func WithRecovery(handler func(any, os.Signal, Handler)) Option {
+func WithRecovery(handler RecoveryHandler) Option {
 	return optionFunc(func(cfg *config) {
 		if handler != nil {
 			cfg.recovery = handler
 		}
 	})
 }
+
+// RecoveryHandler handles panics raised by signal handlers.
+type RecoveryHandler func(context.Context, any, os.Signal, Handler)

--- a/signal/config.go
+++ b/signal/config.go
@@ -38,4 +38,4 @@ func WithRecovery(handler RecoveryHandler) Option {
 }
 
 // RecoveryHandler handles panics raised by signal handlers.
-type RecoveryHandler func(context.Context, any, os.Signal, Handler)
+type RecoveryHandler func(context.Context, os.Signal, Handler, any)

--- a/signal/config.go
+++ b/signal/config.go
@@ -24,6 +24,9 @@ func newConfig(opts ...Option) config {
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt.apply(&cfg)
 	}
 
@@ -39,7 +42,7 @@ func (f optionFunc) apply(cfg *config) {
 // WithHandlers registers handlers when constructing a Server.
 func WithHandlers(handlers ...Handler) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.handlers = append(cfg.handlers, handlers...)
+		cfg.handlers = appendHandlers(cfg.handlers, handlers...)
 	})
 }
 

--- a/signal/config.go
+++ b/signal/config.go
@@ -1,0 +1,35 @@
+package signal
+
+import "os"
+
+// Option configures a Server.
+type Option interface {
+	apply(*config)
+}
+
+type config struct {
+	handlers []Handler
+	recovery func(any, os.Signal, Handler)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(cfg *config) {
+	f(cfg)
+}
+
+// WithHandlers registers handlers when constructing a Server.
+func WithHandlers(handlers ...Handler) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.handlers = append(cfg.handlers, handlers...)
+	})
+}
+
+// WithRecovery configures a panic recovery hook for handler execution.
+func WithRecovery(handler func(any, os.Signal, Handler)) Option {
+	return optionFunc(func(cfg *config) {
+		if handler != nil {
+			cfg.recovery = handler
+		}
+	})
+}

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -2,10 +2,7 @@ module github.com/go-fries/fries/signal/v3
 
 go 1.25.0
 
-replace github.com/go-fries/fries/contract/v3 => ../contract
-
 require (
-	github.com/go-fries/fries/contract/v3 v3.13.0
 	github.com/go-kratos/kratos/v2 v2.9.2
 	github.com/stretchr/testify v1.11.1
 )

--- a/signal/handler.go
+++ b/signal/handler.go
@@ -4,7 +4,11 @@ import (
 	"os"
 )
 
+// Handler processes subscribed operating system signals.
 type Handler interface {
+	// Listen returns the signals that should be routed to this handler.
 	Listen() []os.Signal
+
+	// Handle processes a received signal.
 	Handle(os.Signal)
 }

--- a/signal/handler.go
+++ b/signal/handler.go
@@ -14,6 +14,8 @@ type Handler interface {
 	Handle(context.Context, os.Signal)
 }
 
-type asyncable interface {
-	Async()
+// AsyncHandler marks a Handler that should run asynchronously.
+type AsyncHandler interface {
+	Handler
+	async()
 }

--- a/signal/handler.go
+++ b/signal/handler.go
@@ -13,3 +13,7 @@ type Handler interface {
 	// Handle processes a received signal.
 	Handle(context.Context, os.Signal)
 }
+
+type asyncable interface {
+	Async() bool
+}

--- a/signal/handler.go
+++ b/signal/handler.go
@@ -1,6 +1,7 @@
 package signal
 
 import (
+	"context"
 	"os"
 )
 
@@ -10,5 +11,5 @@ type Handler interface {
 	Listen() []os.Signal
 
 	// Handle processes a received signal.
-	Handle(os.Signal)
+	Handle(context.Context, os.Signal)
 }

--- a/signal/handler.go
+++ b/signal/handler.go
@@ -15,7 +15,7 @@ type Handler interface {
 }
 
 // AsyncHandler marks a Handler that should run asynchronously.
+// External handlers opt in by embedding AsyncHandler.
 type AsyncHandler interface {
-	Handler
 	async()
 }

--- a/signal/handler.go
+++ b/signal/handler.go
@@ -15,5 +15,5 @@ type Handler interface {
 }
 
 type asyncable interface {
-	Async() bool
+	Async()
 }

--- a/signal/handler_test.go
+++ b/signal/handler_test.go
@@ -1,0 +1,15 @@
+package signal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockAsyncHandler struct {
+	AsyncHandler
+}
+
+func TestAsyncHandler(t *testing.T) {
+	assert.Implements(t, (*AsyncHandler)(nil), (*mockAsyncHandler)(nil))
+}

--- a/signal/handler_test.go
+++ b/signal/handler_test.go
@@ -1,6 +1,9 @@
 package signal
 
 import (
+	"context"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +13,13 @@ type mockAsyncHandler struct {
 	AsyncHandler
 }
 
+func (h *mockAsyncHandler) Listen() []os.Signal {
+	return []os.Signal{syscall.SIGUSR1}
+}
+
+func (h *mockAsyncHandler) Handle(context.Context, os.Signal) {}
+
 func TestAsyncHandler(t *testing.T) {
 	assert.Implements(t, (*AsyncHandler)(nil), (*mockAsyncHandler)(nil))
+	assert.Implements(t, (*Handler)(nil), (*mockAsyncHandler)(nil))
 }

--- a/signal/server.go
+++ b/signal/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"sync"
 
 	"github.com/go-fries/fries/contract/v3"
 	"github.com/go-kratos/kratos/v2/log"
@@ -15,7 +16,9 @@ var DefaultRecovery = func(err any, sig os.Signal, _ Handler) {
 
 type Server struct {
 	handlers []Handler
-	stoped   chan struct{}
+	stopped  chan struct{}
+	stopOnce sync.Once
+	mu       sync.RWMutex
 	recovery func(any, os.Signal, Handler)
 }
 
@@ -38,7 +41,7 @@ func WithRecovery(handler func(any, os.Signal, Handler)) Option {
 func NewServer(opts ...Option) *Server {
 	server := &Server{
 		handlers: make([]Handler, 0),
-		stoped:   make(chan struct{}),
+		stopped:  make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -49,38 +52,31 @@ func NewServer(opts ...Option) *Server {
 }
 
 func (s *Server) Start(ctx context.Context) error {
-	var (
-		signals  = make([]os.Signal, 0)
-		handlers = make(map[os.Signal][]Handler)
-	)
-
-	for _, h := range s.handlers {
-		for _, sig := range h.Listen() {
-			if _, ok := handlers[sig]; !ok {
-				handlers[sig] = make([]Handler, 0)
-			}
-			handlers[sig] = append(handlers[sig], h)
-		}
-		signals = append(signals, h.Listen()...)
-	}
-
-	signals = s.uniqueSignals(signals)
-
-	ch := make(chan os.Signal, len(signals))
-	signal.Notify(ch, signals...)
+	handlers, signals := buildHandlers(s.snapshotHandlers())
 
 	log.Infof("[Signal] server starting")
 
+	if len(signals) == 0 {
+		return s.wait(ctx)
+	}
+
+	ch := make(chan os.Signal, len(signals))
+	signal.Notify(ch, signals...)
+	defer signal.Stop(ch)
+
+	return s.serve(ctx, ch, handlers)
+}
+
+func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os.Signal][]Handler) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-s.stoped:
+		case <-s.stopped:
 			return nil
 		case sig := <-ch:
 			if hs, ok := handlers[sig]; ok {
 				for _, h := range hs {
-					// if Support asyncFeature
 					if async, ok := h.(contract.Asyncable); ok && async.Async() {
 						go s.handle(sig, h)
 					} else {
@@ -93,12 +89,17 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) Register(handlers ...Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.handlers = append(s.handlers, handlers...)
 }
 
 func (s *Server) Stop(context.Context) error {
-	log.Infof("[Signal] server stopping")
-	close(s.stoped)
+	s.stopOnce.Do(func() {
+		log.Infof("[Signal] server stopping")
+		close(s.stopped)
+	})
 	return nil
 }
 
@@ -114,14 +115,43 @@ func (s *Server) handle(sig os.Signal, handler Handler) {
 	handler.Handle(sig)
 }
 
-func (s *Server) uniqueSignals(signals []os.Signal) []os.Signal {
-	m := make(map[os.Signal]struct{})
-	for _, sig := range signals {
-		m[sig] = struct{}{}
+func (s *Server) wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.stopped:
+		return nil
 	}
-	signals = make([]os.Signal, 0, len(m))
-	for sig := range m {
-		signals = append(signals, sig)
+}
+
+func (s *Server) snapshotHandlers() []Handler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	handlers := make([]Handler, len(s.handlers))
+	copy(handlers, s.handlers)
+	return handlers
+}
+
+func buildHandlers(handlers []Handler) (map[os.Signal][]Handler, []os.Signal) {
+	routed := make(map[os.Signal][]Handler)
+	signals := make([]os.Signal, 0)
+	seen := make(map[os.Signal]struct{})
+
+	for _, h := range handlers {
+		handlerSeen := make(map[os.Signal]struct{})
+		for _, sig := range h.Listen() {
+			if _, ok := handlerSeen[sig]; ok {
+				continue
+			}
+			handlerSeen[sig] = struct{}{}
+			routed[sig] = append(routed[sig], h)
+			if _, ok := seen[sig]; !ok {
+				seen[sig] = struct{}{}
+				signals = append(signals, sig)
+			}
+		}
 	}
-	return signals
+
+	return routed, signals
 }

--- a/signal/server.go
+++ b/signal/server.go
@@ -10,8 +10,8 @@ import (
 )
 
 // DefaultRecovery logs panics raised by signal handlers.
-var DefaultRecovery RecoveryHandler = func(_ context.Context, err any, sig os.Signal, _ Handler) {
-	log.Errorf("[Signal] handler panic (%s): %v", sig, err)
+var DefaultRecovery RecoveryHandler = func(ctx context.Context, sig os.Signal, _ Handler, recovered any) {
+	log.Context(ctx).Errorf("[Signal] handler panic (%s): %v", sig, recovered)
 }
 
 // Server routes operating system signals to registered handlers.
@@ -101,7 +101,7 @@ func (s *Server) handle(ctx context.Context, sig os.Signal, handler Handler) {
 	defer func() {
 		if s.recovery != nil {
 			if err := recover(); err != nil {
-				s.recovery(ctx, err, sig, handler)
+				s.recovery(ctx, sig, handler, err)
 			}
 		}
 	}()

--- a/signal/server.go
+++ b/signal/server.go
@@ -69,7 +69,7 @@ func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os
 		case sig := <-ch:
 			if hs, ok := handlers[sig]; ok {
 				for _, h := range hs {
-					if async, ok := h.(asyncable); ok && async.Async() {
+					if _, ok := h.(asyncable); ok {
 						go s.handle(ctx, sig, h)
 					} else {
 						s.handle(ctx, sig, h)

--- a/signal/server.go
+++ b/signal/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"reflect"
 	"sync"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -74,7 +75,7 @@ func (s *Server) Register(handlers ...Handler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.handlers = append(s.handlers, handlers...)
+	s.handlers = appendHandlers(s.handlers, handlers...)
 }
 
 // Stop stops the Server and unblocks Start.
@@ -122,6 +123,9 @@ func buildHandlers(handlers []Handler) (map[os.Signal][]Handler, []os.Signal) {
 	seen := make(map[os.Signal]struct{})
 
 	for _, h := range handlers {
+		if isNilHandler(h) {
+			continue
+		}
 		handlerSeen := make(map[os.Signal]struct{})
 		for _, sig := range h.Listen() {
 			if _, ok := handlerSeen[sig]; ok {
@@ -137,4 +141,29 @@ func buildHandlers(handlers []Handler) (map[os.Signal][]Handler, []os.Signal) {
 	}
 
 	return routed, signals
+}
+
+func appendHandlers(dst []Handler, handlers ...Handler) []Handler {
+	for _, h := range handlers {
+		if isNilHandler(h) {
+			continue
+		}
+		dst = append(dst, h)
+	}
+
+	return dst
+}
+
+func isNilHandler(handler Handler) bool {
+	if handler == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(handler)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/signal/server.go
+++ b/signal/server.go
@@ -69,7 +69,11 @@ func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os
 		case sig := <-ch:
 			if hs, ok := handlers[sig]; ok {
 				for _, h := range hs {
-					s.handle(ctx, sig, h)
+					if async, ok := h.(asyncable); ok && async.Async() {
+						go s.handle(ctx, sig, h)
+					} else {
+						s.handle(ctx, sig, h)
+					}
 				}
 			}
 		}

--- a/signal/server.go
+++ b/signal/server.go
@@ -24,38 +24,6 @@ type Server struct {
 	recovery func(any, os.Signal, Handler)
 }
 
-// Option configures a Server.
-type Option interface {
-	apply(*config)
-}
-
-type config struct {
-	handlers []Handler
-	recovery func(any, os.Signal, Handler)
-}
-
-type optionFunc func(*config)
-
-func (f optionFunc) apply(cfg *config) {
-	f(cfg)
-}
-
-// WithHandlers registers handlers when constructing a Server.
-func WithHandlers(handlers ...Handler) Option {
-	return optionFunc(func(cfg *config) {
-		cfg.handlers = append(cfg.handlers, handlers...)
-	})
-}
-
-// WithRecovery configures a panic recovery hook for handler execution.
-func WithRecovery(handler func(any, os.Signal, Handler)) Option {
-	return optionFunc(func(cfg *config) {
-		if handler != nil {
-			cfg.recovery = handler
-		}
-	})
-}
-
 // NewServer creates a Server with the supplied options.
 func NewServer(opts ...Option) *Server {
 	cfg := config{

--- a/signal/server.go
+++ b/signal/server.go
@@ -10,10 +10,12 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
+// DefaultRecovery logs panics raised by signal handlers.
 var DefaultRecovery = func(err any, sig os.Signal, _ Handler) {
 	log.Errorf("[Signal] handler panic (%s): %v", sig, err)
 }
 
+// Server routes operating system signals to registered handlers.
 type Server struct {
 	handlers []Handler
 	stopped  chan struct{}
@@ -22,14 +24,17 @@ type Server struct {
 	recovery func(any, os.Signal, Handler)
 }
 
+// Option configures a Server.
 type Option func(*Server)
 
+// AddHandler registers handlers when constructing a Server.
 func AddHandler(handler ...Handler) Option {
 	return func(s *Server) {
 		s.handlers = append(s.handlers, handler...)
 	}
 }
 
+// WithRecovery configures a panic recovery hook for handler execution.
 func WithRecovery(handler func(any, os.Signal, Handler)) Option {
 	return func(s *Server) {
 		if handler != nil {
@@ -38,6 +43,7 @@ func WithRecovery(handler func(any, os.Signal, Handler)) Option {
 	}
 }
 
+// NewServer creates a Server with the supplied options.
 func NewServer(opts ...Option) *Server {
 	server := &Server{
 		handlers: make([]Handler, 0),
@@ -51,6 +57,7 @@ func NewServer(opts ...Option) *Server {
 	return server
 }
 
+// Start subscribes to registered signals and blocks until the context is done or the server stops.
 func (s *Server) Start(ctx context.Context) error {
 	handlers, signals := buildHandlers(s.snapshotHandlers())
 
@@ -88,6 +95,7 @@ func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os
 	}
 }
 
+// Register adds handlers to the Server.
 func (s *Server) Register(handlers ...Handler) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -95,6 +103,7 @@ func (s *Server) Register(handlers ...Handler) {
 	s.handlers = append(s.handlers, handlers...)
 }
 
+// Stop stops the Server and unblocks Start.
 func (s *Server) Stop(context.Context) error {
 	s.stopOnce.Do(func() {
 		log.Infof("[Signal] server stopping")

--- a/signal/server.go
+++ b/signal/server.go
@@ -9,11 +9,6 @@ import (
 	"github.com/go-kratos/kratos/v2/log"
 )
 
-// DefaultRecovery logs panics raised by signal handlers.
-var DefaultRecovery RecoveryHandler = func(ctx context.Context, sig os.Signal, _ Handler, recovered any) {
-	log.Context(ctx).Errorf("[Signal] handler panic (%s): %v", sig, recovered)
-}
-
 // Server routes operating system signals to registered handlers.
 type Server struct {
 	handlers []Handler
@@ -25,13 +20,7 @@ type Server struct {
 
 // NewServer creates a Server with the supplied options.
 func NewServer(opts ...Option) *Server {
-	cfg := config{
-		handlers: make([]Handler, 0),
-	}
-
-	for _, opt := range opts {
-		opt.apply(&cfg)
-	}
+	cfg := newConfig(opts...)
 
 	server := &Server{
 		handlers: cfg.handlers,

--- a/signal/server.go
+++ b/signal/server.go
@@ -69,7 +69,7 @@ func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os
 		case sig := <-ch:
 			if hs, ok := handlers[sig]; ok {
 				for _, h := range hs {
-					if _, ok := h.(asyncable); ok {
+					if _, ok := h.(AsyncHandler); ok {
 						go s.handle(ctx, sig, h)
 					} else {
 						s.handle(ctx, sig, h)

--- a/signal/server.go
+++ b/signal/server.go
@@ -46,7 +46,7 @@ func NewServer(opts ...Option) *Server {
 func (s *Server) Start(ctx context.Context) error {
 	handlers, signals := buildHandlers(s.snapshotHandlers())
 
-	log.Infof("[Signal] server starting")
+	log.Context(ctx).Infof("[Signal] server starting")
 
 	if len(signals) == 0 {
 		return s.wait(ctx)
@@ -89,9 +89,9 @@ func (s *Server) Register(handlers ...Handler) {
 }
 
 // Stop stops the Server and unblocks Start.
-func (s *Server) Stop(context.Context) error {
+func (s *Server) Stop(ctx context.Context) error {
 	s.stopOnce.Do(func() {
-		log.Infof("[Signal] server stopping")
+		log.Context(ctx).Infof("[Signal] server stopping")
 		close(s.stopped)
 	})
 	return nil

--- a/signal/server.go
+++ b/signal/server.go
@@ -25,33 +25,51 @@ type Server struct {
 }
 
 // Option configures a Server.
-type Option func(*Server)
+type Option interface {
+	apply(*config)
+}
 
-// AddHandler registers handlers when constructing a Server.
-func AddHandler(handler ...Handler) Option {
-	return func(s *Server) {
-		s.handlers = append(s.handlers, handler...)
-	}
+type config struct {
+	handlers []Handler
+	recovery func(any, os.Signal, Handler)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(cfg *config) {
+	f(cfg)
+}
+
+// WithHandlers registers handlers when constructing a Server.
+func WithHandlers(handlers ...Handler) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.handlers = append(cfg.handlers, handlers...)
+	})
 }
 
 // WithRecovery configures a panic recovery hook for handler execution.
 func WithRecovery(handler func(any, os.Signal, Handler)) Option {
-	return func(s *Server) {
+	return optionFunc(func(cfg *config) {
 		if handler != nil {
-			s.recovery = handler
+			cfg.recovery = handler
 		}
-	}
+	})
 }
 
 // NewServer creates a Server with the supplied options.
 func NewServer(opts ...Option) *Server {
-	server := &Server{
+	cfg := config{
 		handlers: make([]Handler, 0),
-		stopped:  make(chan struct{}),
 	}
 
 	for _, opt := range opts {
-		opt(server)
+		opt.apply(&cfg)
+	}
+
+	server := &Server{
+		handlers: cfg.handlers,
+		stopped:  make(chan struct{}),
+		recovery: cfg.recovery,
 	}
 
 	return server
@@ -85,9 +103,9 @@ func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os
 			if hs, ok := handlers[sig]; ok {
 				for _, h := range hs {
 					if async, ok := h.(contract.Asyncable); ok && async.Async() {
-						go s.handle(sig, h)
+						go s.handle(ctx, sig, h)
 					} else {
-						s.handle(sig, h)
+						s.handle(ctx, sig, h)
 					}
 				}
 			}
@@ -112,7 +130,7 @@ func (s *Server) Stop(context.Context) error {
 	return nil
 }
 
-func (s *Server) handle(sig os.Signal, handler Handler) {
+func (s *Server) handle(ctx context.Context, sig os.Signal, handler Handler) {
 	defer func() {
 		if s.recovery != nil {
 			if err := recover(); err != nil {
@@ -121,7 +139,7 @@ func (s *Server) handle(sig os.Signal, handler Handler) {
 		}
 	}()
 
-	handler.Handle(sig)
+	handler.Handle(ctx, sig)
 }
 
 func (s *Server) wait(ctx context.Context) error {

--- a/signal/server.go
+++ b/signal/server.go
@@ -6,7 +6,6 @@ import (
 	"os/signal"
 	"sync"
 
-	"github.com/go-fries/fries/contract/v3"
 	"github.com/go-kratos/kratos/v2/log"
 )
 
@@ -70,11 +69,7 @@ func (s *Server) serve(ctx context.Context, ch <-chan os.Signal, handlers map[os
 		case sig := <-ch:
 			if hs, ok := handlers[sig]; ok {
 				for _, h := range hs {
-					if async, ok := h.(contract.Asyncable); ok && async.Async() {
-						go s.handle(ctx, sig, h)
-					} else {
-						s.handle(ctx, sig, h)
-					}
+					s.handle(ctx, sig, h)
 				}
 			}
 		}

--- a/signal/server.go
+++ b/signal/server.go
@@ -10,7 +10,7 @@ import (
 )
 
 // DefaultRecovery logs panics raised by signal handlers.
-var DefaultRecovery = func(err any, sig os.Signal, _ Handler) {
+var DefaultRecovery RecoveryHandler = func(_ context.Context, err any, sig os.Signal, _ Handler) {
 	log.Errorf("[Signal] handler panic (%s): %v", sig, err)
 }
 
@@ -20,7 +20,7 @@ type Server struct {
 	stopped  chan struct{}
 	stopOnce sync.Once
 	mu       sync.RWMutex
-	recovery func(any, os.Signal, Handler)
+	recovery RecoveryHandler
 }
 
 // NewServer creates a Server with the supplied options.
@@ -101,7 +101,7 @@ func (s *Server) handle(ctx context.Context, sig os.Signal, handler Handler) {
 	defer func() {
 		if s.recovery != nil {
 			if err := recover(); err != nil {
-				s.recovery(err, sig, handler)
+				s.recovery(ctx, err, sig, handler)
 			}
 		}
 	}()

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -72,12 +72,10 @@ func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
 	srv := NewServer()
 	handlers, _ := buildHandlers([]Handler{
 		asyncTestHandler{
-			testHandler: testHandler{
-				signals: []os.Signal{sig},
-				handle: func(_ context.Context, sig os.Signal) {
-					started <- sig
-					<-release
-				},
+			signals: []os.Signal{sig},
+			handle: func(_ context.Context, sig os.Signal) {
+				started <- sig
+				<-release
 			},
 		},
 	})
@@ -189,10 +187,20 @@ func (h testHandler) Handle(ctx context.Context, sig os.Signal) {
 }
 
 type asyncTestHandler struct {
-	testHandler
+	AsyncHandler
+	signals []os.Signal
+	handle  func(context.Context, os.Signal)
 }
 
-func (h asyncTestHandler) Async() {}
+func (h asyncTestHandler) Listen() []os.Signal {
+	return h.signals
+}
+
+func (h asyncTestHandler) Handle(ctx context.Context, sig os.Signal) {
+	if h.handle != nil {
+		h.handle(ctx, sig)
+	}
+}
 
 type countingHandler struct {
 	signals []os.Signal

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -65,34 +65,6 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	assert.NoError(t, <-done)
 }
 
-func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
-	sig := syscall.SIGUSR1
-	handled := make(chan os.Signal, 1)
-	srv := NewServer()
-	handlers, _ := buildHandlers([]Handler{
-		asyncTestHandler{
-			testHandler: testHandler{
-				signals: []os.Signal{sig},
-				handle: func(_ context.Context, sig os.Signal) {
-					handled <- sig
-				},
-			},
-		},
-	})
-
-	ch := make(chan os.Signal, 1)
-	done := make(chan error, 1)
-	go func() {
-		done <- srv.serve(t.Context(), ch, handlers)
-	}()
-
-	ch <- sig
-	assert.Equal(t, sig, <-handled)
-
-	require.NoError(t, srv.Stop(t.Context()))
-	assert.NoError(t, <-done)
-}
-
 func TestServer_StopIsIdempotent(t *testing.T) {
 	srv := NewServer()
 
@@ -177,14 +149,6 @@ func (h testHandler) Handle(ctx context.Context, sig os.Signal) {
 	if h.handle != nil {
 		h.handle(ctx, sig)
 	}
-}
-
-type asyncTestHandler struct {
-	testHandler
-}
-
-func (h asyncTestHandler) Async() bool {
-	return true
 }
 
 type countingHandler struct {

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -3,6 +3,7 @@ package signal
 import (
 	"context"
 	"os"
+	"reflect"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -112,6 +113,11 @@ func TestServer_StopIsIdempotent(t *testing.T) {
 		assert.NoError(t, srv.Stop(t.Context()))
 		assert.NoError(t, srv.Stop(t.Context()))
 	})
+}
+
+func TestNewServer_DefaultRecovery(t *testing.T) {
+	assert.NotNil(t, NewServer().recovery)
+	assert.Equal(t, reflect.ValueOf(defaultRecovery).Pointer(), reflect.ValueOf(NewServer(WithRecovery(nil)).recovery).Pointer())
 }
 
 func TestBuildHandlersCallsListenOnce(t *testing.T) {

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -192,9 +192,7 @@ type asyncTestHandler struct {
 	testHandler
 }
 
-func (h asyncTestHandler) Async() bool {
-	return true
-}
+func (h asyncTestHandler) Async() {}
 
 type countingHandler struct {
 	signals []os.Signal

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -26,11 +26,15 @@ func TestServer_StartWithoutHandlersStops(t *testing.T) {
 
 func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	sig := syscall.SIGUSR1
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "recovery context")
 	handled := make(chan os.Signal, 1)
 	recovered := make(chan any, 1)
+	recoveredCtx := make(chan any, 1)
 
 	srv := NewServer(
-		WithRecovery(func(err any, _ os.Signal, _ Handler) {
+		WithRecovery(func(ctx context.Context, err any, _ os.Signal, _ Handler) {
+			recoveredCtx <- ctx.Value(contextKey{})
 			recovered <- err
 		}),
 	)
@@ -54,11 +58,12 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	ch := make(chan os.Signal, 1)
 	done := make(chan error, 1)
 	go func() {
-		done <- srv.serve(t.Context(), ch, handlers)
+		done <- srv.serve(ctx, ch, handlers)
 	}()
 
 	ch <- sig
 	assert.Equal(t, sig, <-handled)
+	assert.Equal(t, "recovery context", <-recoveredCtx)
 	assert.Equal(t, "handler panic", <-recovered)
 
 	require.NoError(t, srv.Stop(t.Context()))

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -33,9 +33,9 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	recoveredCtx := make(chan any, 1)
 
 	srv := NewServer(
-		WithRecovery(func(ctx context.Context, err any, _ os.Signal, _ Handler) {
+		WithRecovery(func(ctx context.Context, _ os.Signal, _ Handler, panicValue any) {
 			recoveredCtx <- ctx.Value(contextKey{})
-			recovered <- err
+			recovered <- panicValue
 		}),
 	)
 	handlers, signals := buildHandlers([]Handler{

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -22,7 +22,7 @@ func TestServer_StartWithoutHandlersStops(t *testing.T) {
 	}()
 
 	require.NoError(t, srv.Stop(t.Context()))
-	assert.NoError(t, <-done)
+	assert.NoError(t, receive(t, done))
 }
 
 func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
@@ -63,12 +63,12 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	}()
 
 	ch <- sig
-	assert.Equal(t, sig, <-handled)
-	assert.Equal(t, "recovery context", <-recoveredCtx)
-	assert.Equal(t, "handler panic", <-recovered)
+	assert.Equal(t, sig, receive(t, handled))
+	assert.Equal(t, "recovery context", receive(t, recoveredCtx))
+	assert.Equal(t, "handler panic", receive(t, recovered))
 
 	require.NoError(t, srv.Stop(t.Context()))
-	assert.NoError(t, <-done)
+	assert.NoError(t, receive(t, done))
 }
 
 func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
@@ -93,7 +93,7 @@ func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
 	}()
 
 	ch <- sig
-	assert.Equal(t, sig, <-started)
+	assert.Equal(t, sig, receive(t, started))
 
 	require.NoError(t, srv.Stop(t.Context()))
 	select {
@@ -120,6 +120,13 @@ func TestNewServer_DefaultRecovery(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(defaultRecovery).Pointer(), reflect.ValueOf(NewServer(WithRecovery(nil)).recovery).Pointer())
 }
 
+func TestNewServer_SkipsNilOptions(t *testing.T) {
+	assert.NotPanics(t, func() {
+		srv := NewServer(nil)
+		assert.NotNil(t, srv.recovery)
+	})
+}
+
 func TestBuildHandlersCallsListenOnce(t *testing.T) {
 	var listenCalls atomic.Int32
 	handler := countingHandler{
@@ -133,6 +140,16 @@ func TestBuildHandlersCallsListenOnce(t *testing.T) {
 	assert.Equal(t, []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2}, signals)
 	assert.Len(t, handlers[syscall.SIGUSR1], 1)
 	assert.Len(t, handlers[syscall.SIGUSR2], 1)
+}
+
+func TestBuildHandlersSkipsNilHandlers(t *testing.T) {
+	var nilHandler *testHandler
+	handler := testHandler{signals: []os.Signal{syscall.SIGUSR1}}
+
+	handlers, signals := buildHandlers([]Handler{nil, nilHandler, handler})
+
+	assert.Equal(t, []os.Signal{syscall.SIGUSR1}, signals)
+	assert.Equal(t, []Handler{handler}, handlers[syscall.SIGUSR1])
 }
 
 func TestServer_StartReturnsContextError(t *testing.T) {
@@ -176,10 +193,20 @@ func TestServer_ServePassesContextToHandlers(t *testing.T) {
 	}()
 
 	ch <- sig
-	assert.Equal(t, "context value", <-handled)
+	assert.Equal(t, "context value", receive(t, handled))
 
 	require.NoError(t, srv.Stop(t.Context()))
-	assert.NoError(t, <-done)
+	assert.NoError(t, receive(t, done))
+}
+
+func TestServer_RegisterSkipsNilHandlers(t *testing.T) {
+	var nilHandler *testHandler
+	handler := testHandler{signals: []os.Signal{syscall.SIGUSR1}}
+	srv := NewServer(WithHandlers(nil, nilHandler, handler))
+
+	srv.Register(nil, nilHandler)
+
+	assert.Equal(t, []Handler{handler}, srv.snapshotHandlers())
 }
 
 type testHandler struct {
@@ -240,5 +267,18 @@ func TestServer_StartStopsPromptly(t *testing.T) {
 		assert.NoError(t, err)
 	case <-time.After(time.Second):
 		t.Fatal("server did not stop")
+	}
+}
+
+func receive[T any](t *testing.T, ch <-chan T) T {
+	t.Helper()
+
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel receive")
+		var zero T
+		return zero
 	}
 }

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -1,80 +1,190 @@
 package signal
 
 import (
-	"bytes"
-	"fmt"
+	"context"
 	"os"
-	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-var (
-	buffer bytes.Buffer
-	mu     sync.Mutex
-)
+func TestServer_StartWithoutHandlersStops(t *testing.T) {
+	srv := NewServer()
+	done := make(chan error, 1)
 
-func TestServer(t *testing.T) {
-	srv := newServer()
+	go func() {
+		done <- srv.Start(context.Background())
+	}()
 
-	go srv.Start(t.Context()) //nolint:errcheck
-
-	time.Sleep(2 * time.Second)
-
-	assert.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGUSR1))
-	assert.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGUSR2))
-
-	time.Sleep(2 * time.Second)
-
-	mu.Lock()
-	assert.Equal(t, `exampleHandler signal: user defined signal 1
-signal: user defined signal 1, handler: *signal.example2Handler, err: example2Handler panic
-exampleHandler signal: user defined signal 2
-`, buffer.String())
-	mu.Unlock()
-
-	srv.Stop(t.Context()) //nolint:errcheck
+	require.NoError(t, srv.Stop(t.Context()))
+	assert.NoError(t, <-done)
 }
 
-func newServer() *Server {
+func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
+	sig := syscall.SIGUSR1
+	handled := make(chan os.Signal, 1)
+	recovered := make(chan any, 1)
+
 	srv := NewServer(
-		WithRecovery(func(err any, signal os.Signal, handler Handler) {
-			mu.Lock()
-			defer mu.Unlock()
-			fmt.Fprintf(&buffer, "signal: %s, handler: %T, err: %v\n", signal, handler, err)
+		WithRecovery(func(err any, _ os.Signal, _ Handler) {
+			recovered <- err
 		}),
 	)
+	handlers, signals := buildHandlers([]Handler{
+		testHandler{
+			signals: []os.Signal{sig},
+			handle: func(sig os.Signal) {
+				handled <- sig
+			},
+		},
+		testHandler{
+			signals: []os.Signal{sig},
+			handle: func(os.Signal) {
+				panic("handler panic")
+			},
+		},
+	})
 
-	srv.Register(&exampleHandler{}, &example2Handler{})
+	assert.Equal(t, []os.Signal{sig}, signals)
 
-	return srv
+	ch := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.serve(context.Background(), ch, handlers)
+	}()
+
+	ch <- sig
+	assert.Equal(t, sig, <-handled)
+	assert.Equal(t, "handler panic", <-recovered)
+
+	require.NoError(t, srv.Stop(t.Context()))
+	assert.NoError(t, <-done)
 }
 
-type exampleHandler struct{}
+func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
+	sig := syscall.SIGUSR1
+	handled := make(chan os.Signal, 1)
+	srv := NewServer()
+	handlers, _ := buildHandlers([]Handler{
+		asyncTestHandler{
+			testHandler: testHandler{
+				signals: []os.Signal{sig},
+				handle: func(sig os.Signal) {
+					handled <- sig
+				},
+			},
+		},
+	})
 
-func (h *exampleHandler) Listen() []os.Signal {
-	return []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2}
+	ch := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.serve(context.Background(), ch, handlers)
+	}()
+
+	ch <- sig
+	assert.Equal(t, sig, <-handled)
+
+	require.NoError(t, srv.Stop(t.Context()))
+	assert.NoError(t, <-done)
 }
 
-func (h *exampleHandler) Handle(sig os.Signal) {
-	mu.Lock()
-	defer mu.Unlock()
-	fmt.Fprintf(&buffer, "exampleHandler signal: %s\n", sig)
+func TestServer_StopIsIdempotent(t *testing.T) {
+	srv := NewServer()
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, srv.Stop(t.Context()))
+		assert.NoError(t, srv.Stop(t.Context()))
+	})
 }
 
-type example2Handler struct{}
+func TestBuildHandlersCallsListenOnce(t *testing.T) {
+	var listenCalls atomic.Int32
+	handler := countingHandler{
+		signals: []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGUSR1},
+		count:   &listenCalls,
+	}
 
-func (h *example2Handler) Listen() []os.Signal {
-	return []os.Signal{syscall.SIGUSR1}
+	handlers, signals := buildHandlers([]Handler{handler})
+
+	assert.Equal(t, int32(1), listenCalls.Load())
+	assert.Equal(t, []os.Signal{syscall.SIGUSR1, syscall.SIGUSR2}, signals)
+	assert.Len(t, handlers[syscall.SIGUSR1], 1)
+	assert.Len(t, handlers[syscall.SIGUSR2], 1)
 }
 
-func (h *example2Handler) Async() bool {
-	return false
+func TestServer_StartReturnsContextError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.ErrorIs(t, NewServer().Start(ctx), context.Canceled)
 }
 
-func (h *example2Handler) Handle(os.Signal) {
-	panic("example2Handler panic")
+func TestServer_SnapshotHandlers(t *testing.T) {
+	srv := NewServer()
+	handler := testHandler{signals: []os.Signal{syscall.SIGUSR1}}
+	srv.Register(handler)
+
+	handlers := srv.snapshotHandlers()
+	require.Len(t, handlers, 1)
+
+	handlers[0] = nil
+	assert.Equal(t, []Handler{handler}, srv.snapshotHandlers())
+}
+
+type testHandler struct {
+	signals []os.Signal
+	handle  func(os.Signal)
+}
+
+func (h testHandler) Listen() []os.Signal {
+	return h.signals
+}
+
+func (h testHandler) Handle(sig os.Signal) {
+	if h.handle != nil {
+		h.handle(sig)
+	}
+}
+
+type asyncTestHandler struct {
+	testHandler
+}
+
+func (h asyncTestHandler) Async() bool {
+	return true
+}
+
+type countingHandler struct {
+	signals []os.Signal
+	count   *atomic.Int32
+}
+
+func (h countingHandler) Listen() []os.Signal {
+	h.count.Add(1)
+	return h.signals
+}
+
+func (h countingHandler) Handle(os.Signal) {}
+
+func TestServer_StartStopsPromptly(t *testing.T) {
+	srv := NewServer(AddHandler(testHandler{signals: []os.Signal{syscall.SIGUSR1}}))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- srv.Start(context.Background())
+	}()
+
+	require.NoError(t, srv.Stop(t.Context()))
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("server did not stop")
+	}
 }

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -17,7 +17,7 @@ func TestServer_StartWithoutHandlersStops(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() {
-		done <- srv.Start(context.Background())
+		done <- srv.Start(t.Context())
 	}()
 
 	require.NoError(t, srv.Stop(t.Context()))
@@ -37,13 +37,13 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	handlers, signals := buildHandlers([]Handler{
 		testHandler{
 			signals: []os.Signal{sig},
-			handle: func(sig os.Signal) {
+			handle: func(_ context.Context, sig os.Signal) {
 				handled <- sig
 			},
 		},
 		testHandler{
 			signals: []os.Signal{sig},
-			handle: func(os.Signal) {
+			handle: func(context.Context, os.Signal) {
 				panic("handler panic")
 			},
 		},
@@ -54,7 +54,7 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	ch := make(chan os.Signal, 1)
 	done := make(chan error, 1)
 	go func() {
-		done <- srv.serve(context.Background(), ch, handlers)
+		done <- srv.serve(t.Context(), ch, handlers)
 	}()
 
 	ch <- sig
@@ -73,7 +73,7 @@ func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
 		asyncTestHandler{
 			testHandler: testHandler{
 				signals: []os.Signal{sig},
-				handle: func(sig os.Signal) {
+				handle: func(_ context.Context, sig os.Signal) {
 					handled <- sig
 				},
 			},
@@ -83,7 +83,7 @@ func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
 	ch := make(chan os.Signal, 1)
 	done := make(chan error, 1)
 	go func() {
-		done <- srv.serve(context.Background(), ch, handlers)
+		done <- srv.serve(t.Context(), ch, handlers)
 	}()
 
 	ch <- sig
@@ -118,7 +118,7 @@ func TestBuildHandlersCallsListenOnce(t *testing.T) {
 }
 
 func TestServer_StartReturnsContextError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	assert.ErrorIs(t, NewServer().Start(ctx), context.Canceled)
@@ -136,18 +136,46 @@ func TestServer_SnapshotHandlers(t *testing.T) {
 	assert.Equal(t, []Handler{handler}, srv.snapshotHandlers())
 }
 
+func TestServer_ServePassesContextToHandlers(t *testing.T) {
+	sig := syscall.SIGUSR1
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "context value")
+	handled := make(chan any, 1)
+	srv := NewServer()
+	handlers, _ := buildHandlers([]Handler{
+		testHandler{
+			signals: []os.Signal{sig},
+			handle: func(ctx context.Context, _ os.Signal) {
+				handled <- ctx.Value(contextKey{})
+			},
+		},
+	})
+
+	ch := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.serve(ctx, ch, handlers)
+	}()
+
+	ch <- sig
+	assert.Equal(t, "context value", <-handled)
+
+	require.NoError(t, srv.Stop(t.Context()))
+	assert.NoError(t, <-done)
+}
+
 type testHandler struct {
 	signals []os.Signal
-	handle  func(os.Signal)
+	handle  func(context.Context, os.Signal)
 }
 
 func (h testHandler) Listen() []os.Signal {
 	return h.signals
 }
 
-func (h testHandler) Handle(sig os.Signal) {
+func (h testHandler) Handle(ctx context.Context, sig os.Signal) {
 	if h.handle != nil {
-		h.handle(sig)
+		h.handle(ctx, sig)
 	}
 }
 
@@ -169,14 +197,14 @@ func (h countingHandler) Listen() []os.Signal {
 	return h.signals
 }
 
-func (h countingHandler) Handle(os.Signal) {}
+func (h countingHandler) Handle(context.Context, os.Signal) {}
 
 func TestServer_StartStopsPromptly(t *testing.T) {
-	srv := NewServer(AddHandler(testHandler{signals: []os.Signal{syscall.SIGUSR1}}))
+	srv := NewServer(WithHandlers(testHandler{signals: []os.Signal{syscall.SIGUSR1}}))
 	done := make(chan error, 1)
 
 	go func() {
-		done <- srv.Start(context.Background())
+		done <- srv.Start(t.Context())
 	}()
 
 	require.NoError(t, srv.Stop(t.Context()))

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -65,6 +65,43 @@ func TestServer_ServeDispatchesAndRecovers(t *testing.T) {
 	assert.NoError(t, <-done)
 }
 
+func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
+	sig := syscall.SIGUSR1
+	started := make(chan os.Signal, 1)
+	release := make(chan struct{})
+	srv := NewServer()
+	handlers, _ := buildHandlers([]Handler{
+		asyncTestHandler{
+			testHandler: testHandler{
+				signals: []os.Signal{sig},
+				handle: func(_ context.Context, sig os.Signal) {
+					started <- sig
+					<-release
+				},
+			},
+		},
+	})
+
+	ch := make(chan os.Signal, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.serve(t.Context(), ch, handlers)
+	}()
+
+	ch <- sig
+	assert.Equal(t, sig, <-started)
+
+	require.NoError(t, srv.Stop(t.Context()))
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("server did not stop while async handler was running")
+	}
+	close(release)
+}
+
 func TestServer_StopIsIdempotent(t *testing.T) {
 	srv := NewServer()
 
@@ -149,6 +186,14 @@ func (h testHandler) Handle(ctx context.Context, sig os.Signal) {
 	if h.handle != nil {
 		h.handle(ctx, sig)
 	}
+}
+
+type asyncTestHandler struct {
+	testHandler
+}
+
+func (h asyncTestHandler) Async() bool {
+	return true
 }
 
 type countingHandler struct {


### PR DESCRIPTION
## Summary
Refactor the signal server lifecycle and handler APIs to make shutdown, recovery, and handler dispatch behavior more explicit and testable.

## Changes
- Add context-aware signal handling with `Handler.Handle(context.Context, os.Signal)`
- Replace function options with config-backed option interfaces and `WithHandlers`
- Make server stop idempotent, snapshot handlers safely, and avoid OS signal registration when no handlers exist
- Add default context-aware recovery handling and support async handlers through `signal.AsyncHandler`
- Refresh the signal README and replace slow OS-signal tests with channel-driven unit tests

## Motivation
- The previous implementation mixed option application, signal routing, and lifecycle state in one path, which made races and shutdown behavior harder to reason about
- Handler and recovery callbacks now receive context consistently, matching the rest of the server lifecycle

## Breaking Changes
- `Handler.Handle` now requires a `context.Context` parameter
- `AddHandler` is replaced by `WithHandlers`
- Async handlers now opt in by embedding `signal.AsyncHandler`
- `WithRecovery` now accepts `RecoveryHandler func(context.Context, os.Signal, Handler, any)`

## Testing
- `make test/signal`
- `go test -race ./...` from `signal/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added async handler support for non-blocking signal processing with improved lifecycle management.
  * New configuration options for handler registration and customizable panic recovery with full signal context.

* **Improvements**
  * Enhanced server concurrency safety and idempotent shutdown behavior.
  * Improved signal handler invocation with context propagation.

* **Documentation**
  * Updated signal handler examples and added behavior documentation.

* **Tests**
  * Expanded test coverage with comprehensive unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->