### PR TITLE
fix(gorm/logger/otel): ignore record not found by default

### DIFF
--- a/gorm/logger/otel/README.md
+++ b/gorm/logger/otel/README.md
@@ -39,5 +39,8 @@ func openDB(dialector gorm.Dialector) (*gorm.DB, error) {
 `Trace` emits SQL log records for errors, slow SQL, and info-level query
 logging. SQL records include `db.query.text`, `gorm.rows_affected`,
 `gorm.elapsed_ms`, and `gorm.event` attributes.
+`logger.ErrRecordNotFound` is ignored by default because it is commonly an
+expected query miss rather than an application failure. Use
+`WithIgnoreRecordNotFoundError(false)` to report it as an error log record.
 Use `WithParameterizedQueries(true)` to keep GORM from expanding SQL parameter
 values into the rendered query text.

--- a/gorm/logger/otel/config.go
+++ b/gorm/logger/otel/config.go
@@ -101,10 +101,11 @@ func WithParameterizedQueries(parameterized bool) Option {
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{
-		provider:      global.GetLoggerProvider(),
-		version:       Version(),
-		level:         logger.Warn,
-		slowThreshold: 200 * time.Millisecond,
+		provider:                  global.GetLoggerProvider(),
+		version:                   Version(),
+		level:                     logger.Warn,
+		slowThreshold:             200 * time.Millisecond,
+		ignoreRecordNotFoundError: true,
 	}
 	for _, opt := range opts {
 		opt.apply(cfg)

--- a/gorm/logger/otel/config_test.go
+++ b/gorm/logger/otel/config_test.go
@@ -21,7 +21,7 @@ func TestNewConfigDefaults(t *testing.T) {
 	assert.Empty(t, cfg.attributes)
 	assert.Equal(t, logger.Warn, cfg.level)
 	assert.Equal(t, 200*time.Millisecond, cfg.slowThreshold)
-	assert.False(t, cfg.ignoreRecordNotFoundError)
+	assert.True(t, cfg.ignoreRecordNotFoundError)
 	assert.False(t, cfg.parameterizedQueries)
 }
 
@@ -36,7 +36,7 @@ func TestConfigOptions(t *testing.T) {
 		WithAttributes(attribute.String("layer", "database")),
 		WithLogLevel(logger.Info),
 		WithSlowThreshold(time.Second),
-		WithIgnoreRecordNotFoundError(true),
+		WithIgnoreRecordNotFoundError(false),
 		WithParameterizedQueries(true),
 	)
 
@@ -49,7 +49,7 @@ func TestConfigOptions(t *testing.T) {
 	}, cfg.attributes)
 	assert.Equal(t, logger.Info, cfg.level)
 	assert.Equal(t, time.Second, cfg.slowThreshold)
-	assert.True(t, cfg.ignoreRecordNotFoundError)
+	assert.False(t, cfg.ignoreRecordNotFoundError)
 	assert.True(t, cfg.parameterizedQueries)
 }
 

--- a/gorm/logger/otel/logger_test.go
+++ b/gorm/logger/otel/logger_test.go
@@ -60,7 +60,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, scopeName, provider.name)
 	assert.Equal(t, logger.Warn, l.level)
 	assert.Equal(t, 200*time.Millisecond, l.slowThreshold)
-	assert.False(t, l.ignoreRecordNotFoundError)
+	assert.True(t, l.ignoreRecordNotFoundError)
 	assert.False(t, l.parameterizedQueries)
 }
 
@@ -257,7 +257,6 @@ func TestTraceIgnoresRecordNotFound(t *testing.T) {
 	l := New(
 		WithLoggerProvider(provider),
 		WithLogLevel(logger.Error),
-		WithIgnoreRecordNotFoundError(true),
 	)
 	provider.logger.enabled = true
 	called := false
@@ -269,6 +268,27 @@ func TestTraceIgnoresRecordNotFound(t *testing.T) {
 
 	assert.False(t, called)
 	assert.False(t, provider.logger.emitted)
+}
+
+func TestTraceReportsRecordNotFoundWhenConfigured(t *testing.T) {
+	provider := &recordingLoggerProvider{}
+	l := New(
+		WithLoggerProvider(provider),
+		WithLogLevel(logger.Error),
+		WithIgnoreRecordNotFoundError(false),
+	)
+	provider.logger.enabled = true
+
+	l.Trace(t.Context(), time.Now(), func() (string, int64) {
+		return "select * from users", 0
+	}, logger.ErrRecordNotFound)
+
+	require.True(t, provider.logger.emitted)
+	assert.Equal(t, log.SeverityError, provider.logger.record.Severity())
+	assert.Equal(t, log.StringValue("gorm.sql.error"), provider.logger.record.Body())
+	attrs := recordAttributes(provider.logger.record)
+	assert.Equal(t, "select * from users", attrs["db.query.text"].Value.AsString())
+	assert.Equal(t, "record not found", attrs["error.message"].Value.AsString())
 }
 
 func TestTraceSkipsSQLRenderingWhenDisabled(t *testing.T) {


### PR DESCRIPTION
## Summary
Make the GORM OpenTelemetry logger ignore `logger.ErrRecordNotFound` by default so expected query misses do not emit error log records.

## Changes
- Set `ignoreRecordNotFoundError` to `true` in the default config
- Keep `WithIgnoreRecordNotFoundError(false)` for users who want to report record-not-found results as error logs
- Update tests for the new default and the explicit opt-in reporting path
- Document the default behavior in `gorm/logger/otel/README.md`

## Motivation
- `ErrRecordNotFound` is often an expected query miss rather than an application failure
- Avoid polluting OpenTelemetry error logs and alerting signals with expected not-found results

## Testing
- `go test ./...`
- `make lint/gorm/logger/otel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Record-not-found errors in the OpenTelemetry logger are now ignored by default, treating them as expected query outcomes rather than errors.

* **Documentation**
  * Updated documentation to clarify the default error handling behavior for record-not-found errors and explained how to enable error reporting via configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->