### PR TITLE
feat(gorm/logger/otel): add log record attributes

### DIFF
--- a/gorm/logger/otel/README.md
+++ b/gorm/logger/otel/README.md
@@ -14,10 +14,12 @@ go get github.com/go-fries/fries/gorm/logger/otel/v3
 package main
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-fries/fries/gorm/logger/otel/v3"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -31,8 +33,19 @@ func openDB(dialector gorm.Dialector) (*gorm.DB, error) {
 			otel.WithSlowThreshold(200*time.Millisecond),
 			otel.WithParameterizedQueries(true),
 			otel.WithAttributes(attribute.String("component", "gorm")),
+			otel.WithLogAttributes(log.String("db.system", "mysql")),
+			otel.WithTraceContext(),
+			otel.WithLogAttributeFuncs(func(ctx context.Context) []log.KeyValue {
+				return []log.KeyValue{
+					log.String("tenant.id", tenantIDFromContext(ctx)),
+				}
+			}),
 		),
 	})
+}
+
+func tenantIDFromContext(context.Context) string {
+	return "tenant-1"
 }
 ```
 
@@ -42,5 +55,9 @@ logging. SQL records include `db.query.text`, `gorm.rows_affected`,
 `logger.ErrRecordNotFound` is ignored by default because it is commonly an
 expected query miss rather than an application failure. Use
 `WithIgnoreRecordNotFoundError(false)` to report it as an error log record.
+Use `WithLogAttributes` and `WithLogAttributeFuncs` to add fixed or
+context-derived attributes to each emitted log record.
+Use `WithTraceContext` to add `trace.id` and `span.id` from the current span
+context when they are available.
 Use `WithParameterizedQueries(true)` to keep GORM from expanding SQL parameter
 values into the rendered query text.

--- a/gorm/logger/otel/README.md
+++ b/gorm/logger/otel/README.md
@@ -44,7 +44,7 @@ func openDB(dialector gorm.Dialector) (*gorm.DB, error) {
 	})
 }
 
-func tenantIDFromContext(context.Context) string {
+func tenantIDFromContext(ctx context.Context) string {
 	return "tenant-1"
 }
 ```

--- a/gorm/logger/otel/config.go
+++ b/gorm/logger/otel/config.go
@@ -100,6 +100,10 @@ func WithLogAttributeFuncs(funcs ...LogAttributeFunc) Option {
 func WithTraceContext() Option {
 	return WithLogAttributeFuncs(func(ctx context.Context) []log.KeyValue {
 		span := trace.SpanContextFromContext(ctx)
+		if !span.HasTraceID() && !span.HasSpanID() {
+			return nil
+		}
+
 		attrs := make([]log.KeyValue, 0, 2) //nolint:mnd
 		if span.HasTraceID() {
 			attrs = append(attrs, log.String("trace.id", span.TraceID().String()))

--- a/gorm/logger/otel/config.go
+++ b/gorm/logger/otel/config.go
@@ -1,11 +1,13 @@
 package otel
 
 import (
+	"context"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"
+	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm/logger"
 )
 
@@ -14,11 +16,16 @@ type config struct {
 	version                   string
 	schemaURL                 string
 	attributes                []attribute.KeyValue
+	logAttributes             []log.KeyValue
+	logAttributeFuncs         []LogAttributeFunc
 	level                     logger.LogLevel
 	slowThreshold             time.Duration
 	ignoreRecordNotFoundError bool
 	parameterizedQueries      bool
 }
+
+// LogAttributeFunc returns OpenTelemetry log record attributes for ctx.
+type LogAttributeFunc func(ctx context.Context) []log.KeyValue
 
 // Option configures a [Logger].
 type Option interface {
@@ -65,6 +72,42 @@ func WithSchemaURL(schemaURL string) Option {
 func WithAttributes(attributes ...attribute.KeyValue) Option {
 	return optionFunc(func(c *config) {
 		c.attributes = append(c.attributes, attributes...)
+	})
+}
+
+// WithLogAttributes adds OpenTelemetry log record attributes emitted with each
+// log record.
+func WithLogAttributes(attributes ...log.KeyValue) Option {
+	return optionFunc(func(c *config) {
+		c.logAttributes = append(c.logAttributes, attributes...)
+	})
+}
+
+// WithLogAttributeFuncs adds functions that return OpenTelemetry log record
+// attributes for each emitted log record.
+func WithLogAttributeFuncs(funcs ...LogAttributeFunc) Option {
+	return optionFunc(func(c *config) {
+		for _, fn := range funcs {
+			if fn != nil {
+				c.logAttributeFuncs = append(c.logAttributeFuncs, fn)
+			}
+		}
+	})
+}
+
+// WithTraceContext adds the current span trace and span IDs to each emitted log
+// record when they are available in the log context.
+func WithTraceContext() Option {
+	return WithLogAttributeFuncs(func(ctx context.Context) []log.KeyValue {
+		span := trace.SpanContextFromContext(ctx)
+		attrs := make([]log.KeyValue, 0, 2) //nolint:mnd
+		if span.HasTraceID() {
+			attrs = append(attrs, log.String("trace.id", span.TraceID().String()))
+		}
+		if span.HasSpanID() {
+			attrs = append(attrs, log.String("span.id", span.SpanID().String()))
+		}
+		return attrs
 	})
 }
 

--- a/gorm/logger/otel/config_test.go
+++ b/gorm/logger/otel/config_test.go
@@ -1,12 +1,14 @@
 package otel
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"
 	"gorm.io/gorm/logger"
 )
@@ -19,6 +21,8 @@ func TestNewConfigDefaults(t *testing.T) {
 	assert.Equal(t, Version(), cfg.version)
 	assert.Empty(t, cfg.schemaURL)
 	assert.Empty(t, cfg.attributes)
+	assert.Empty(t, cfg.logAttributes)
+	assert.Empty(t, cfg.logAttributeFuncs)
 	assert.Equal(t, logger.Warn, cfg.level)
 	assert.Equal(t, 200*time.Millisecond, cfg.slowThreshold)
 	assert.True(t, cfg.ignoreRecordNotFoundError)
@@ -27,6 +31,9 @@ func TestNewConfigDefaults(t *testing.T) {
 
 func TestConfigOptions(t *testing.T) {
 	provider := &recordingLoggerProvider{}
+	attributeFunc := func(context.Context) []log.KeyValue {
+		return []log.KeyValue{log.String("tenant.id", "tenant-1")}
+	}
 
 	cfg := newConfig(
 		WithLoggerProvider(provider),
@@ -34,6 +41,8 @@ func TestConfigOptions(t *testing.T) {
 		WithSchemaURL("https://example.com/schema"),
 		WithAttributes(attribute.String("component", "gorm")),
 		WithAttributes(attribute.String("layer", "database")),
+		WithLogAttributes(log.String("log.scope", "gorm")),
+		WithLogAttributeFuncs(nil, attributeFunc),
 		WithLogLevel(logger.Info),
 		WithSlowThreshold(time.Second),
 		WithIgnoreRecordNotFoundError(false),
@@ -47,6 +56,9 @@ func TestConfigOptions(t *testing.T) {
 		attribute.String("component", "gorm"),
 		attribute.String("layer", "database"),
 	}, cfg.attributes)
+	assert.Equal(t, []log.KeyValue{log.String("log.scope", "gorm")}, cfg.logAttributes)
+	require.Len(t, cfg.logAttributeFuncs, 1)
+	assert.Equal(t, []log.KeyValue{log.String("tenant.id", "tenant-1")}, cfg.logAttributeFuncs[0](t.Context()))
 	assert.Equal(t, logger.Info, cfg.level)
 	assert.Equal(t, time.Second, cfg.slowThreshold)
 	assert.False(t, cfg.ignoreRecordNotFoundError)

--- a/gorm/logger/otel/doc.go
+++ b/gorm/logger/otel/doc.go
@@ -5,6 +5,7 @@
 //
 //	import (
 //		"github.com/go-fries/fries/gorm/logger/otel/v3"
+//		"go.opentelemetry.io/otel/log"
 //		"go.opentelemetry.io/otel/log/global"
 //		"gorm.io/gorm"
 //		"gorm.io/gorm/logger"
@@ -14,6 +15,8 @@
 //		Logger: otel.New(
 //			otel.WithLoggerProvider(global.GetLoggerProvider()),
 //			otel.WithLogLevel(logger.Warn),
+//			otel.WithLogAttributes(log.String("component", "gorm")),
+//			otel.WithTraceContext(),
 //		),
 //	})
 package otel

--- a/gorm/logger/otel/go.mod
+++ b/gorm/logger/otel/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/log v0.20.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	gorm.io/gorm v1.31.1
 )
 
@@ -19,7 +20,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/gorm/logger/otel/logger.go
+++ b/gorm/logger/otel/logger.go
@@ -22,6 +22,8 @@ var (
 // Logger emits GORM logs through the OpenTelemetry Logs API.
 type Logger struct {
 	logger                    log.Logger
+	logAttributes             []log.KeyValue
+	logAttributeFuncs         []LogAttributeFunc
 	level                     logger.LogLevel
 	slowThreshold             time.Duration
 	ignoreRecordNotFoundError bool
@@ -34,6 +36,8 @@ func New(opts ...Option) *Logger {
 
 	return &Logger{
 		logger:                    cfg.newLogger(scopeName),
+		logAttributes:             cfg.logAttributes,
+		logAttributeFuncs:         cfg.logAttributeFuncs,
 		level:                     cfg.level,
 		slowThreshold:             cfg.slowThreshold,
 		ignoreRecordNotFoundError: cfg.ignoreRecordNotFoundError,
@@ -115,12 +119,26 @@ func (l *Logger) emit(ctx context.Context, severity log.Severity, severityText, 
 	record.SetSeverityText(severityText)
 	record.SetBody(log.StringValue(body))
 	record.AddAttributes(attrs...)
+	record.AddAttributes(l.attributes(ctx)...)
 
 	l.logger.Emit(ctx, record)
 }
 
 func (l *Logger) enabled(ctx context.Context, severity log.Severity) bool {
 	return l.logger.Enabled(ctx, log.EnabledParameters{Severity: severity})
+}
+
+func (l *Logger) attributes(ctx context.Context) []log.KeyValue {
+	if len(l.logAttributes) == 0 && len(l.logAttributeFuncs) == 0 {
+		return nil
+	}
+
+	attrs := make([]log.KeyValue, 0, len(l.logAttributes))
+	attrs = append(attrs, l.logAttributes...)
+	for _, fn := range l.logAttributeFuncs {
+		attrs = append(attrs, fn(ctx)...)
+	}
+	return attrs
 }
 
 func (l *Logger) emitSQL(

--- a/gorm/logger/otel/logger.go
+++ b/gorm/logger/otel/logger.go
@@ -119,26 +119,16 @@ func (l *Logger) emit(ctx context.Context, severity log.Severity, severityText, 
 	record.SetSeverityText(severityText)
 	record.SetBody(log.StringValue(body))
 	record.AddAttributes(attrs...)
-	record.AddAttributes(l.attributes(ctx)...)
+	record.AddAttributes(l.logAttributes...)
+	for _, fn := range l.logAttributeFuncs {
+		record.AddAttributes(fn(ctx)...)
+	}
 
 	l.logger.Emit(ctx, record)
 }
 
 func (l *Logger) enabled(ctx context.Context, severity log.Severity) bool {
 	return l.logger.Enabled(ctx, log.EnabledParameters{Severity: severity})
-}
-
-func (l *Logger) attributes(ctx context.Context) []log.KeyValue {
-	if len(l.logAttributes) == 0 && len(l.logAttributeFuncs) == 0 {
-		return nil
-	}
-
-	attrs := make([]log.KeyValue, 0, len(l.logAttributes))
-	attrs = append(attrs, l.logAttributes...)
-	for _, fn := range l.logAttributeFuncs {
-		attrs = append(attrs, fn(ctx)...)
-	}
-	return attrs
 }
 
 func (l *Logger) emitSQL(

--- a/gorm/logger/otel/logger_test.go
+++ b/gorm/logger/otel/logger_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
+	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm/logger"
 )
 
@@ -91,6 +92,72 @@ func TestInfoEmitsRecord(t *testing.T) {
 	assert.Equal(t, log.StringValue("hello gorm"), provider.logger.record.Body())
 }
 
+type attributeContextKey struct{}
+
+func TestInfoEmitsConfiguredLogAttributes(t *testing.T) {
+	provider := &recordingLoggerProvider{}
+	l := New(
+		WithLoggerProvider(provider),
+		WithLogLevel(logger.Info),
+		WithLogAttributes(log.String("component", "gorm")),
+		WithLogAttributeFuncs(func(ctx context.Context) []log.KeyValue {
+			tenantID, _ := ctx.Value(attributeContextKey{}).(string)
+			return []log.KeyValue{
+				log.String("tenant.id", tenantID),
+			}
+		}),
+	)
+	provider.logger.enabled = true
+
+	ctx := context.WithValue(t.Context(), attributeContextKey{}, "tenant-1")
+	l.Info(ctx, "hello %s", "gorm")
+
+	require.True(t, provider.logger.emitted)
+	attrs := recordAttributes(provider.logger.record)
+	assert.Equal(t, "gorm", attrs["component"].Value.AsString())
+	assert.Equal(t, "tenant-1", attrs["tenant.id"].Value.AsString())
+}
+
+func TestInfoEmitsTraceContext(t *testing.T) {
+	provider := &recordingLoggerProvider{}
+	l := New(
+		WithLoggerProvider(provider),
+		WithLogLevel(logger.Info),
+		WithTraceContext(),
+	)
+	provider.logger.enabled = true
+	traceID := trace.TraceID{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	spanID := trace.SpanID{2, 2, 2, 2, 2, 2, 2, 2}
+	ctx := trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	l.Info(ctx, "hello")
+
+	require.True(t, provider.logger.emitted)
+	attrs := recordAttributes(provider.logger.record)
+	assert.Equal(t, traceID.String(), attrs["trace.id"].Value.AsString())
+	assert.Equal(t, spanID.String(), attrs["span.id"].Value.AsString())
+}
+
+func TestInfoSkipsInvalidTraceContext(t *testing.T) {
+	provider := &recordingLoggerProvider{}
+	l := New(
+		WithLoggerProvider(provider),
+		WithLogLevel(logger.Info),
+		WithTraceContext(),
+	)
+	provider.logger.enabled = true
+
+	l.Info(t.Context(), "hello")
+
+	require.True(t, provider.logger.emitted)
+	attrs := recordAttributes(provider.logger.record)
+	assert.NotContains(t, attrs, "trace.id")
+	assert.NotContains(t, attrs, "span.id")
+}
+
 func TestWarnAndErrorRespectLogLevel(t *testing.T) {
 	provider := &recordingLoggerProvider{}
 	l := New(WithLoggerProvider(provider), WithLogLevel(logger.Error))
@@ -166,6 +233,25 @@ func TestLogMethodsSkipFormattingWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestLogAttributeFuncsAreSkippedWhenDisabled(t *testing.T) {
+	provider := &recordingLoggerProvider{}
+	called := false
+	l := New(
+		WithLoggerProvider(provider),
+		WithLogLevel(logger.Info),
+		WithLogAttributeFuncs(func(context.Context) []log.KeyValue {
+			called = true
+			return []log.KeyValue{log.String("tenant.id", "tenant-1")}
+		}),
+	)
+	provider.logger.enabled = false
+
+	l.Info(t.Context(), "ignored")
+
+	assert.False(t, called)
+	assert.False(t, provider.logger.emitted)
+}
+
 func TestTraceError(t *testing.T) {
 	provider := &recordingLoggerProvider{}
 	l := New(WithLoggerProvider(provider), WithLogLevel(logger.Error))
@@ -237,7 +323,11 @@ func TestTraceSlowSQL(t *testing.T) {
 
 func TestTraceInfo(t *testing.T) {
 	provider := &recordingLoggerProvider{}
-	l := New(WithLoggerProvider(provider), WithLogLevel(logger.Info))
+	l := New(
+		WithLoggerProvider(provider),
+		WithLogLevel(logger.Info),
+		WithLogAttributes(log.String("component", "gorm")),
+	)
 	provider.logger.enabled = true
 
 	l.Trace(t.Context(), time.Now(), func() (string, int64) {
@@ -249,6 +339,7 @@ func TestTraceInfo(t *testing.T) {
 	assert.Equal(t, log.StringValue("gorm.sql"), provider.logger.record.Body())
 	attrs := recordAttributes(provider.logger.record)
 	assert.Equal(t, int64(1), attrs["gorm.rows_affected"].Value.AsInt64())
+	assert.Equal(t, "gorm", attrs["component"].Value.AsString())
 	assert.NotContains(t, attrs, "db.response.returned_rows")
 }
 


### PR DESCRIPTION
## Summary
Add APIs for attaching fixed and context-derived OpenTelemetry log record attributes to the GORM OTel logger.

## Changes
- Add `WithLogAttributes` for fixed log record attributes
- Add `WithLogAttributeFuncs` and `LogAttributeFunc` for context-derived log record attributes
- Add `WithTraceContext` to attach `trace.id` and `span.id` from the current span context
- Apply configured log attributes to all emitted GORM OTel log records
- Update README, package docs, tests, and direct trace dependency metadata

## Motivation
- Make it easy to enrich GORM SQL logs with request, tenant, and trace correlation metadata without custom wrappers
- Keep instrumentation scope attributes and per-record log attributes clearly separated

## Testing
- `go test ./...`
- `make lint/gorm/logger/otel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added log attribute configuration for OpenTelemetry GORM logger, supporting both static attributes and dynamic context-derived attributes per log record
  * Enabled automatic trace context propagation (trace ID/span ID) to log records when available

* **Documentation**
  * Updated usage examples demonstrating how to configure log attributes and enable trace context support

* **Tests**
  * Added comprehensive test coverage for configured log attributes, trace context emission, and attribute function execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->