### PR TITLE
refactor(gorm/logger/otel): remove trace context option

### DIFF
--- a/gorm/logger/otel/README.md
+++ b/gorm/logger/otel/README.md
@@ -48,13 +48,29 @@ func tenantIDFromContext(ctx context.Context) string {
 }
 ```
 
+## Log Records
+
 `Trace` emits SQL log records for errors, slow SQL, and info-level query
-logging. SQL records include `db.query.text`, `gorm.rows_affected`,
-`gorm.elapsed_ms`, and `gorm.event` attributes.
+logging. SQL records include these attributes:
+
+- `db.query.text`
+- `gorm.rows_affected`
+- `gorm.elapsed_ms`
+- `gorm.event`
+
+## Record Not Found
+
 `logger.ErrRecordNotFound` is ignored by default because it is commonly an
-expected query miss rather than an application failure. Use
-`WithIgnoreRecordNotFoundError(false)` to report it as an error log record.
+expected query miss rather than an application failure.
+
+Use `WithIgnoreRecordNotFoundError(false)` to report it as an error log record.
+
+## Attributes
+
 Use `WithLogAttributes` and `WithLogAttributeFuncs` to add fixed or
 context-derived attributes to each emitted log record.
+
+## SQL Parameters
+
 Use `WithParameterizedQueries(true)` to keep GORM from expanding SQL parameter
 values into the rendered query text.

--- a/gorm/logger/otel/README.md
+++ b/gorm/logger/otel/README.md
@@ -34,7 +34,6 @@ func openDB(dialector gorm.Dialector) (*gorm.DB, error) {
 			otel.WithParameterizedQueries(true),
 			otel.WithAttributes(attribute.String("component", "gorm")),
 			otel.WithLogAttributes(log.String("db.system", "mysql")),
-			otel.WithTraceContext(),
 			otel.WithLogAttributeFuncs(func(ctx context.Context) []log.KeyValue {
 				return []log.KeyValue{
 					log.String("tenant.id", tenantIDFromContext(ctx)),
@@ -57,7 +56,5 @@ expected query miss rather than an application failure. Use
 `WithIgnoreRecordNotFoundError(false)` to report it as an error log record.
 Use `WithLogAttributes` and `WithLogAttributeFuncs` to add fixed or
 context-derived attributes to each emitted log record.
-Use `WithTraceContext` to add `trace.id` and `span.id` from the current span
-context when they are available.
 Use `WithParameterizedQueries(true)` to keep GORM from expanding SQL parameter
 values into the rendered query text.

--- a/gorm/logger/otel/config.go
+++ b/gorm/logger/otel/config.go
@@ -7,7 +7,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"
-	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm/logger"
 )
 
@@ -92,26 +91,6 @@ func WithLogAttributeFuncs(funcs ...LogAttributeFunc) Option {
 				c.logAttributeFuncs = append(c.logAttributeFuncs, fn)
 			}
 		}
-	})
-}
-
-// WithTraceContext adds the current span trace and span IDs to each emitted log
-// record when they are available in the log context.
-func WithTraceContext() Option {
-	return WithLogAttributeFuncs(func(ctx context.Context) []log.KeyValue {
-		span := trace.SpanContextFromContext(ctx)
-		if !span.HasTraceID() && !span.HasSpanID() {
-			return nil
-		}
-
-		attrs := make([]log.KeyValue, 0, 2) //nolint:mnd
-		if span.HasTraceID() {
-			attrs = append(attrs, log.String("trace.id", span.TraceID().String()))
-		}
-		if span.HasSpanID() {
-			attrs = append(attrs, log.String("span.id", span.SpanID().String()))
-		}
-		return attrs
 	})
 }
 

--- a/gorm/logger/otel/doc.go
+++ b/gorm/logger/otel/doc.go
@@ -16,7 +16,6 @@
 //			otel.WithLoggerProvider(global.GetLoggerProvider()),
 //			otel.WithLogLevel(logger.Warn),
 //			otel.WithLogAttributes(log.String("component", "gorm")),
-//			otel.WithTraceContext(),
 //		),
 //	})
 package otel

--- a/gorm/logger/otel/go.mod
+++ b/gorm/logger/otel/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/log v0.20.0
-	go.opentelemetry.io/otel/trace v1.44.0
 	gorm.io/gorm v1.31.1
 )
 
@@ -20,6 +19,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/gorm/logger/otel/logger_test.go
+++ b/gorm/logger/otel/logger_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
-	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm/logger"
 )
 
@@ -116,46 +115,6 @@ func TestInfoEmitsConfiguredLogAttributes(t *testing.T) {
 	attrs := recordAttributes(provider.logger.record)
 	assert.Equal(t, "gorm", attrs["component"].Value.AsString())
 	assert.Equal(t, "tenant-1", attrs["tenant.id"].Value.AsString())
-}
-
-func TestInfoEmitsTraceContext(t *testing.T) {
-	provider := &recordingLoggerProvider{}
-	l := New(
-		WithLoggerProvider(provider),
-		WithLogLevel(logger.Info),
-		WithTraceContext(),
-	)
-	provider.logger.enabled = true
-	traceID := trace.TraceID{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
-	spanID := trace.SpanID{2, 2, 2, 2, 2, 2, 2, 2}
-	ctx := trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID: traceID,
-		SpanID:  spanID,
-	}))
-
-	l.Info(ctx, "hello")
-
-	require.True(t, provider.logger.emitted)
-	attrs := recordAttributes(provider.logger.record)
-	assert.Equal(t, traceID.String(), attrs["trace.id"].Value.AsString())
-	assert.Equal(t, spanID.String(), attrs["span.id"].Value.AsString())
-}
-
-func TestInfoSkipsInvalidTraceContext(t *testing.T) {
-	provider := &recordingLoggerProvider{}
-	l := New(
-		WithLoggerProvider(provider),
-		WithLogLevel(logger.Info),
-		WithTraceContext(),
-	)
-	provider.logger.enabled = true
-
-	l.Info(t.Context(), "hello")
-
-	require.True(t, provider.logger.emitted)
-	attrs := recordAttributes(provider.logger.record)
-	assert.NotContains(t, attrs, "trace.id")
-	assert.NotContains(t, attrs, "span.id")
 }
 
 func TestWarnAndErrorRespectLogLevel(t *testing.T) {


### PR DESCRIPTION
## Summary
Remove the `WithTraceContext` helper from the GORM OpenTelemetry logger.

## Changes
- Remove `WithTraceContext` and its tests
- Remove README and package example references to `WithTraceContext`
- Move `go.opentelemetry.io/otel/trace` back to an indirect dependency

## Motivation
- The OpenTelemetry Go SDK already reads the current span context from `Logger.Emit(ctx, record)` and sets the log record trace/span fields
- Avoid duplicating trace/span IDs as regular log attributes by default
- Keep `WithLogAttributeFuncs` as the generic escape hatch for deployments that explicitly want trace/span IDs as attributes

## Testing
- `go test ./...`
- `make lint/gorm/logger/otel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Breaking Changes

* Removed the `WithTraceContext()` configuration option from the OpenTelemetry logger. Trace and span ID attributes will no longer be automatically included in logs. Applications relying on this functionality will require code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->