### PR TITLE
docs: add contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,13 +26,9 @@ Run commands from the repository root unless working in a specific module.
 For focused work, use module-specific Make targets instead of manually changing directories. For example, `make test/cache` tests `cache/`, `make lint/cache` runs tidy plus lint, and `make lint-fix/cache` applies supported fixes.
 
 ## Coding Style & Naming Conventions
-Follow standard Go formatting with tabs and idiomatic package layout. Package names should be short and lowercase; exported identifiers use `CamelCase`. The linter configuration enables formatting checks including `gofumpt` and `goimports`, so run `make lint` before submitting. Keep module boundaries clear: update the nearest `go.mod` and avoid introducing unnecessary dependencies across components.
+Follow standard Go formatting with tabs and idiomatic package layout. Package names should be short and lowercase; exported identifiers use `CamelCase`. The linter configuration enables formatting checks including `gofumpt` and `goimports`, so run `make lint` before submitting.
 
-For new releasable component modules, update the repository release and reporting metadata in the same change. In practice this usually means adding the module path to `versions.yaml` and adding the matching path rewrite to `codecov.yml`. Public modules should include package documentation (`doc.go`), a README when the module is user-facing, Go doc comments for exported identifiers, and a module-local `Version()` when other versioned components follow that pattern.
-
-OpenTelemetry integrations should keep instrumentation scope names stable and aligned with the module path. Prefer official OpenTelemetry semantic convention constants and helper functions over raw attribute strings when they exist; use package-specific attributes only for data that has no suitable semantic convention.
-
-For component configuration design conventions, follow [CONTRIBUTING.md](CONTRIBUTING.md).
+For repository-wide contribution conventions, including module layout, public modules, component configuration, options, testing, and validation, follow [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Testing Guidelines
 Place tests beside the package under test using `*_test.go`. Use Go test naming conventions: `TestXxx`, `BenchmarkXxx`, and `FuzzXxx`. `github.com/stretchr/testify` is available when assertions improve readability. Long-running or integration-style tests should honor `testing.Short()`. Race-sensitive changes should be verified with `make test-race`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ For new releasable component modules, update the repository release and reportin
 
 OpenTelemetry integrations should keep instrumentation scope names stable and aligned with the module path. Prefer official OpenTelemetry semantic convention constants and helper functions over raw attribute strings when they exist; use package-specific attributes only for data that has no suitable semantic convention.
 
+For component configuration design conventions, follow [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Testing Guidelines
 Place tests beside the package under test using `*_test.go`. Use Go test naming conventions: `TestXxx`, `BenchmarkXxx`, and `FuzzXxx`. `github.com/stretchr/testify` is available when assertions improve readability. Long-running or integration-style tests should honor `testing.Short()`. Race-sensitive changes should be verified with `make test-race`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Keep module boundaries explicit:
 - avoid unnecessary dependencies across components
 - keep framework integrations under the framework or component they adapt
 
-Framework integrations should follow the existing package layout. Kratos integrations live under `kratos/`, Hyperf Jet integrations live under `hyperf/jet/`, GORM integrations live under `gorm/`, and OpenTelemetry components live under `otel/` or under the integration package that emits telemetry.
+Framework and library integrations should follow the existing package layout for the integration target. Prefer placing integration code near the component or framework it adapts instead of introducing a new top-level area without a clear repository-wide reason.
 
 ## Design Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,38 @@
 # Contributing
 
-## Component Configuration Design
-For new components and refactors, prefer keeping configuration state and option parsing in a package-local `config.go`. The file should define the internal `config` type, default values, the public `Option` contract, `optionFunc`, `WithXxx` option helpers, `newConfig(...)`, and small config-owned factory helpers such as `newLogger(...)`, `newResource(...)`, or `newTracerProvider(...)` when they are driven by configuration.
+This document defines contribution conventions for this repository. It applies to new components, component refactors, public API design, and tests across all modules in this repository.
 
-Keep runtime types focused on lifecycle and behavior. For example, a `Client`, `Logger`, or `Middleware` should generally call into its `config` for configured dependencies instead of carrying many option fields or scattered defaulting logic directly.
+The goal is to keep components consistent, maintainable, and predictable for both users and maintainers.
 
-Use an interface-based option contract with an unexported apply method:
+## Design Principles
+
+- Keep component boundaries clear. A component should own its configuration, runtime behavior, and tests within its package or module boundary.
+- Prefer explicit behavior over implicit side effects. Errors should be returned where they occur and should not be hidden until later runtime behavior.
+- Keep public APIs small and stable. Add exported identifiers only when they describe a real user-facing capability.
+- Prefer established repository patterns over new local styles unless the component has a clear reason to differ.
+- Avoid over-design. Add abstractions only when they reduce real complexity, remove meaningful duplication, or make public behavior easier to understand.
+
+## Component Configuration
+
+Configuration state and option parsing should live in a package-local `config.go` when a component has configurable behavior.
+
+Use `config.go` for:
+
+- the internal `config` type
+- default values
+- the public `Option` contract
+- the private `optionFunc` implementation
+- public `WithXxx(...)` option helpers
+- `newConfig(...)`
+- small config-owned factory helpers such as `newLogger(...)`, `newResource(...)`, or `newTracerProvider(...)`
+
+Runtime types should focus on lifecycle and behavior. A `Client`, `Logger`, `Middleware`, or similar type should generally call into its `config` for configured dependencies instead of carrying many option fields or scattered defaulting logic directly.
+
+Config-owned factory helpers are appropriate when the created value is determined by configuration. Keep business logic, request handling, and runtime orchestration outside `config.go`.
+
+## Options
+
+Use an interface-based option contract with an unexported apply method by default:
 
 ```go
 type Option interface {
@@ -19,19 +46,65 @@ func (f optionFunc) apply(c *config) {
 }
 ```
 
-Then implement public options as `WithXxx(...) Option` functions that return `optionFunc`. Place these option functions immediately after `optionFunc.apply`, followed by `newConfig(...)` and config helper methods. Prefer this form over exporting or aliasing a raw `func(*config)` option type because it keeps option construction controlled inside the package while still allowing future specialized option implementations.
+Public option helpers should use `WithXxx(...) Option` naming and return `optionFunc`:
 
-When a component needs option-time validation or setup that can fail, it is acceptable for that package to use an error-returning option contract instead:
+```go
+func WithServiceName(name string) Option {
+	return optionFunc(func(c *config) {
+		c.serviceName = name
+	})
+}
+```
+
+Place option definitions in this order:
+
+1. `Option`
+2. `optionFunc`
+3. `optionFunc.apply`
+4. public `WithXxx(...)` helpers
+5. `newConfig(...)`
+6. config helper methods
+
+Prefer this form over exporting or aliasing a raw `func(*config)` option type. It keeps option construction controlled inside the package while leaving room for future specialized option implementations.
+
+When option application has a real failure path, use an error-returning option contract:
 
 ```go
 type Option interface {
 	apply(*config) error
 }
+
+type optionFunc func(*config) error
+
+func (f optionFunc) apply(c *config) error {
+	return f(c)
+}
 ```
 
-Choose the non-error form for simple assignment and defaulting. Choose the error-returning form only when the component has a real failure path during option application, and keep validation errors explicit rather than hiding them in later runtime behavior.
+Use the non-error form for simple assignment and defaulting. Use the error-returning form when option-time validation or setup can fail. Return validation errors explicitly instead of deferring them to later runtime behavior.
 
 ## Testing
-Use `github.com/stretchr/testify` when it improves test readability, especially for grouped assertions, error checks, and setup requirements. Prefer `require` for conditions that must stop the current test before continuing, such as constructor errors, nil checks before dereferencing, or setup failures. Prefer `assert` for independent value checks where the test can report multiple failures in one run.
 
-Use Go's standard `testing` package conventions for test structure and naming. Keep tests close to the package under test, use table tests when they make behavior easier to scan, and prefer explicit assertions such as `require.ErrorIs`, `assert.ErrorIs`, `require.NoError`, and `assert.Equal` over manual boolean checks when they clarify intent.
+Tests should live beside the package under test and follow Go's standard `testing` package conventions.
+
+Use `github.com/stretchr/testify` when it improves readability. This is encouraged for grouped assertions, error checks, and setup requirements, but it is not required for trivial standard-library checks.
+
+Use `require` for conditions that must stop the current test before continuing, including:
+
+- constructor errors
+- setup failures
+- nil checks before dereferencing
+- preconditions for later assertions
+
+Use `assert` for independent value checks where the test can continue and report multiple failures in one run.
+
+Prefer explicit assertions that describe intent:
+
+- `require.NoError`
+- `require.ErrorIs`
+- `assert.ErrorIs`
+- `assert.Equal`
+- `assert.Same`
+- `assert.Contains`
+
+Use table tests when they make behavior easier to scan. Keep each case focused on one observable behavior, and avoid broad table tests that hide setup complexity or make failures hard to diagnose.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ This document defines contribution conventions for this repository. It applies t
 
 The goal is to keep components consistent, maintainable, and predictable for both users and maintainers.
 
+## Repository Structure
+
+This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3`, and many component directories have their own `go.mod` files.
+
+Keep module boundaries explicit:
+
+- update the nearest `go.mod` for the module being changed
+- avoid unnecessary dependencies across components
+- keep framework integrations under the framework or component they adapt
+
+Framework integrations should follow the existing package layout. Kratos integrations live under `kratos/`, Hyperf Jet integrations live under `hyperf/jet/`, GORM integrations live under `gorm/`, and OpenTelemetry components live under `otel/` or under the integration package that emits telemetry.
+
 ## Design Principles
 
 - Keep component boundaries clear. A component should own its configuration, runtime behavior, and tests within its package or module boundary.
@@ -11,6 +23,21 @@ The goal is to keep components consistent, maintainable, and predictable for bot
 - Keep public APIs small and stable. Add exported identifiers only when they describe a real user-facing capability.
 - Prefer established repository patterns over new local styles unless the component has a clear reason to differ.
 - Avoid over-design. Add abstractions only when they reduce real complexity, remove meaningful duplication, or make public behavior easier to understand.
+
+## Public Modules
+
+New releasable component modules should update repository release and reporting metadata in the same change.
+
+For public modules:
+
+- add the module path to `versions.yaml`
+- add the matching Codecov path rewrite to `codecov.yml`
+- include package documentation in `doc.go`
+- include a `README.md` when the module is intended for direct use
+- add Go doc comments for exported identifiers
+- provide a module-local `Version()` helper when the component exposes or reports version metadata
+
+Public modules should be usable from Go documentation alone. README files should focus on installation, common usage, and behavior that is not obvious from type signatures.
 
 ## Component Configuration
 
@@ -108,3 +135,27 @@ Prefer explicit assertions that describe intent:
 - `assert.Contains`
 
 Use table tests when they make behavior easier to scan. Keep each case focused on one observable behavior, and avoid broad table tests that hide setup complexity or make failures hard to diagnose.
+
+## Validation
+
+Run commands from the repository root unless working in a specific module.
+
+Use repository-level commands for broad changes:
+
+- `make build`
+- `make test`
+- `make test-short`
+- `make test-race`
+- `make test-coverage`
+- `make lint`
+
+Use module-specific Make targets for focused work, such as `make test/cache`, `make lint/cache`, and `make lint-fix/cache`.
+
+Run `make lint` before submitting broad or public API changes. It runs `go mod tidy` across modules and then `golangci-lint`.
+
+For protobuf changes, use the Buf targets defined by the repository:
+
+- `make buf-lint`
+- `make buf-build`
+- `make buf-validate`
+- `make buf-generate`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,8 @@ type Option interface {
 ```
 
 Choose the non-error form for simple assignment and defaulting. Choose the error-returning form only when the component has a real failure path during option application, and keep validation errors explicit rather than hiding them in later runtime behavior.
+
+## Testing
+Use `github.com/stretchr/testify` when it improves test readability, especially for grouped assertions, error checks, and setup requirements. Prefer `require` for conditions that must stop the current test before continuing, such as constructor errors, nil checks before dereferencing, or setup failures. Prefer `assert` for independent value checks where the test can report multiple failures in one run.
+
+Use Go's standard `testing` package conventions for test structure and naming. Keep tests close to the package under test, use table tests when they make behavior easier to scan, and prefer explicit assertions such as `require.ErrorIs`, `assert.ErrorIs`, `require.NoError`, and `assert.Equal` over manual boolean checks when they clarify intent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+## Component Configuration Design
+For new components and refactors, prefer keeping configuration state and option parsing in a package-local `config.go`. The file should define the internal `config` type, default values, the public `Option` contract, `optionFunc`, `WithXxx` option helpers, `newConfig(...)`, and small config-owned factory helpers such as `newLogger(...)`, `newResource(...)`, or `newTracerProvider(...)` when they are driven by configuration.
+
+Keep runtime types focused on lifecycle and behavior. For example, a `Client`, `Logger`, or `Middleware` should generally call into its `config` for configured dependencies instead of carrying many option fields or scattered defaulting logic directly.
+
+Use an interface-based option contract with an unexported apply method:
+
+```go
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+```
+
+Then implement public options as `WithXxx(...) Option` functions that return `optionFunc`. Place these option functions immediately after `optionFunc.apply`, followed by `newConfig(...)` and config helper methods. Prefer this form over exporting or aliasing a raw `func(*config)` option type because it keeps option construction controlled inside the package while still allowing future specialized option implementations.
+
+When a component needs option-time validation or setup that can fail, it is acceptable for that package to use an error-returning option contract instead:
+
+```go
+type Option interface {
+	apply(*config) error
+}
+```
+
+Choose the non-error form for simple assignment and defaulting. Choose the error-returning form only when the component has a real failure path during option application, and keep validation errors explicit rather than hiding them in later runtime behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,14 @@ This document defines contribution conventions for this repository. It applies t
 
 The goal is to keep components consistent, maintainable, and predictable for both users and maintainers.
 
-## Repository Structure
+## Module Layout
 
 This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3`, and many component directories have their own `go.mod` files.
 
 Keep module boundaries explicit:
 
 - update the nearest `go.mod` for the module being changed
+- keep module paths in `go.mod` suffixed with `/v3`
 - avoid unnecessary dependencies across components
 - keep framework integrations under the framework or component they adapt
 
@@ -53,7 +54,7 @@ Use `config.go` for:
 - `newConfig(...)`
 - small config-owned factory helpers such as `newLogger(...)`, `newResource(...)`, or `newTracerProvider(...)`
 
-Runtime types should focus on lifecycle and behavior. A `Client`, `Logger`, `Middleware`, or similar type should generally call into its `config` for configured dependencies instead of carrying many option fields or scattered defaulting logic directly.
+Runtime types should focus on lifecycle and behavior. The primary runtime type in a component should generally call into its `config` for configured dependencies instead of carrying many option fields or scattered defaulting logic directly.
 
 Config-owned factory helpers are appropriate when the created value is determined by configuration. Keep business logic, request handling, and runtime orchestration outside `config.go`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 go get github.com/go-fries/fries/v3
 ```
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and component design conventions.
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.


### PR DESCRIPTION
## Summary
Add a repository-level contribution guide for stable component design and testing conventions.

## Changes
- Add CONTRIBUTING.md with module layout, public module, component configuration, option, testing, and validation guidance
- Link the contribution guide from README.md
- Update AGENTS.md to defer repository-wide contribution conventions to CONTRIBUTING.md

## Motivation
- Make stable project conventions visible to open-source contributors and future maintainers

## Testing
- Not run; documentation-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Created comprehensive contribution guidelines documentation for the repository
  * Updated README to include reference to contribution guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->