### PR TITLE
refactor(strings)!: expand string helpers and remove InSlice

### DIFF
--- a/strings/README.md
+++ b/strings/README.md
@@ -30,7 +30,6 @@ func main() {
 ## Helpers
 
 - `Is` matches a string against a `*` wildcard pattern.
-- `InSlice` reports whether a string exists in a slice.
 - `MD5` and `SHA1` return lowercase hexadecimal hashes.
 - `Reverse` reverses a string by Unicode code points.
 - `Replace` replaces all occurrences of a substring.

--- a/strings/README.md
+++ b/strings/README.md
@@ -1,0 +1,43 @@
+# Strings
+
+This package provides string helper functions for common application code.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/strings/v3
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-fries/fries/strings/v3"
+)
+
+func main() {
+	fmt.Println(strings.Is("*.example.com", "api.example.com"))
+	fmt.Println(strings.MD5("abc"))
+	fmt.Println(strings.Reverse("张三"))
+	fmt.Println(strings.After("Hello, World!", ","))
+}
+```
+
+## Helpers
+
+- `Is` matches a string against a `*` wildcard pattern.
+- `InSlice` reports whether a string exists in a slice.
+- `MD5` and `SHA1` return lowercase hexadecimal hashes.
+- `Reverse` reverses a string by Unicode code points.
+- `Replace` replaces all occurrences of a substring.
+- `Shuffle` randomly reorders characters.
+- `Random` returns a random alphabetic string.
+- `Len` returns the Unicode code point length.
+- `IsUUID` validates UUID strings.
+- `UUID` returns a new UUID string.
+- `After` and `Before` split around the first occurrence of a separator.
+- `SubstrCount` counts substring occurrences in a byte-indexed range.

--- a/strings/README.md
+++ b/strings/README.md
@@ -34,10 +34,14 @@ func main() {
 - `MD5` and `SHA1` return lowercase hexadecimal hashes.
 - `Reverse` reverses a string by Unicode code points.
 - `Replace` replaces all occurrences of a substring.
+- `ReplaceFirst` and `ReplaceLast` replace only the first or last occurrence.
 - `Shuffle` randomly reorders characters.
 - `Random` returns a random alphabetic string.
 - `Len` returns the Unicode code point length.
 - `IsUUID` validates UUID strings.
 - `UUID` returns a new UUID string.
-- `After` and `Before` split around the first occurrence of a separator.
+- `EnsurePrefix` and `EnsureSuffix` add a prefix or suffix exactly once.
+- `After`, `AfterLast`, `Before`, and `BeforeLast` split around a separator.
+- `Between` and `BetweenFirst` return text between boundary strings.
+- `NormalizeSpace` trims and collapses whitespace runs.
 - `SubstrCount` counts substring occurrences in a byte-indexed range.

--- a/strings/doc.go
+++ b/strings/doc.go
@@ -1,0 +1,6 @@
+// Package strings provides string helper functions.
+//
+// It includes helpers for wildcard matching, hashing, Unicode-aware length and
+// reversal, UUID generation and validation, random strings, and substring
+// extraction.
+package strings

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"regexp"
 	"slices"
 	"strings"
@@ -114,7 +114,7 @@ func Shuffle(s string) string {
 
 // Random returns a random alphabetic string with the specified length.
 //
-// Random uses math/rand and is not suitable for security-sensitive values.
+// Random uses math/rand/v2 and is not suitable for security-sensitive values.
 //
 // Example:
 //
@@ -126,7 +126,7 @@ func Random(length int) string {
 	b := make([]rune, length)
 
 	for i := range b {
-		b[i] = letters[rand.Intn(lettersLength)]
+		b[i] = letters[rand.IntN(lettersLength)]
 	}
 
 	return string(b)

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -3,7 +3,7 @@ package strings
 import (
 	"crypto/md5"
 	"crypto/sha1"
-	"fmt"
+	"encoding/hex"
 	"math/rand/v2"
 	"regexp"
 	"slices"
@@ -83,7 +83,7 @@ func InSlice(slice []string, s string) bool {
 func MD5(s string) string {
 	sm := md5.Sum([]byte(s))
 
-	return fmt.Sprintf("%x", sm)
+	return hex.EncodeToString(sm[:])
 }
 
 // SHA1 returns the SHA-1 hash of s as a lowercase hexadecimal string.
@@ -94,7 +94,7 @@ func MD5(s string) string {
 func SHA1(s string) string {
 	sm := sha1.Sum([]byte(s))
 
-	return fmt.Sprintf("%x", sm)
+	return hex.EncodeToString(sm[:])
 }
 
 // Reverse returns s with its Unicode code points in reverse order.

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -142,6 +142,10 @@ func Shuffle(s string) string {
 //
 //	Random(10) // "qujrlkhyqr"
 func Random(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
 	letters := []rune(randomLetters)
 	lettersLength := len(letters)
 

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"math/rand/v2"
 	"regexp"
-	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -64,15 +63,6 @@ func Is(pattern, value string) bool {
 	}
 
 	return patternIndex == len(pattern)
-}
-
-// InSlice reports whether s exists in slice.
-//
-// Example:
-//
-//	InSlice([]string{"1", "2"}, "1") // true
-func InSlice(slice []string, s string) bool {
-	return slices.Contains(slice, s)
 }
 
 // MD5 returns the MD5 hash of s as a lowercase hexadecimal string.

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -33,15 +33,37 @@ func Is(pattern, value string) bool {
 		return true
 	}
 
-	pattern = regexp.QuoteMeta(pattern)
-	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
+	patternIndex, valueIndex := 0, 0
+	starIndex, matchIndex := -1, 0
 
-	match, err := regexp.MatchString("^"+pattern+"$", value)
-	if err != nil {
-		return false
+	for valueIndex < len(value) {
+		if patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+			starIndex = patternIndex
+			matchIndex = valueIndex
+			patternIndex++
+			continue
+		}
+
+		if patternIndex < len(pattern) && pattern[patternIndex] == value[valueIndex] {
+			patternIndex++
+			valueIndex++
+			continue
+		}
+
+		if starIndex == -1 {
+			return false
+		}
+
+		patternIndex = starIndex + 1
+		matchIndex++
+		valueIndex = matchIndex
 	}
 
-	return match
+	for patternIndex < len(pattern) && pattern[patternIndex] == '*' {
+		patternIndex++
+	}
+
+	return patternIndex == len(pattern)
 }
 
 // InSlice reports whether s exists in slice.

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -228,6 +228,9 @@ func SubstrCount(haystack, needle string, offset int, lengths ...int) int {
 
 	var end int
 	if len(lengths) > 0 {
+		if lengths[0] < 0 {
+			return 0
+		}
 		end = min(offset+lengths[0], len(haystack))
 	} else {
 		end = len(haystack)

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -119,6 +119,40 @@ func Replace(s, from, to string) string {
 	return strings.NewReplacer(from, to).Replace(s)
 }
 
+// ReplaceFirst replaces the first occurrence of from in s with to.
+//
+// If from is empty or not found, ReplaceFirst returns s unchanged.
+//
+// Example:
+//
+//	ReplaceFirst("the quick brown fox", "the", "a") // "a quick brown fox"
+func ReplaceFirst(s, from, to string) string {
+	if from == "" {
+		return s
+	}
+	return strings.Replace(s, from, to, 1)
+}
+
+// ReplaceLast replaces the last occurrence of from in s with to.
+//
+// If from is empty or not found, ReplaceLast returns s unchanged.
+//
+// Example:
+//
+//	ReplaceLast("the quick brown fox jumps over the lazy dog", "the", "a") // "the quick brown fox jumps over a lazy dog"
+func ReplaceLast(s, from, to string) string {
+	if from == "" {
+		return s
+	}
+
+	index := strings.LastIndex(s, from)
+	if index == -1 {
+		return s
+	}
+
+	return s[:index] + to + s[index+len(from):]
+}
+
 // Shuffle returns s with its characters in random order.
 //
 // Example:
@@ -178,6 +212,36 @@ func UUID() string {
 	return uuid.New().String()
 }
 
+// EnsurePrefix returns s with prefix prepended exactly once.
+//
+// If prefix is empty or s already starts with prefix, EnsurePrefix returns s
+// unchanged.
+//
+// Example:
+//
+//	EnsurePrefix("api.example.com", "https://") // "https://api.example.com"
+func EnsurePrefix(s, prefix string) string {
+	if prefix == "" || strings.HasPrefix(s, prefix) {
+		return s
+	}
+	return prefix + s
+}
+
+// EnsureSuffix returns s with suffix appended exactly once.
+//
+// If suffix is empty or s already ends with suffix, EnsureSuffix returns s
+// unchanged.
+//
+// Example:
+//
+//	EnsureSuffix("api.example.com", "/") // "api.example.com/"
+func EnsureSuffix(s, suffix string) string {
+	if suffix == "" || strings.HasSuffix(s, suffix) {
+		return s
+	}
+	return s + suffix
+}
+
 // After returns the remainder of subject after the first occurrence of search.
 //
 // If search is empty or not found, After returns subject unchanged.
@@ -197,6 +261,26 @@ func After(subject, search string) string {
 	return after
 }
 
+// AfterLast returns the remainder of subject after the last occurrence of search.
+//
+// If search is empty or not found, AfterLast returns subject unchanged.
+//
+// Example:
+//
+//	AfterLast("path/to/file.go", "/") // "file.go"
+func AfterLast(subject, search string) string {
+	if search == "" {
+		return subject
+	}
+
+	index := strings.LastIndex(subject, search)
+	if index == -1 {
+		return subject
+	}
+
+	return subject[index+len(search):]
+}
+
 // Before returns the portion of subject before the first occurrence of search.
 //
 // If search is empty or not found, Before returns subject unchanged.
@@ -214,6 +298,86 @@ func Before(subject, search string) string {
 		return subject
 	}
 	return before
+}
+
+// BeforeLast returns the portion of subject before the last occurrence of search.
+//
+// If search is empty or not found, BeforeLast returns subject unchanged.
+//
+// Example:
+//
+//	BeforeLast("path/to/file.go", "/") // "path/to"
+func BeforeLast(subject, search string) string {
+	if search == "" {
+		return subject
+	}
+
+	index := strings.LastIndex(subject, search)
+	if index == -1 {
+		return subject
+	}
+
+	return subject[:index]
+}
+
+// Between returns the portion of subject between the first occurrence of from
+// and the last following occurrence of to.
+//
+// If from or to is empty, or either boundary is not found, Between returns
+// subject unchanged.
+//
+// Example:
+//
+//	Between("[a] [b]", "[", "]") // "a] [b"
+func Between(subject, from, to string) string {
+	return between(subject, from, to, true)
+}
+
+// BetweenFirst returns the portion of subject between the first occurrence of
+// from and the first following occurrence of to.
+//
+// If from or to is empty, or either boundary is not found, BetweenFirst returns
+// subject unchanged.
+//
+// Example:
+//
+//	BetweenFirst("[a] [b]", "[", "]") // "a"
+func BetweenFirst(subject, from, to string) string {
+	return between(subject, from, to, false)
+}
+
+func between(subject, from, to string, last bool) string {
+	if from == "" || to == "" {
+		return subject
+	}
+
+	start := strings.Index(subject, from)
+	if start == -1 {
+		return subject
+	}
+
+	offset := start + len(from)
+	after := subject[offset:]
+
+	end := strings.Index(after, to)
+	if last {
+		end = strings.LastIndex(after, to)
+	}
+	if end == -1 {
+		return subject
+	}
+
+	return after[:end]
+}
+
+// NormalizeSpace returns s with leading and trailing whitespace removed and
+// each internal run of whitespace replaced by a single space.
+//
+// Example:
+//
+//	NormalizeSpace("  hello \n world  ") // "hello world"
+func NormalizeSpace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // SubstrCount returns the number of non-overlapping instances of needle in

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -20,8 +20,9 @@ const (
 
 var uuidRegex = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
-// Is returns true if the value matches the pattern.
-// The pattern can contain the wildcard character *.
+// Is reports whether value matches pattern.
+// The pattern can contain the wildcard character *, which matches any sequence
+// of characters.
 //
 // Example:
 //
@@ -43,7 +44,7 @@ func Is(pattern, value string) bool {
 	return match
 }
 
-// InSlice checks if a string is in a string slice.
+// InSlice reports whether s exists in slice.
 //
 // Example:
 //
@@ -52,7 +53,7 @@ func InSlice(slice []string, s string) bool {
 	return slices.Contains(slice, s)
 }
 
-// MD5 returns the md5 hash of a string.
+// MD5 returns the MD5 hash of s as a lowercase hexadecimal string.
 //
 // Example:
 //
@@ -63,7 +64,7 @@ func MD5(s string) string {
 	return fmt.Sprintf("%x", sm)
 }
 
-// SHA1 returns the sha1 hash of a string.
+// SHA1 returns the SHA-1 hash of s as a lowercase hexadecimal string.
 //
 // Example:
 //
@@ -74,7 +75,7 @@ func SHA1(s string) string {
 	return fmt.Sprintf("%x", sm)
 }
 
-// Reverse returns a string with its characters in reverse order.
+// Reverse returns s with its Unicode code points in reverse order.
 //
 // Example:
 //
@@ -87,7 +88,7 @@ func Reverse(s string) string {
 	return string(runes)
 }
 
-// Replace replaces all occurrences of one substring with another.
+// Replace replaces all occurrences of from in s with to.
 //
 // Example:
 //
@@ -96,7 +97,7 @@ func Replace(s, from, to string) string {
 	return strings.NewReplacer(from, to).Replace(s)
 }
 
-// Shuffle returns a string with its characters in random order.
+// Shuffle returns s with its characters in random order.
 //
 // Example:
 //
@@ -111,7 +112,9 @@ func Shuffle(s string) string {
 	return strings.Join(ss, "")
 }
 
-// Random returns a random string with the specified length.
+// Random returns a random alphabetic string with the specified length.
+//
+// Random uses math/rand and is not suitable for security-sensitive values.
 //
 // Example:
 //
@@ -129,8 +132,7 @@ func Random(length int) string {
 	return string(b)
 }
 
-// Len returns the length of a string.
-// Support chinese characters.
+// Len returns the number of Unicode code points in s.
 //
 // Example:
 //
@@ -145,13 +147,14 @@ func IsUUID(str string) bool {
 	return uuidRegex.MatchString(str)
 }
 
-// UUID generate uuid string
+// UUID returns a new UUID string.
 func UUID() string {
 	return uuid.New().String()
 }
 
-// After Return the remainder of a string after a given value.
-// Support chinese characters.
+// After returns the remainder of subject after the first occurrence of search.
+//
+// If search is empty or not found, After returns subject unchanged.
 //
 // Example:
 //
@@ -168,13 +171,14 @@ func After(subject, search string) string {
 	return after
 }
 
-// Before Get the portion of a string before the first occurrence of a given value.
-// Support chinese characters.
+// Before returns the portion of subject before the first occurrence of search.
+//
+// If search is empty or not found, Before returns subject unchanged.
 //
 // Example:
 //
-//	After("Hello, World!", ",") //  Hello
-//	After("张三李四", "李") // 张三
+//	Before("Hello, World!", ",") // Hello
+//	Before("张三李四", "李") // 张三
 func Before(subject, search string) string {
 	if search == "" {
 		return subject
@@ -186,7 +190,10 @@ func Before(subject, search string) string {
 	return before
 }
 
-// SubstrCount Returns the number of substring occurrences.
+// SubstrCount returns the number of non-overlapping instances of needle in
+// haystack.
+//
+// The offset and optional length arguments are byte indexes.
 //
 // Example:
 //

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -50,6 +50,18 @@ func TestReplace(t *testing.T) {
 	assert.Equal(t, "bbbbcc", Replace("aabbcc", "a", "b"))
 }
 
+func TestReplaceFirst(t *testing.T) {
+	assert.Equal(t, "a quick brown fox", ReplaceFirst("the quick brown fox", "the", "a"))
+	assert.Equal(t, "the quick brown fox", ReplaceFirst("the quick brown fox", "", "a"))
+	assert.Equal(t, "the quick brown fox", ReplaceFirst("the quick brown fox", "cat", "a"))
+}
+
+func TestReplaceLast(t *testing.T) {
+	assert.Equal(t, "the quick brown fox jumps over a lazy dog", ReplaceLast("the quick brown fox jumps over the lazy dog", "the", "a"))
+	assert.Equal(t, "the quick brown fox", ReplaceLast("the quick brown fox", "", "a"))
+	assert.Equal(t, "the quick brown fox", ReplaceLast("the quick brown fox", "cat", "a"))
+}
+
 func TestStrShuffle(t *testing.T) {
 	assert.True(t, InSlice([]string{"abc", "acb", "bac", "bca", "cab", "cba"}, Shuffle("abc")))
 }
@@ -87,6 +99,18 @@ func TestUUID(t *testing.T) {
 	assert.True(t, IsUUID(uuid))
 }
 
+func TestEnsurePrefix(t *testing.T) {
+	assert.Equal(t, "https://api.example.com", EnsurePrefix("api.example.com", "https://"))
+	assert.Equal(t, "https://api.example.com", EnsurePrefix("https://api.example.com", "https://"))
+	assert.Equal(t, "api.example.com", EnsurePrefix("api.example.com", ""))
+}
+
+func TestEnsureSuffix(t *testing.T) {
+	assert.Equal(t, "api.example.com/", EnsureSuffix("api.example.com", "/"))
+	assert.Equal(t, "api.example.com/", EnsureSuffix("api.example.com/", "/"))
+	assert.Equal(t, "api.example.com", EnsureSuffix("api.example.com", ""))
+}
+
 func TestAfter(t *testing.T) {
 	tests := []struct {
 		name, s, sep, want string
@@ -103,6 +127,22 @@ func TestAfter(t *testing.T) {
 	}
 }
 
+func TestAfterLast(t *testing.T) {
+	tests := []struct {
+		name, s, sep, want string
+	}{
+		{"", "path/to/file.go", "/", "file.go"},
+		{"", "path/to/file.go", "", "path/to/file.go"},
+		{"", "", "Hello", ""},
+		{"", "张三李四张三", "张", "三"},
+		{"", "张三李四", "王", "张三李四"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, AfterLast(tt.s, tt.sep))
+	}
+}
+
 func TestBefore(t *testing.T) {
 	tests := []struct {
 		name, s, sep, want string
@@ -116,6 +156,62 @@ func TestBefore(t *testing.T) {
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, Before(tt.s, tt.sep))
 	}
+}
+
+func TestBeforeLast(t *testing.T) {
+	tests := []struct {
+		name, s, sep, want string
+	}{
+		{"", "path/to/file.go", "/", "path/to"},
+		{"", "path/to/file.go", "", "path/to/file.go"},
+		{"", "", "Hello", ""},
+		{"", "张三李四张三", "张", "张三李四"},
+		{"", "张三李四", "王", "张三李四"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, BeforeLast(tt.s, tt.sep))
+	}
+}
+
+func TestBetween(t *testing.T) {
+	tests := []struct {
+		name, s, from, to, want string
+	}{
+		{"", "[a] [b]", "[", "]", "a] [b"},
+		{"", "Hello [World]!", "[", "]", "World"},
+		{"", "Hello World!", "[", "]", "Hello World!"},
+		{"", "Hello [World!", "[", "]", "Hello [World!"},
+		{"", "Hello [World]!", "", "]", "Hello [World]!"},
+		{"", "张三[李四]王五[赵六]", "[", "]", "李四]王五[赵六"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, Between(tt.s, tt.from, tt.to))
+	}
+}
+
+func TestBetweenFirst(t *testing.T) {
+	tests := []struct {
+		name, s, from, to, want string
+	}{
+		{"", "[a] [b]", "[", "]", "a"},
+		{"", "Hello [World]!", "[", "]", "World"},
+		{"", "Hello World!", "[", "]", "Hello World!"},
+		{"", "Hello [World!", "[", "]", "Hello [World!"},
+		{"", "Hello [World]!", "[", "", "Hello [World]!"},
+		{"", "张三[李四]王五[赵六]", "[", "]", "李四"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, BetweenFirst(tt.s, tt.from, tt.to))
+	}
+}
+
+func TestNormalizeSpace(t *testing.T) {
+	assert.Equal(t, "hello world", NormalizeSpace("  hello \n world  "))
+	assert.Equal(t, "张三 李四", NormalizeSpace("张三\t\n李四"))
+	assert.Empty(t, NormalizeSpace(" \t\n "))
 }
 
 func TestSubstrCount(t *testing.T) {

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -21,6 +21,10 @@ func TestIs(t *testing.T) {
 	assert.False(t, Is("*dd/d", "dd/"))
 	assert.True(t, Is("v1.2.*", "v1.2.3"))
 	assert.False(t, Is("v1.2.*", "v1x2x3"))
+	assert.True(t, Is("a+b", "a+b"))
+	assert.False(t, Is("a+b", "ab"))
+	assert.True(t, Is("[abc]*", "[abc]d"))
+	assert.True(t, Is("张*", "张三"))
 }
 
 func TestInSlice(t *testing.T) {

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -121,6 +121,7 @@ func TestSubstrCount(t *testing.T) {
 	assert.Equal(t, 5, SubstrCount("babababbaaba", "a", 0, 10))
 	assert.Equal(t, 0, SubstrCount("babababbaaba", "a", -1, 10))
 	assert.Equal(t, 0, SubstrCount("babababbaaba", "a", 15, 10))
+	assert.Equal(t, 0, SubstrCount("babababbaaba", "a", 1, -1))
 	assert.Equal(t, 6, SubstrCount("babababbaaba", "a", 0, Len("babababbaaba")))
 	assert.Equal(t, 2, SubstrCount("121212312", "1", 1, 5))
 	assert.Equal(t, 4, SubstrCount("121212312", "1", 0, 100))

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -1,6 +1,7 @@
 package strings
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,13 +26,6 @@ func TestIs(t *testing.T) {
 	assert.False(t, Is("a+b", "ab"))
 	assert.True(t, Is("[abc]*", "[abc]d"))
 	assert.True(t, Is("张*", "张三"))
-}
-
-func TestInSlice(t *testing.T) {
-	assert.True(t, InSlice([]string{"1", "2"}, "1"))
-	assert.True(t, InSlice([]string{"1", "2"}, "2"))
-	assert.False(t, InSlice([]string{"1", "2"}, "3"))
-	assert.False(t, InSlice([]string{"1", "2"}, "12"))
 }
 
 func TestMD5(t *testing.T) {
@@ -62,8 +56,8 @@ func TestReplaceLast(t *testing.T) {
 	assert.Equal(t, "the quick brown fox", ReplaceLast("the quick brown fox", "cat", "a"))
 }
 
-func TestStrShuffle(t *testing.T) {
-	assert.True(t, InSlice([]string{"abc", "acb", "bac", "bca", "cab", "cba"}, Shuffle("abc")))
+func TestShuffle(t *testing.T) {
+	assert.True(t, slices.Contains([]string{"abc", "acb", "bac", "bca", "cab", "cba"}, Shuffle("abc")))
 }
 
 func TestRandom(t *testing.T) {

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -62,6 +62,7 @@ func TestRandom(t *testing.T) {
 		assert.Contains(t, randomLetters, string(r))
 	}
 	assert.Empty(t, Random(0))
+	assert.Empty(t, Random(-1))
 }
 
 func TestLength(t *testing.T) {

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -55,11 +55,13 @@ func TestStrShuffle(t *testing.T) {
 }
 
 func TestRandom(t *testing.T) {
-	r1, r2 := Random(10), Random(10)
+	random := Random(10)
 
-	assert.Equal(t, 10, len(r1))
-	assert.Equal(t, 10, len(r2))
-	assert.NotEqual(t, r1, r2)
+	assert.Len(t, random, 10)
+	for _, r := range random {
+		assert.Contains(t, randomLetters, string(r))
+	}
+	assert.Empty(t, Random(0))
 }
 
 func TestLength(t *testing.T) {

--- a/strings/version.go
+++ b/strings/version.go
@@ -1,0 +1,6 @@
+package strings
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "3.14.0"
+}

--- a/strings/version_test.go
+++ b/strings/version_test.go
@@ -1,0 +1,20 @@
+package strings_test
+
+import (
+	"regexp"
+	"testing"
+
+	friesstrings "github.com/go-fries/fries/strings/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := friesstrings.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}


### PR DESCRIPTION
## Summary
Refine the strings package with package documentation, new helper functions inspired by Laravel/Hyperf string utilities, and small robustness improvements.

## Changes
- Add package README, package documentation, and a module-local Version helper
- Add string helpers for first/last replacement, prefix/suffix ensuring, before/after-last extraction, between extraction, and whitespace normalization
- Replace regexp-backed wildcard matching with a linear matcher and move random helpers to math/rand/v2
- Harden Random and SubstrCount edge cases and improve related tests
- Remove InSlice in favor of the standard library slices.Contains

## Breaking Changes
- Removed InSlice. Use slices.Contains from the Go standard library instead.

## Motivation
- Keep this public helper package aligned with current Go conventions while retaining useful string helpers from the Laravel/Hyperf-inspired API surface

## Testing
- go test ./...
- make lint/strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string manipulation functions: first/last replacement, prefix/suffix handling, substring extraction (after, before, between), and whitespace normalization.

* **Improvements**
  * Enhanced wildcard matching and hash generation; improved random string generation.

* **Documentation**
  * Added comprehensive README with usage examples and function reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->