### PR TITLE
fix(queue): account for Redis pending delivery attempts

### DIFF
--- a/queue/adapter/redis/queue.go
+++ b/queue/adapter/redis/queue.go
@@ -247,11 +247,14 @@ func (q *Queue) claimPending(ctx context.Context, name string, visibilityTimeout
 		Start:    "0-0",
 		Count:    1,
 	}).Result()
-	if errors.Is(err, goredis.Nil) || len(messages) == 0 {
+	if errors.Is(err, goredis.Nil) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
+	}
+	if len(messages) == 0 {
+		return nil, nil
 	}
 	return q.leaseFromClaimedMessage(ctx, name, messages[0])
 }
@@ -276,11 +279,14 @@ func (q *Queue) deliveryCount(ctx context.Context, name, messageID string) (int6
 		End:    messageID,
 		Count:  1,
 	}).Result()
-	if errors.Is(err, goredis.Nil) || len(pending) == 0 {
+	if errors.Is(err, goredis.Nil) {
 		return 0, nil
 	}
 	if err != nil {
 		return 0, err
+	}
+	if len(pending) == 0 {
+		return 0, nil
 	}
 	return pending[0].RetryCount, nil
 }
@@ -313,6 +319,9 @@ func (q *Queue) leaseFromMessageWithDeliveryCount(message goredis.XMessage, deli
 }
 
 func attemptWithDeliveryCount(baseAttempt int, deliveryCount int64) int {
+	if baseAttempt < 0 {
+		baseAttempt = 0
+	}
 	if deliveryCount <= 0 {
 		if baseAttempt == math.MaxInt {
 			return math.MaxInt

--- a/queue/adapter/redis/queue.go
+++ b/queue/adapter/redis/queue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -252,10 +253,39 @@ func (q *Queue) claimPending(ctx context.Context, name string, visibilityTimeout
 	if err != nil {
 		return nil, err
 	}
-	return q.leaseFromMessage(messages[0])
+	return q.leaseFromClaimedMessage(ctx, name, messages[0])
 }
 
 func (q *Queue) leaseFromMessage(message goredis.XMessage) (queue.Lease, error) {
+	return q.leaseFromMessageWithDeliveryCount(message, 0)
+}
+
+func (q *Queue) leaseFromClaimedMessage(ctx context.Context, name string, message goredis.XMessage) (queue.Lease, error) {
+	deliveryCount, err := q.deliveryCount(ctx, name, message.ID)
+	if err != nil {
+		return nil, err
+	}
+	return q.leaseFromMessageWithDeliveryCount(message, deliveryCount)
+}
+
+func (q *Queue) deliveryCount(ctx context.Context, name, messageID string) (int64, error) {
+	pending, err := q.redis.XPendingExt(ctx, &goredis.XPendingExtArgs{
+		Stream: q.streamKey(name),
+		Group:  q.group,
+		Start:  messageID,
+		End:    messageID,
+		Count:  1,
+	}).Result()
+	if errors.Is(err, goredis.Nil) || len(pending) == 0 {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return pending[0].RetryCount, nil
+}
+
+func (q *Queue) leaseFromMessageWithDeliveryCount(message goredis.XMessage, deliveryCount int64) (queue.Lease, error) {
 	value, ok := message.Values[taskField]
 	if !ok {
 		return nil, fmt.Errorf("queue/adapter/redis: message %s missing %q field", message.ID, taskField)
@@ -275,11 +305,29 @@ func (q *Queue) leaseFromMessage(message goredis.XMessage) (queue.Lease, error) 
 	if err := json.Unmarshal(data, &task); err != nil {
 		return nil, err
 	}
-	task.Attempt++
+	task.Attempt = attemptWithDeliveryCount(task.Attempt, deliveryCount)
 	return &redisLease{
 		task:     &task,
 		streamID: message.ID,
 	}, nil
+}
+
+func attemptWithDeliveryCount(baseAttempt int, deliveryCount int64) int {
+	if deliveryCount <= 0 {
+		if baseAttempt == math.MaxInt {
+			return math.MaxInt
+		}
+		return baseAttempt + 1
+	}
+
+	if baseAttempt >= math.MaxInt {
+		return math.MaxInt
+	}
+	maxRemaining := math.MaxInt - baseAttempt
+	if deliveryCount > int64(maxRemaining) {
+		return math.MaxInt
+	}
+	return baseAttempt + int(deliveryCount)
 }
 
 func (q *Queue) addToStream(ctx context.Context, name string, data []byte) error {

--- a/queue/adapter/redis/queue_test.go
+++ b/queue/adapter/redis/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -65,6 +66,71 @@ func TestQueue_LeaseFromMessageAcceptsBytes(t *testing.T) {
 	require.NotNil(t, lease.Task())
 	assert.Equal(t, "task-1", lease.Task().ID)
 	assert.Equal(t, 1, lease.Task().Attempt)
+}
+
+func TestQueue_LeaseFromMessageWithDeliveryCount(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueue(nil)
+	data, err := json.Marshal(&queue.Task{ID: "task-1", Type: "send_email", Attempt: 1})
+	require.NoError(t, err)
+
+	lease, err := q.leaseFromMessageWithDeliveryCount(goredis.XMessage{
+		ID: "1-0",
+		Values: map[string]any{
+			taskField: data,
+		},
+	}, 2)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.NotNil(t, lease.Task())
+	assert.Equal(t, 3, lease.Task().Attempt)
+}
+
+func TestAttemptWithDeliveryCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		baseAttempt   int
+		deliveryCount int64
+		want          int
+	}{
+		{
+			name:          "increments when delivery count is unavailable",
+			baseAttempt:   1,
+			deliveryCount: 0,
+			want:          2,
+		},
+		{
+			name:          "adds redis delivery count to stored attempt",
+			baseAttempt:   1,
+			deliveryCount: 2,
+			want:          3,
+		},
+		{
+			name:          "saturates unavailable delivery count",
+			baseAttempt:   math.MaxInt,
+			deliveryCount: 0,
+			want:          math.MaxInt,
+		},
+		{
+			name:          "saturates large delivery count",
+			baseAttempt:   math.MaxInt - 1,
+			deliveryCount: 2,
+			want:          math.MaxInt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := attemptWithDeliveryCount(tt.baseAttempt, tt.deliveryCount)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestQueue_LeaseFromMessageErrors(t *testing.T) {
@@ -230,6 +296,91 @@ func TestQueue_RetryReenqueuesAndAcksLease(t *testing.T) {
 	assert.Equal(t, 2, lease.Task().Attempt)
 }
 
+func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
+	t.Parallel()
+
+	q, client := newRedisTestQueue(t)
+	ctx := t.Context()
+
+	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
+	require.NoError(t, err)
+
+	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.NotNil(t, lease.Task())
+	assert.Equal(t, 1, lease.Task().Attempt)
+
+	messages, err := client.XRange(ctx, q.streamKey("critical"), "-", "+").Result()
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	stored := taskFromMessage(t, messages[0])
+	assert.Equal(t, 0, stored.Attempt)
+
+	var claimed queue.Lease
+	require.Eventually(t, func() bool {
+		got, err := q.Dequeue(ctx, "critical", time.Millisecond)
+		if errors.Is(err, queue.ErrNoTask) {
+			return false
+		}
+		require.NoError(t, err)
+		claimed = got
+		return true
+	}, time.Second, 10*time.Millisecond)
+
+	require.NotNil(t, claimed)
+	require.NotNil(t, claimed.Task())
+	assert.Equal(t, "send_email", claimed.Task().Type)
+	assert.Equal(t, 2, claimed.Task().Attempt)
+	require.NoError(t, q.Ack(ctx, claimed))
+}
+
+func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
+	t.Parallel()
+
+	q, client := newRedisTestQueue(t)
+	ctx := t.Context()
+
+	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
+	require.NoError(t, err)
+
+	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.NotNil(t, lease.Task())
+	require.Equal(t, 1, lease.Task().Attempt)
+	require.NoError(t, q.Retry(ctx, lease, 0))
+
+	lease, err = q.Dequeue(ctx, "critical", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.NotNil(t, lease.Task())
+	assert.Equal(t, 2, lease.Task().Attempt)
+
+	messages, err := client.XRange(ctx, q.streamKey("critical"), "-", "+").Result()
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	stored := taskFromMessage(t, messages[1])
+	assert.Equal(t, 1, stored.Attempt)
+
+	var claimed queue.Lease
+	require.Eventually(t, func() bool {
+		got, err := q.Dequeue(ctx, "critical", time.Millisecond)
+		if errors.Is(err, queue.ErrNoTask) {
+			return false
+		}
+		require.NoError(t, err)
+		claimed = got
+		return true
+	}, time.Second, 10*time.Millisecond)
+
+	require.NotNil(t, claimed)
+	require.NotNil(t, claimed.Task())
+	assert.Equal(t, "send_email", claimed.Task().Type)
+	assert.Equal(t, 3, claimed.Task().Attempt)
+	require.NoError(t, q.Ack(ctx, claimed))
+}
+
 func TestQueue_DeadLetterWritesReasonAndAcksLease(t *testing.T) {
 	t.Parallel()
 
@@ -319,4 +470,25 @@ func newRedisTestQueue(t *testing.T) (*Queue, *goredis.Client) {
 func sanitizeRedisKey(name string) string {
 	replacer := strings.NewReplacer("/", "-", " ", "-", ":", "-")
 	return replacer.Replace(name)
+}
+
+func taskFromMessage(t *testing.T, message goredis.XMessage) queue.Task {
+	t.Helper()
+
+	value, ok := message.Values[taskField]
+	require.True(t, ok)
+
+	var data []byte
+	switch v := value.(type) {
+	case string:
+		data = []byte(v)
+	case []byte:
+		data = v
+	default:
+		require.Failf(t, "unsupported task field", "%T", value)
+	}
+
+	var task queue.Task
+	require.NoError(t, json.Unmarshal(data, &task))
+	return task
 }

--- a/queue/adapter/redis/queue_test.go
+++ b/queue/adapter/redis/queue_test.go
@@ -17,6 +17,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type redisClientStub struct {
+	goredis.UniversalClient
+
+	xAutoClaimMessages []goredis.XMessage
+	xAutoClaimErr      error
+	xPendingExt        []goredis.XPendingExt
+	xPendingExtErr     error
+}
+
+func (c *redisClientStub) XAutoClaim(ctx context.Context, _ *goredis.XAutoClaimArgs) *goredis.XAutoClaimCmd {
+	cmd := goredis.NewXAutoClaimCmd(ctx)
+	cmd.SetVal(c.xAutoClaimMessages, "0-0")
+	cmd.SetErr(c.xAutoClaimErr)
+	return cmd
+}
+
+func (c *redisClientStub) XPendingExt(ctx context.Context, _ *goredis.XPendingExtArgs) *goredis.XPendingExtCmd {
+	cmd := goredis.NewXPendingExtCmd(ctx)
+	cmd.SetVal(c.xPendingExt)
+	cmd.SetErr(c.xPendingExtErr)
+	return cmd
+}
+
 func TestQueue_LeaseFromMessage(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +143,18 @@ func TestAttemptWithDeliveryCount(t *testing.T) {
 			deliveryCount: 2,
 			want:          math.MaxInt,
 		},
+		{
+			name:          "normalizes negative stored attempt",
+			baseAttempt:   -1,
+			deliveryCount: 2,
+			want:          2,
+		},
+		{
+			name:          "normalizes negative stored attempt without delivery count",
+			baseAttempt:   -1,
+			deliveryCount: 0,
+			want:          1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -131,6 +166,28 @@ func TestAttemptWithDeliveryCount(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestQueue_ClaimPendingReturnsXAutoClaimError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("xautoclaim failed")
+	q := NewQueue(&redisClientStub{xAutoClaimErr: wantErr})
+
+	_, err := q.claimPending(t.Context(), "critical", time.Second)
+
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestQueue_DeliveryCountReturnsXPendingExtError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("xpending failed")
+	q := NewQueue(&redisClientStub{xPendingExtErr: wantErr})
+
+	_, err := q.deliveryCount(t.Context(), "critical", "1-0")
+
+	require.ErrorIs(t, err, wantErr)
 }
 
 func TestQueue_LeaseFromMessageErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix Redis queue redelivery attempt calculation so claimed pending stream messages account for Redis delivery counts instead of treating every claimed message as a single decoded delivery.

## Changes
- Read Redis pending-entry delivery count when leasing messages returned by XAUTOCLAIM
- Combine stored task attempts with Redis delivery counts using saturating arithmetic
- Add unit coverage for delivery-count attempt calculation and Redis redelivery scenarios

## Motivation
- Workers use Task.Attempt to decide retry and dead-letter behavior, so redelivered pending Redis stream messages should expose the correct attempt count to handlers.

## Testing
- go test -count=1 ./... (queue/adapter/redis)
- go test -count=1 ./... (queue)
- golangci-lint run --allow-serial-runners (queue/adapter/redis)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Redis queue adapter now incorporates message delivery counts from consumer groups when creating task leases, improving retry handling and attempt tracking accuracy.

* **Tests**
  * Added comprehensive test coverage for lease creation with delivery counts and retry attempt calculation, including edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->