### PR TITLE
feat(queue): add typed tasker registration helper

### DIFF
--- a/queue/README.md
+++ b/queue/README.md
@@ -72,7 +72,8 @@ _, _ = queue.EnqueueFor(ctx, producer, "send_email", SendEmail{UserID: 1, Subjec
 ```
 
 Use `Tasker` and `HandleTasker` when one type should own both enqueueing and
-handling for a task type. This keeps the task type string in one place.
+handling for a task type. This keeps the task type string in one place. Name
+application helpers `Enqueue` when they add tasks to the queue.
 
 ```go
 const sendEmailTaskType = "send_email"
@@ -98,6 +99,8 @@ tasker := &SendEmailTasker{producer: producer}
 worker := queue.NewWorker(q, queue.HandleTasker[SendEmail](tasker))
 _, _ = tasker.Enqueue(ctx, SendEmail{UserID: 1, Subject: "welcome"})
 ```
+
+See [examples/tasker](examples/tasker) for a runnable Tasker example.
 
 ## Retry and Dead Letter
 

--- a/queue/README.md
+++ b/queue/README.md
@@ -71,6 +71,34 @@ worker := queue.NewWorker(
 _, _ = queue.EnqueueFor(ctx, producer, "send_email", SendEmail{UserID: 1, Subject: "welcome"})
 ```
 
+Use `Tasker` and `HandleTasker` when one type should own both enqueueing and
+handling for a task type. This keeps the task type string in one place.
+
+```go
+const sendEmailTaskType = "send_email"
+
+type SendEmailTasker struct {
+	producer *queue.Producer
+}
+
+func (t *SendEmailTasker) TaskType() string {
+	return sendEmailTaskType
+}
+
+func (t *SendEmailTasker) Enqueue(ctx context.Context, payload SendEmail, opts ...queue.EnqueueOption) (*queue.Task, error) {
+	return queue.EnqueueFor(ctx, t.producer, t.TaskType(), payload, opts...)
+}
+
+func (t *SendEmailTasker) Handle(ctx context.Context, task *queue.TaskFor[SendEmail]) error {
+	// task.Payload is SendEmail.
+	return nil
+}
+
+tasker := &SendEmailTasker{producer: producer}
+worker := queue.NewWorker(q, queue.HandleTasker[SendEmail](tasker))
+_, _ = tasker.Enqueue(ctx, SendEmail{UserID: 1, Subject: "welcome"})
+```
+
 ## Retry and Dead Letter
 
 Workers ACK tasks only when handlers return `nil`. Handler errors are retried

--- a/queue/examples/tasker/go.mod
+++ b/queue/examples/tasker/go.mod
@@ -1,0 +1,16 @@
+module github.com/go-fries/fries/queue/examples/tasker/v3
+
+go 1.25.0
+
+replace (
+	github.com/go-fries/fries/codec/v3 => ../../../codec
+	github.com/go-fries/fries/queue/adapter/memory/v3 => ../../adapter/memory
+	github.com/go-fries/fries/queue/v3 => ../../
+)
+
+require (
+	github.com/go-fries/fries/queue/adapter/memory/v3 v3.14.0
+	github.com/go-fries/fries/queue/v3 v3.14.0
+)
+
+require github.com/go-fries/fries/codec/v3 v3.14.0 // indirect

--- a/queue/examples/tasker/go.sum
+++ b/queue/examples/tasker/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/queue/examples/tasker/main.go
+++ b/queue/examples/tasker/main.go
@@ -56,6 +56,12 @@ func (t *SendEmailTasker) Handle(ctx context.Context, task *queue.TaskFor[SendEm
 }
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -73,13 +79,11 @@ func main() {
 	}()
 
 	if _, err := tasker.Enqueue(ctx, 42, "welcome"); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	time.Sleep(100 * time.Millisecond)
 
 	cancel()
-	if err := <-errs; err != nil {
-		log.Fatal(err)
-	}
+	return <-errs
 }

--- a/queue/examples/tasker/main.go
+++ b/queue/examples/tasker/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/go-fries/fries/queue/adapter/memory/v3"
+	"github.com/go-fries/fries/queue/v3"
+)
+
+const sendEmailTaskType = "send_email"
+
+type SendEmail struct {
+	UserID  int    `json:"user_id"`
+	Subject string `json:"subject"`
+}
+
+type EmailSender interface {
+	Send(ctx context.Context, userID int, subject string) error
+}
+
+type LogEmailSender struct{}
+
+func (LogEmailSender) Send(_ context.Context, userID int, subject string) error {
+	fmt.Printf("sent email: user_id=%d subject=%s\n", userID, subject)
+	return nil
+}
+
+type SendEmailTasker struct {
+	producer *queue.Producer
+	sender   EmailSender
+}
+
+func NewSendEmailTasker(producer *queue.Producer, sender EmailSender) *SendEmailTasker {
+	return &SendEmailTasker{
+		producer: producer,
+		sender:   sender,
+	}
+}
+
+func (t *SendEmailTasker) TaskType() string {
+	return sendEmailTaskType
+}
+
+func (t *SendEmailTasker) Enqueue(ctx context.Context, userID int, subject string, opts ...queue.EnqueueOption) (*queue.Task, error) {
+	return queue.EnqueueFor(ctx, t.producer, t.TaskType(), SendEmail{
+		UserID:  userID,
+		Subject: subject,
+	}, opts...)
+}
+
+func (t *SendEmailTasker) Handle(ctx context.Context, task *queue.TaskFor[SendEmail]) error {
+	return t.sender.Send(ctx, task.Payload.UserID, task.Payload.Subject)
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := memory.NewQueue()
+	tasker := NewSendEmailTasker(queue.NewProducer(q), LogEmailSender{})
+	worker := queue.NewWorker(
+		q,
+		queue.HandleTasker[SendEmail](tasker),
+		queue.WithPollInterval(10*time.Millisecond),
+	)
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- worker.Run(ctx)
+	}()
+
+	if _, err := tasker.Enqueue(ctx, 42, "welcome"); err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	cancel()
+	if err := <-errs; err != nil {
+		log.Fatal(err)
+	}
+}

--- a/queue/typed.go
+++ b/queue/typed.go
@@ -34,6 +34,13 @@ type HandlerFor[T any] interface {
 	Handle(ctx context.Context, task *TaskFor[T]) error
 }
 
+// Tasker binds one task type to its typed handler.
+type Tasker[T any] interface {
+	// TaskType returns the task type handled by this tasker.
+	TaskType() string
+	HandlerFor[T]
+}
+
 // HandlerFuncFor adapts a function to HandlerFor.
 type HandlerFuncFor[T any] func(ctx context.Context, task *TaskFor[T]) error
 
@@ -89,6 +96,14 @@ func EnqueueForWithCodec[T any](
 // HandleFor decodes task payloads with the default JSON codec before calling handler.
 func HandleFor[T any](taskType string, handler HandlerFor[T]) WorkerOption {
 	return HandleForWithCodec(taskType, defaultCodec, handler)
+}
+
+// HandleTasker registers tasker as the typed handler for tasker.TaskType().
+func HandleTasker[T any](tasker Tasker[T]) WorkerOption {
+	if tasker == nil {
+		return Handle("", nil)
+	}
+	return HandleFor(tasker.TaskType(), tasker)
 }
 
 // HandleForWithCodec decodes task payloads with codec before calling handler.

--- a/queue/typed.go
+++ b/queue/typed.go
@@ -34,9 +34,14 @@ type HandlerFor[T any] interface {
 	Handle(ctx context.Context, task *TaskFor[T]) error
 }
 
-// Tasker binds one task type to its typed handler.
+// Tasker binds a typed handler to the task type it handles.
+//
+// Use Tasker when an application wants one concrete type to own the task type
+// constant and the typed Handle method. Applications can add their own Enqueue
+// method to the same concrete type, but Enqueue is intentionally not part of
+// this interface so each task can expose a business-friendly enqueue signature.
 type Tasker[T any] interface {
-	// TaskType returns the task type handled by this tasker.
+	// TaskType returns the queue task type handled by this tasker.
 	TaskType() string
 	HandlerFor[T]
 }
@@ -98,7 +103,10 @@ func HandleFor[T any](taskType string, handler HandlerFor[T]) WorkerOption {
 	return HandleForWithCodec(taskType, defaultCodec, handler)
 }
 
-// HandleTasker registers tasker as the typed handler for tasker.TaskType().
+// HandleTasker registers tasker as the typed handler for its TaskType.
+//
+// It is equivalent to calling HandleFor(tasker.TaskType(), tasker). A nil tasker
+// is ignored, matching HandleFor's nil-handler behavior.
 func HandleTasker[T any](tasker Tasker[T]) WorkerOption {
 	if tasker == nil {
 		return Handle("", nil)

--- a/queue/typed_test.go
+++ b/queue/typed_test.go
@@ -16,6 +16,25 @@ type emailPayload struct {
 	Subject string `json:"subject"`
 }
 
+type emailTasker struct {
+	handled chan *TaskFor[emailPayload]
+}
+
+func (t *emailTasker) TaskType() string {
+	return "send_email"
+}
+
+func (t *emailTasker) Handle(ctx context.Context, task *TaskFor[emailPayload]) error {
+	select {
+	case t.handled <- task:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+var _ Tasker[emailPayload] = (*emailTasker)(nil)
+
 func TestEnqueueForEncodesPayload(t *testing.T) {
 	t.Parallel()
 
@@ -73,6 +92,53 @@ func TestHandleForDecodesPayload(t *testing.T) {
 
 	cancel()
 	require.NoError(t, <-errs)
+}
+
+func TestHandleTaskerRegistersTypedHandler(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	q := newTestQueue()
+	tasker := &emailTasker{handled: make(chan *TaskFor[emailPayload], 1)}
+	worker := NewWorker(
+		q,
+		HandleTasker[emailPayload](tasker),
+		WithPollInterval(time.Millisecond),
+	)
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- worker.Run(ctx)
+	}()
+
+	_, err := EnqueueFor(t.Context(), NewProducer(q), tasker.TaskType(), emailPayload{
+		UserID:  12,
+		Subject: "reset",
+	})
+	require.NoError(t, err)
+
+	select {
+	case task := <-tasker.handled:
+		require.NotNil(t, task.Task)
+		assert.Equal(t, 12, task.Payload.UserID)
+		assert.Equal(t, "reset", task.Payload.Subject)
+	case <-time.After(time.Second):
+		require.Fail(t, "timeout waiting for tasker")
+	}
+
+	cancel()
+	require.NoError(t, <-errs)
+}
+
+func TestHandleTaskerIgnoresNilTasker(t *testing.T) {
+	t.Parallel()
+
+	var tasker Tasker[emailPayload]
+	config := newWorkerConfig(HandleTasker[emailPayload](tasker))
+
+	assert.Empty(t, config.handlers)
 }
 
 type passthroughCodec struct{}

--- a/versions.yaml
+++ b/versions.yaml
@@ -152,4 +152,5 @@ excluded-modules:
   - github.com/go-fries/fries/examples/cloudevents/amqp091/v3
   - github.com/go-fries/fries/examples/cloudevents/eventdispatcher/v3
   - github.com/go-fries/fries/examples/mysql/canal/v3
+  - github.com/go-fries/fries/queue/examples/tasker/v3
   - github.com/go-fries/fries/eino/components/embedding/cached/example/v3


### PR DESCRIPTION
## Summary
Add a typed Tasker registration helper for queue tasks so applications can keep the task type and handler on one concrete type.

## Changes
- Add `Tasker[T]` and `HandleTasker[T]` for typed queue handler registration
- Document the Tasker pattern in `queue/README.md`
- Add a runnable `queue/examples/tasker` module showing a business-style enqueue and handler flow
- Exclude the new example module from stable module versioning

## Motivation
- Queue users can avoid repeating task type strings across enqueueing and worker registration while keeping task-specific enqueue signatures in application code

## Testing
- `go test -count=1 ./...` in `queue`
- `go run .` in `queue/examples/tasker`
- `go test -count=1 ./...` in `queue/examples/tasker`
- `golangci-lint run --allow-serial-runners` in `queue`
- `.tools/multimod verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `Tasker` pattern for simplified typed task handling, enabling centralized task type definition with integrated handler registration.

* **Documentation**
  * Added "Tasker" guide with practical examples demonstrating task enqueueing and processing workflows.

* **Tests**
  * Added tests validating typed task handling behavior.

* **Chores**
  * Added example project demonstrating `Tasker` pattern implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->