### PR TITLE
feat(queue): add RabbitMQ adapter

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -79,6 +79,7 @@ fixes:
   - github.com/go-fries/fries/locker/redis/v3::locker/redis/
   - github.com/go-fries/fries/queue/v3::queue/
   - github.com/go-fries/fries/queue/adapter/memory/v3::queue/adapter/memory/
+  - github.com/go-fries/fries/queue/adapter/rabbitmq/v3::queue/adapter/rabbitmq/
   - github.com/go-fries/fries/queue/adapter/redis/v3::queue/adapter/redis/
   - github.com/go-fries/fries/queue/kratos/server/v3::queue/kratos/server/
   - github.com/go-fries/fries/queue/middleware/recovery/v3::queue/middleware/recovery/

--- a/queue/adapter/memory/queue.go
+++ b/queue/adapter/memory/queue.go
@@ -13,6 +13,7 @@ type Queue struct {
 	mu         sync.Mutex
 	queues     map[string][]*queue.Task
 	deadLetter map[string][]*queue.Task
+	notify     chan struct{}
 }
 
 var _ queue.Queue = (*Queue)(nil)
@@ -22,6 +23,7 @@ func NewQueue() *Queue {
 	return &Queue{
 		queues:     make(map[string][]*queue.Task),
 		deadLetter: make(map[string][]*queue.Task),
+		notify:     make(chan struct{}),
 	}
 }
 
@@ -43,76 +45,157 @@ func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
 	defer q.mu.Unlock()
 
 	q.queues[task.Queue] = append(q.queues[task.Queue], task)
+	q.signal()
 	return nil
 }
 
-// Dequeue returns the first available task from queueName.
-func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, error) {
+// NewConsumer creates a consumer for queueName.
+func (q *Queue) NewConsumer(ctx context.Context, queueName string) (queue.Consumer, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	if queueName == "" {
 		queueName = queue.DefaultQueue
 	}
+	return &consumer{
+		queue: q,
+		name:  queueName,
+		done:  make(chan struct{}),
+	}, nil
+}
 
+type consumer struct {
+	queue *Queue
+	name  string
+	done  chan struct{}
+	once  sync.Once
+}
+
+func (c *consumer) Receive(ctx context.Context) (queue.Delivery, error) {
+	for {
+		task, notify, wait := c.queue.next(c.name)
+		if task != nil {
+			return &delivery{queue: c.queue, task: task}, nil
+		}
+
+		var timer *time.Timer
+		var timerC <-chan time.Time
+		if wait > 0 {
+			timer = time.NewTimer(wait)
+			timerC = timer.C
+		}
+
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			return nil, ctx.Err()
+		case <-c.done:
+			stopTimer(timer)
+			return nil, context.Canceled
+		case <-notify:
+			stopTimer(timer)
+		case <-timerC:
+		}
+	}
+}
+
+func (c *consumer) Close() error {
+	c.once.Do(func() {
+		close(c.done)
+	})
+	return nil
+}
+
+type delivery struct {
+	queue *Queue
+	task  *queue.Task
+}
+
+func (d *delivery) Task() *queue.Task {
+	if d == nil {
+		return nil
+	}
+	return d.task
+}
+
+func (*delivery) Ack(ctx context.Context) error {
+	return ctx.Err()
+}
+
+func (d *delivery) Retry(ctx context.Context, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d == nil || d.task == nil {
+		return nil
+	}
+
+	task := d.task.Clone()
+	task.AvailableAt = time.Now().UTC().Add(delay)
+	return d.queue.Enqueue(ctx, task)
+}
+
+func (d *delivery) DeadLetter(ctx context.Context, reason string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d == nil || d.task == nil {
+		return nil
+	}
+
+	task := d.task.Clone()
+	if task.Metadata == nil {
+		task.Metadata = make(map[string]string)
+	}
+	task.Metadata["queue.dead_letter.reason"] = reason
+
+	d.queue.mu.Lock()
+	defer d.queue.mu.Unlock()
+
+	d.queue.deadLetter[task.Queue] = append(d.queue.deadLetter[task.Queue], task)
+	return nil
+}
+
+func (q *Queue) next(queueName string) (*queue.Task, <-chan struct{}, time.Duration) {
 	now := time.Now().UTC()
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	var wait time.Duration
 	tasks := q.queues[queueName]
 	for i, task := range tasks {
 		if task.AvailableAt.After(now) {
+			delay := task.AvailableAt.Sub(now)
+			if wait == 0 || delay < wait {
+				wait = delay
+			}
 			continue
 		}
 
 		q.queues[queueName] = append(tasks[:i], tasks[i+1:]...)
 		task = task.Clone()
 		task.Attempt++
-		return queue.NewLease(task), nil
+		return task, q.notify, 0
 	}
 
-	return nil, queue.ErrNoTask
+	return nil, q.notify, wait
 }
 
-// Ack marks a memory lease as complete.
-func (q *Queue) Ack(ctx context.Context, _ queue.Lease) error {
-	return ctx.Err()
+func (q *Queue) signal() {
+	close(q.notify)
+	q.notify = make(chan struct{})
 }
 
-// Retry re-enqueues a leased task after delay.
-func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duration) error {
-	if err := ctx.Err(); err != nil {
-		return err
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
 	}
-	if lease == nil || lease.Task() == nil {
-		return nil
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
 	}
-
-	task := lease.Task().Clone()
-	task.AvailableAt = time.Now().UTC().Add(delay)
-	return q.Enqueue(ctx, task)
-}
-
-// DeadLetter stores a leased task in the in-memory dead-letter list.
-func (q *Queue) DeadLetter(ctx context.Context, lease queue.Lease, reason string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if lease == nil || lease.Task() == nil {
-		return nil
-	}
-
-	task := lease.Task().Clone()
-	if task.Metadata == nil {
-		task.Metadata = make(map[string]string)
-	}
-	task.Metadata["queue.dead_letter.reason"] = reason
-
-	q.mu.Lock()
-	defer q.mu.Unlock()
-
-	q.deadLetter[task.Queue] = append(q.deadLetter[task.Queue], task)
-	return nil
 }
 
 // DeadLetters returns a copy of dead-lettered tasks for queueName.

--- a/queue/adapter/memory/queue.go
+++ b/queue/adapter/memory/queue.go
@@ -47,7 +47,7 @@ func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
 }
 
 // Dequeue returns the first available task from queueName.
-func (q *Queue) Dequeue(ctx context.Context, queueName string, _ time.Duration) (queue.Lease, error) {
+func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/queue/adapter/memory/queue_test.go
+++ b/queue/adapter/memory/queue_test.go
@@ -26,18 +26,18 @@ func TestQueue_EnqueueDefaultsQueueAndClonesTask(t *testing.T) {
 	task.Payload[0] = 'x'
 	task.Metadata["trace"] = "2"
 
-	lease, err := q.Dequeue(ctx, "")
+	delivery, err := receive(ctx, q, "")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
 
-	assert.Equal(t, queue.DefaultQueue, lease.Task().Queue)
-	assert.Equal(t, 1, lease.Task().Attempt)
-	assert.Equal(t, "hello", string(lease.Task().Payload))
-	assert.Equal(t, "1", lease.Task().Metadata["trace"])
+	assert.Equal(t, queue.DefaultQueue, delivery.Task().Queue)
+	assert.Equal(t, 1, delivery.Task().Attempt)
+	assert.Equal(t, "hello", string(delivery.Task().Payload))
+	assert.Equal(t, "1", delivery.Task().Metadata["trace"])
 }
 
-func TestQueue_DequeueHonorsAvailability(t *testing.T) {
+func TestQueue_ReceiveHonorsAvailability(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -49,8 +49,10 @@ func TestQueue_DequeueHonorsAvailability(t *testing.T) {
 		AvailableAt: now.Add(time.Minute),
 	}))
 
-	_, err := q.Dequeue(ctx, queue.DefaultQueue)
-	require.ErrorIs(t, err, queue.ErrNoTask)
+	receiveCtx, cancel := context.WithTimeout(ctx, time.Millisecond)
+	_, err := receive(receiveCtx, q, queue.DefaultQueue)
+	cancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
 	require.NoError(t, q.Enqueue(ctx, &queue.Task{
 		ID:          "ready",
@@ -58,12 +60,12 @@ func TestQueue_DequeueHonorsAvailability(t *testing.T) {
 		AvailableAt: now.Add(-time.Minute),
 	}))
 
-	lease, err := q.Dequeue(ctx, queue.DefaultQueue)
+	delivery, err := receive(ctx, q, queue.DefaultQueue)
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, "ready", lease.Task().ID)
-	assert.Equal(t, 1, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "ready", delivery.Task().ID)
+	assert.Equal(t, 1, delivery.Task().Attempt)
 }
 
 func TestQueue_RetryReenqueuesTask(t *testing.T) {
@@ -77,16 +79,16 @@ func TestQueue_RetryReenqueuesTask(t *testing.T) {
 		Queue: "critical",
 	}))
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NoError(t, q.Retry(ctx, lease, 0))
+	require.NoError(t, delivery.Retry(ctx, 0))
 
-	lease, err = q.Dequeue(ctx, "critical")
+	delivery, err = receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, "task-1", lease.Task().ID)
-	assert.Equal(t, 2, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "task-1", delivery.Task().ID)
+	assert.Equal(t, 2, delivery.Task().Attempt)
 }
 
 func TestQueue_DeadLettersClonesTask(t *testing.T) {
@@ -106,9 +108,9 @@ func TestQueue_DeadLettersClonesTask(t *testing.T) {
 	task.Payload[0] = 'x'
 	task.Metadata["trace"] = "2"
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NoError(t, q.DeadLetter(ctx, lease, "failed"))
+	require.NoError(t, delivery.DeadLetter(ctx, "failed"))
 
 	dead := q.DeadLetters("critical")
 	require.Len(t, dead, 1)
@@ -135,22 +137,38 @@ func TestQueue_MethodsReturnContextError(t *testing.T) {
 	task := &queue.Task{ID: "task-1", Type: "send_email"}
 
 	require.ErrorIs(t, q.Enqueue(ctx, task), context.Canceled)
-	_, err := q.Dequeue(ctx, queue.DefaultQueue)
+	consumer, err := q.NewConsumer(t.Context(), queue.DefaultQueue)
+	require.NoError(t, err)
+	_, err = consumer.Receive(ctx)
 	require.ErrorIs(t, err, context.Canceled)
-	require.ErrorIs(t, q.Ack(ctx, nil), context.Canceled)
-	require.ErrorIs(t, q.Retry(ctx, queue.NewLease(task), 0), context.Canceled)
-	require.ErrorIs(t, q.DeadLetter(ctx, queue.NewLease(task), "failed"), context.Canceled)
+
+	delivery := &delivery{queue: q, task: task}
+	require.ErrorIs(t, delivery.Ack(ctx), context.Canceled)
+	require.ErrorIs(t, delivery.Retry(ctx, 0), context.Canceled)
+	require.ErrorIs(t, delivery.DeadLetter(ctx, "failed"), context.Canceled)
 }
 
-func TestQueue_NilLeaseOperationsAreNoop(t *testing.T) {
+func TestQueue_NilDeliveryOperationsAreNoop(t *testing.T) {
 	t.Parallel()
 
 	q := NewQueue()
+	var nilDelivery *delivery
 
 	require.NoError(t, q.Enqueue(t.Context(), nil))
-	require.NoError(t, q.Retry(t.Context(), nil, 0))
-	require.NoError(t, q.Retry(t.Context(), queue.NewLease(nil), 0))
-	require.NoError(t, q.DeadLetter(t.Context(), nil, "failed"))
-	require.NoError(t, q.DeadLetter(t.Context(), queue.NewLease(nil), "failed"))
+	require.NoError(t, nilDelivery.Retry(t.Context(), 0))
+	require.NoError(t, nilDelivery.DeadLetter(t.Context(), "failed"))
+	require.NoError(t, (&delivery{queue: q}).Retry(t.Context(), 0))
+	require.NoError(t, (&delivery{queue: q}).DeadLetter(t.Context(), "failed"))
 	assert.Empty(t, q.DeadLetters(queue.DefaultQueue))
+}
+
+func receive(ctx context.Context, q *Queue, queueName string) (queue.Delivery, error) {
+	consumer, err := q.NewConsumer(ctx, queueName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+	return consumer.Receive(ctx)
 }

--- a/queue/adapter/memory/queue_test.go
+++ b/queue/adapter/memory/queue_test.go
@@ -26,7 +26,7 @@ func TestQueue_EnqueueDefaultsQueueAndClonesTask(t *testing.T) {
 	task.Payload[0] = 'x'
 	task.Metadata["trace"] = "2"
 
-	lease, err := q.Dequeue(ctx, "", time.Minute)
+	lease, err := q.Dequeue(ctx, "")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -49,7 +49,7 @@ func TestQueue_DequeueHonorsAvailability(t *testing.T) {
 		AvailableAt: now.Add(time.Minute),
 	}))
 
-	_, err := q.Dequeue(ctx, queue.DefaultQueue, time.Minute)
+	_, err := q.Dequeue(ctx, queue.DefaultQueue)
 	require.ErrorIs(t, err, queue.ErrNoTask)
 
 	require.NoError(t, q.Enqueue(ctx, &queue.Task{
@@ -58,7 +58,7 @@ func TestQueue_DequeueHonorsAvailability(t *testing.T) {
 		AvailableAt: now.Add(-time.Minute),
 	}))
 
-	lease, err := q.Dequeue(ctx, queue.DefaultQueue, time.Minute)
+	lease, err := q.Dequeue(ctx, queue.DefaultQueue)
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -77,11 +77,11 @@ func TestQueue_RetryReenqueuesTask(t *testing.T) {
 		Queue: "critical",
 	}))
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NoError(t, q.Retry(ctx, lease, 0))
 
-	lease, err = q.Dequeue(ctx, "critical", time.Minute)
+	lease, err = q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -106,7 +106,7 @@ func TestQueue_DeadLettersClonesTask(t *testing.T) {
 	task.Payload[0] = 'x'
 	task.Metadata["trace"] = "2"
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NoError(t, q.DeadLetter(ctx, lease, "failed"))
 
@@ -135,7 +135,7 @@ func TestQueue_MethodsReturnContextError(t *testing.T) {
 	task := &queue.Task{ID: "task-1", Type: "send_email"}
 
 	require.ErrorIs(t, q.Enqueue(ctx, task), context.Canceled)
-	_, err := q.Dequeue(ctx, queue.DefaultQueue, time.Minute)
+	_, err := q.Dequeue(ctx, queue.DefaultQueue)
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorIs(t, q.Ack(ctx, nil), context.Canceled)
 	require.ErrorIs(t, q.Retry(ctx, queue.NewLease(task), 0), context.Canceled)

--- a/queue/adapter/rabbitmq/README.md
+++ b/queue/adapter/rabbitmq/README.md
@@ -23,10 +23,10 @@ import (
 
 func main() {
 	conn, _ := amqp.Dial("amqp://guest:guest@localhost:5672/")
-	ch, _ := conn.Channel()
+	defer conn.Close()
 
 	q := rabbitmq.NewQueue(
-		ch,
+		conn,
 		rabbitmq.WithPrefix("app"),
 	)
 	producer := queue.NewProducer(q)
@@ -51,3 +51,7 @@ Delayed tasks are stored in RabbitMQ TTL queues that dead-letter back to the
 ready queue after the delay, so the adapter does not require the RabbitMQ
 delayed message exchange plugin. RabbitMQ re-delivers unacknowledged tasks when
 the channel or connection closes.
+
+The adapter opens AMQP channels internally for queue operations. RabbitMQ
+channels are not safe to share between goroutines, so applications should share
+the connection and let the adapter manage per-operation channels.

--- a/queue/adapter/rabbitmq/README.md
+++ b/queue/adapter/rabbitmq/README.md
@@ -49,9 +49,13 @@ stores queue `emails` as `app.emails`.
 
 Delayed tasks are stored in RabbitMQ TTL queues that dead-letter back to the
 ready queue after the delay, so the adapter does not require the RabbitMQ
-delayed message exchange plugin. RabbitMQ re-delivers unacknowledged tasks when
-the channel or connection closes.
+delayed message exchange plugin. The current implementation creates one delay
+queue per queue name and delay value, for example `emails.delay.1500`, so prefer
+bounded retry delays in production workloads. RabbitMQ re-delivers unacknowledged
+tasks when the channel or connection closes.
 
-The adapter opens AMQP channels internally for queue operations. RabbitMQ
-channels are not safe to share between goroutines, so applications should share
-the connection and let the adapter manage per-operation channels.
+The adapter opens AMQP channels internally. Producers use short-lived channels
+for publish operations, and each consumer owns one channel for receiving and
+acknowledging deliveries. RabbitMQ channels are not safe to share between
+goroutines, so applications should share the connection and let the adapter
+manage channels.

--- a/queue/adapter/rabbitmq/README.md
+++ b/queue/adapter/rabbitmq/README.md
@@ -50,5 +50,4 @@ stores queue `emails` as `app.emails`.
 Delayed tasks are stored in RabbitMQ TTL queues that dead-letter back to the
 ready queue after the delay, so the adapter does not require the RabbitMQ
 delayed message exchange plugin. RabbitMQ re-delivers unacknowledged tasks when
-the channel or connection closes; the queue visibility timeout passed to
-`Dequeue` is not used by this adapter.
+the channel or connection closes.

--- a/queue/adapter/rabbitmq/README.md
+++ b/queue/adapter/rabbitmq/README.md
@@ -59,3 +59,8 @@ for publish operations, and each consumer owns one channel for receiving and
 acknowledging deliveries. RabbitMQ channels are not safe to share between
 goroutines, so applications should share the connection and let the adapter
 manage channels.
+
+Consumers set RabbitMQ QoS prefetch to `1` by default so a consumer does not
+reserve more unacknowledged deliveries than it can process. Use `WithPrefetch`
+to tune this per-consumer limit, or set it to `0` to use RabbitMQ's unlimited
+prefetch behavior.

--- a/queue/adapter/rabbitmq/README.md
+++ b/queue/adapter/rabbitmq/README.md
@@ -1,0 +1,54 @@
+# RabbitMQ Queue
+
+A RabbitMQ AMQP 0.9.1 queue implementation for `github.com/go-fries/fries/queue/v3`.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/queue/adapter/rabbitmq/v3
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"context"
+
+	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/adapter/rabbitmq/v3"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+func main() {
+	conn, _ := amqp.Dial("amqp://guest:guest@localhost:5672/")
+	ch, _ := conn.Channel()
+
+	q := rabbitmq.NewQueue(
+		ch,
+		rabbitmq.WithPrefix("app"),
+	)
+	producer := queue.NewProducer(q)
+	worker := queue.NewWorker(
+		q,
+		queue.Handle("send_email", queue.HandlerFunc(func(ctx context.Context, task *queue.Task) error {
+			// process task
+			return nil
+		})),
+	)
+
+	_, _ = producer.Enqueue(context.Background(), "send_email", []byte("hello"))
+	_ = worker.Run(context.Background())
+}
+```
+
+The adapter declares durable ready queues by default. Queue names map directly
+to RabbitMQ queue names unless `WithPrefix` is used; for example, prefix `app`
+stores queue `emails` as `app.emails`.
+
+Delayed tasks are stored in RabbitMQ TTL queues that dead-letter back to the
+ready queue after the delay, so the adapter does not require the RabbitMQ
+delayed message exchange plugin. RabbitMQ re-delivers unacknowledged tasks when
+the channel or connection closes; the queue visibility timeout passed to
+`Dequeue` is not used by this adapter.

--- a/queue/adapter/rabbitmq/config.go
+++ b/queue/adapter/rabbitmq/config.go
@@ -5,12 +5,16 @@ import (
 	"time"
 )
 
-const defaultDelayQueueTTL = time.Hour
+const (
+	defaultDelayQueueTTL = time.Hour
+	defaultPrefetch      = 1
+)
 
 type config struct {
 	prefix        string
 	durable       bool
 	delayQueueTTL time.Duration
+	prefetch      int
 }
 
 // Option configures a RabbitMQ queue adapter.
@@ -49,10 +53,22 @@ func WithDelayQueueTTL(ttl time.Duration) Option {
 	})
 }
 
+// WithPrefetch sets the maximum unacknowledged deliveries per consumer.
+//
+// Set prefetch to 0 to use RabbitMQ's unlimited prefetch behavior.
+func WithPrefetch(prefetch int) Option {
+	return optionFunc(func(c *config) {
+		if prefetch >= 0 {
+			c.prefetch = prefetch
+		}
+	})
+}
+
 func newConfig(opts ...Option) *config {
 	c := &config{
 		durable:       true,
 		delayQueueTTL: defaultDelayQueueTTL,
+		prefetch:      defaultPrefetch,
 	}
 	for _, opt := range opts {
 		opt.apply(c)

--- a/queue/adapter/rabbitmq/config.go
+++ b/queue/adapter/rabbitmq/config.go
@@ -1,0 +1,61 @@
+package rabbitmq
+
+import (
+	"strings"
+	"time"
+)
+
+const defaultDelayQueueTTL = time.Hour
+
+type config struct {
+	prefix        string
+	durable       bool
+	delayQueueTTL time.Duration
+}
+
+// Option configures a RabbitMQ queue adapter.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+
+// WithPrefix sets the queue name prefix used for ready, delay, and dead-letter queues.
+func WithPrefix(prefix string) Option {
+	return optionFunc(func(c *config) {
+		if prefix != "" {
+			c.prefix = strings.TrimSuffix(prefix, ".")
+		}
+	})
+}
+
+// WithDurable sets whether declared RabbitMQ queues survive broker restarts.
+func WithDurable(durable bool) Option {
+	return optionFunc(func(c *config) {
+		c.durable = durable
+	})
+}
+
+// WithDelayQueueTTL sets how long unused delay queues remain after their delay expires.
+func WithDelayQueueTTL(ttl time.Duration) Option {
+	return optionFunc(func(c *config) {
+		if ttl > 0 {
+			c.delayQueueTTL = ttl
+		}
+	})
+}
+
+func newConfig(opts ...Option) *config {
+	c := &config{
+		durable:       true,
+		delayQueueTTL: defaultDelayQueueTTL,
+	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
+}

--- a/queue/adapter/rabbitmq/doc.go
+++ b/queue/adapter/rabbitmq/doc.go
@@ -1,0 +1,2 @@
+// Package rabbitmq adapts RabbitMQ AMQP 0.9.1 queues to the queue component.
+package rabbitmq

--- a/queue/adapter/rabbitmq/go.mod
+++ b/queue/adapter/rabbitmq/go.mod
@@ -1,0 +1,20 @@
+module github.com/go-fries/fries/queue/adapter/rabbitmq/v3
+
+go 1.25.0
+
+replace github.com/go-fries/fries/queue/v3 => ../../
+
+replace github.com/go-fries/fries/codec/v3 => ../../../codec
+
+require (
+	github.com/go-fries/fries/queue/v3 v3.14.0
+	github.com/rabbitmq/amqp091-go v1.11.0
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-fries/fries/codec/v3 v3.14.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/queue/adapter/rabbitmq/go.sum
+++ b/queue/adapter/rabbitmq/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRbEY8O8=
+github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/queue/adapter/rabbitmq/lease.go
+++ b/queue/adapter/rabbitmq/lease.go
@@ -1,44 +1,116 @@
 package rabbitmq
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/go-fries/fries/queue/v3"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-type rabbitLease struct {
+type consumer struct {
+	queue      *Queue
+	channel    channel
+	deliveries <-chan amqp.Delivery
+	closeOnce  sync.Once
+	closeErr   error
+}
+
+func (c *consumer) Receive(ctx context.Context) (queue.Delivery, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case delivery, ok := <-c.deliveries:
+		if !ok {
+			return nil, context.Canceled
+		}
+		leased, err := deliveryFromAMQP(delivery)
+		if err != nil {
+			_ = delivery.Reject(false)
+			return nil, err
+		}
+		leased.queue = c.queue
+		return &leased, nil
+	}
+}
+
+func (c *consumer) Close() error {
+	if c == nil || c.channel == nil {
+		return nil
+	}
+	c.closeOnce.Do(func() {
+		c.closeErr = c.channel.Close()
+	})
+	return c.closeErr
+}
+
+type delivery struct {
+	queue    *Queue
 	task     *queue.Task
 	delivery amqp.Delivery
-	closer   interface {
-		Close() error
-	}
-
-	closeOnce sync.Once
-	closeErr  error
 }
 
-func (l *rabbitLease) Task() *queue.Task {
-	if l == nil {
+func (d *delivery) Task() *queue.Task {
+	if d == nil {
 		return nil
 	}
-	return l.task
+	return d.task
 }
 
-func (l *rabbitLease) close() error {
-	if l == nil || l.closer == nil {
+func (d *delivery) Ack(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d == nil || d.task == nil {
 		return nil
 	}
-	l.closeOnce.Do(func() {
-		l.closeErr = l.closer.Close()
+	return d.delivery.Ack(false)
+}
+
+func (d *delivery) Retry(ctx context.Context, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d == nil || d.task == nil {
+		return nil
+	}
+
+	task := d.task.Clone()
+	task.AvailableAt = time.Now().UTC().Add(delay)
+	if err := d.queue.publishTask(ctx, task, delay); err != nil {
+		return err
+	}
+	return d.Ack(ctx)
+}
+
+func (d *delivery) DeadLetter(ctx context.Context, reason string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if d == nil || d.task == nil {
+		return nil
+	}
+
+	task := d.task.Clone()
+	if task.Metadata == nil {
+		task.Metadata = make(map[string]string)
+	}
+	task.Metadata[deadReasonKey] = reason
+
+	msg, err := publishingFromTask(task)
+	if err != nil {
+		return err
+	}
+	msg.Headers = amqp.Table{deadReasonKey: reason}
+	err = d.queue.withChannel(ctx, func(ch channel) error {
+		if err := d.queue.ensureDeadLetterQueue(ch, task.Queue); err != nil {
+			return err
+		}
+		return ch.PublishWithContext(ctx, defaultExchange, d.queue.deadLetterQueueName(task.Queue), false, false, msg)
 	})
-	return l.closeErr
-}
-
-func closeLease(lease queue.Lease) {
-	l, ok := lease.(*rabbitLease)
-	if !ok {
-		return
+	if err != nil {
+		return err
 	}
-	_ = l.close()
+	return d.Ack(ctx)
 }

--- a/queue/adapter/rabbitmq/lease.go
+++ b/queue/adapter/rabbitmq/lease.go
@@ -1,6 +1,8 @@
 package rabbitmq
 
 import (
+	"sync"
+
 	"github.com/go-fries/fries/queue/v3"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -8,6 +10,12 @@ import (
 type rabbitLease struct {
 	task     *queue.Task
 	delivery amqp.Delivery
+	closer   interface {
+		Close() error
+	}
+
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func (l *rabbitLease) Task() *queue.Task {
@@ -15,4 +23,22 @@ func (l *rabbitLease) Task() *queue.Task {
 		return nil
 	}
 	return l.task
+}
+
+func (l *rabbitLease) close() error {
+	if l == nil || l.closer == nil {
+		return nil
+	}
+	l.closeOnce.Do(func() {
+		l.closeErr = l.closer.Close()
+	})
+	return l.closeErr
+}
+
+func closeLease(lease queue.Lease) {
+	l, ok := lease.(*rabbitLease)
+	if !ok {
+		return
+	}
+	_ = l.close()
 }

--- a/queue/adapter/rabbitmq/lease.go
+++ b/queue/adapter/rabbitmq/lease.go
@@ -1,0 +1,18 @@
+package rabbitmq
+
+import (
+	"github.com/go-fries/fries/queue/v3"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type rabbitLease struct {
+	task     *queue.Task
+	delivery amqp.Delivery
+}
+
+func (l *rabbitLease) Task() *queue.Task {
+	if l == nil {
+		return nil
+	}
+	return l.task
+}

--- a/queue/adapter/rabbitmq/message.go
+++ b/queue/adapter/rabbitmq/message.go
@@ -30,7 +30,7 @@ func publishingFromTask(task *queue.Task) (amqp.Publishing, error) {
 	}, nil
 }
 
-func leaseFromDelivery(delivery amqp.Delivery) (queue.Lease, error) {
+func leaseFromDelivery(delivery amqp.Delivery, closer interface{ Close() error }) (queue.Lease, error) {
 	var task queue.Task
 	if err := json.Unmarshal(delivery.Body, &task); err != nil {
 		return nil, err
@@ -42,6 +42,7 @@ func leaseFromDelivery(delivery amqp.Delivery) (queue.Lease, error) {
 	return &rabbitLease{
 		task:     &task,
 		delivery: delivery,
+		closer:   closer,
 	}, nil
 }
 

--- a/queue/adapter/rabbitmq/message.go
+++ b/queue/adapter/rabbitmq/message.go
@@ -1,0 +1,80 @@
+package rabbitmq
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/go-fries/fries/queue/v3"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+const (
+	contentTypeJSON = "application/json"
+	deadReasonKey   = "queue.dead_letter.reason"
+)
+
+func publishingFromTask(task *queue.Task) (amqp.Publishing, error) {
+	data, err := json.Marshal(task)
+	if err != nil {
+		return amqp.Publishing{}, err
+	}
+
+	return amqp.Publishing{
+		ContentType:  contentTypeJSON,
+		DeliveryMode: amqp.Persistent,
+		MessageId:    task.ID,
+		Timestamp:    task.CreatedAt,
+		Body:         data,
+	}, nil
+}
+
+func leaseFromDelivery(delivery amqp.Delivery) (queue.Lease, error) {
+	var task queue.Task
+	if err := json.Unmarshal(delivery.Body, &task); err != nil {
+		return nil, err
+	}
+	if task.Queue == "" {
+		task.Queue = queue.DefaultQueue
+	}
+	task.Attempt = nextAttempt(task.Attempt)
+	return &rabbitLease{
+		task:     &task,
+		delivery: delivery,
+	}, nil
+}
+
+func nextAttempt(attempt int) int {
+	if attempt < 0 {
+		return 1
+	}
+	if attempt == math.MaxInt {
+		return math.MaxInt
+	}
+	return attempt + 1
+}
+
+func delayFromAvailableAt(now, availableAt time.Time) time.Duration {
+	if availableAt.IsZero() || !availableAt.After(now) {
+		return 0
+	}
+	return availableAt.Sub(now)
+}
+
+func durationMillis(d time.Duration) int64 {
+	if d <= 0 {
+		return 0
+	}
+	if d < time.Millisecond {
+		return 1
+	}
+	return d.Milliseconds()
+}
+
+func queueDeclareError(name string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("queue/adapter/rabbitmq: declare queue %q: %w", name, err)
+}

--- a/queue/adapter/rabbitmq/message.go
+++ b/queue/adapter/rabbitmq/message.go
@@ -30,19 +30,18 @@ func publishingFromTask(task *queue.Task) (amqp.Publishing, error) {
 	}, nil
 }
 
-func leaseFromDelivery(delivery amqp.Delivery, closer interface{ Close() error }) (queue.Lease, error) {
+func deliveryFromAMQP(amqpDelivery amqp.Delivery) (delivery, error) {
 	var task queue.Task
-	if err := json.Unmarshal(delivery.Body, &task); err != nil {
-		return nil, err
+	if err := json.Unmarshal(amqpDelivery.Body, &task); err != nil {
+		return delivery{}, err
 	}
 	if task.Queue == "" {
 		task.Queue = queue.DefaultQueue
 	}
 	task.Attempt = nextAttempt(task.Attempt)
-	return &rabbitLease{
+	return delivery{
 		task:     &task,
-		delivery: delivery,
-		closer:   closer,
+		delivery: amqpDelivery,
 	}, nil
 }
 

--- a/queue/adapter/rabbitmq/queue.go
+++ b/queue/adapter/rabbitmq/queue.go
@@ -13,18 +13,24 @@ import (
 
 const defaultExchange = ""
 
-var errNilChannel = errors.New("queue/adapter/rabbitmq: channel is nil")
+var (
+	errNilConnection    = errors.New("queue/adapter/rabbitmq: connection is nil")
+	errNilChannelOpener = errors.New("queue/adapter/rabbitmq: channel opener is nil")
+	errNilChannel       = errors.New("queue/adapter/rabbitmq: channel is nil")
+)
 
-// Channel is the subset of an AMQP 0.9.1 channel used by Queue.
-type Channel interface {
+type channel interface {
 	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
 	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	Get(queue string, autoAck bool) (amqp.Delivery, bool, error)
+	Close() error
 }
+
+type channelOpener func(ctx context.Context) (channel, error)
 
 // Queue stores and consumes queue tasks with RabbitMQ.
 type Queue struct {
-	channel       Channel
+	opener        channelOpener
 	prefix        string
 	durable       bool
 	delayQueueTTL time.Duration
@@ -32,11 +38,23 @@ type Queue struct {
 
 var _ queue.Queue = (*Queue)(nil)
 
-// NewQueue creates a RabbitMQ queue adapter using channel.
-func NewQueue(channel Channel, opts ...Option) *Queue {
+// NewQueue creates a RabbitMQ queue adapter using connection.
+func NewQueue(connection *amqp.Connection, opts ...Option) *Queue {
+	return newQueue(func(ctx context.Context) (channel, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if connection == nil {
+			return nil, errNilConnection
+		}
+		return connection.Channel()
+	}, opts...)
+}
+
+func newQueue(opener channelOpener, opts ...Option) *Queue {
 	c := newConfig(opts...)
 	return &Queue{
-		channel:       channel,
+		opener:        opener,
 		prefix:        c.prefix,
 		durable:       c.durable,
 		delayQueueTTL: c.delayQueueTTL,
@@ -67,36 +85,56 @@ func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, err
 	if queueName == "" {
 		queueName = queue.DefaultQueue
 	}
-	if err := q.ensureReadyQueue(queueName); err != nil {
-		return nil, err
-	}
 
-	delivery, ok, err := q.channel.Get(q.readyQueueName(queueName), false)
+	ch, err := q.openChannel(ctx)
 	if err != nil {
 		return nil, err
 	}
+	if err := q.ensureReadyQueue(ch, queueName); err != nil {
+		_ = ch.Close()
+		return nil, err
+	}
+
+	delivery, ok, err := ch.Get(q.readyQueueName(queueName), false)
+	if err != nil {
+		_ = ch.Close()
+		return nil, err
+	}
 	if !ok {
+		_ = ch.Close()
 		return nil, queue.ErrNoTask
 	}
 
-	return leaseFromDelivery(delivery)
+	lease, err := leaseFromDelivery(delivery, ch)
+	if err != nil {
+		_ = ch.Close()
+		return nil, err
+	}
+	return lease, nil
 }
 
 // Ack acknowledges a leased RabbitMQ delivery.
 func (q *Queue) Ack(ctx context.Context, lease queue.Lease) error {
 	if err := ctx.Err(); err != nil {
+		closeLease(lease)
 		return err
 	}
 	l, ok := lease.(*rabbitLease)
 	if !ok || l == nil || l.task == nil {
 		return nil
 	}
-	return l.delivery.Ack(false)
+	err := l.delivery.Ack(false)
+	closeErr := l.close()
+	if err != nil {
+		return err
+	}
+	return closeErr
 }
 
 // Retry republishes a leased task after delay and acknowledges the original delivery.
 func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duration) error {
 	if err := ctx.Err(); err != nil {
+		closeLease(lease)
 		return err
 	}
 	if lease == nil || lease.Task() == nil {
@@ -106,6 +144,7 @@ func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duratio
 	task := lease.Task().Clone()
 	task.AvailableAt = time.Now().UTC().Add(delay)
 	if err := q.publishTask(ctx, task, delay); err != nil {
+		closeLease(lease)
 		return err
 	}
 	return q.Ack(ctx, lease)
@@ -114,6 +153,7 @@ func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duratio
 // DeadLetter publishes a leased task to the dead-letter queue and acknowledges the original delivery.
 func (q *Queue) DeadLetter(ctx context.Context, lease queue.Lease, reason string) error {
 	if err := ctx.Err(); err != nil {
+		closeLease(lease)
 		return err
 	}
 	if lease == nil || lease.Task() == nil {
@@ -126,70 +166,97 @@ func (q *Queue) DeadLetter(ctx context.Context, lease queue.Lease, reason string
 	}
 	task.Metadata[deadReasonKey] = reason
 
-	if err := q.ensureDeadLetterQueue(task.Queue); err != nil {
-		return err
-	}
 	msg, err := publishingFromTask(task)
 	if err != nil {
 		return err
 	}
 	msg.Headers = amqp.Table{deadReasonKey: reason}
-	if err := q.channel.PublishWithContext(ctx, defaultExchange, q.deadLetterQueueName(task.Queue), false, false, msg); err != nil {
+	err = q.withChannel(ctx, func(ch channel) error {
+		if err := q.ensureDeadLetterQueue(ch, task.Queue); err != nil {
+			return err
+		}
+		return ch.PublishWithContext(ctx, defaultExchange, q.deadLetterQueueName(task.Queue), false, false, msg)
+	})
+	if err != nil {
+		closeLease(lease)
 		return err
 	}
 	return q.Ack(ctx, lease)
 }
 
 func (q *Queue) publishTask(ctx context.Context, task *queue.Task, delay time.Duration) error {
-	if q.channel == nil {
-		return errNilChannel
-	}
-	if err := q.ensureReadyQueue(task.Queue); err != nil {
-		return err
-	}
-
 	msg, err := publishingFromTask(task)
 	if err != nil {
 		return err
 	}
 
-	target := q.readyQueueName(task.Queue)
-	if delay > 0 {
-		target = q.delayQueueName(task.Queue, delay)
-		if err := q.ensureDelayQueue(task.Queue, target, delay); err != nil {
+	return q.withChannel(ctx, func(ch channel) error {
+		if err := q.ensureReadyQueue(ch, task.Queue); err != nil {
 			return err
 		}
-	}
-	return q.channel.PublishWithContext(ctx, defaultExchange, target, false, false, msg)
+
+		target := q.readyQueueName(task.Queue)
+		if delay > 0 {
+			target = q.delayQueueName(task.Queue, delay)
+			if err := q.ensureDelayQueue(ch, task.Queue, target, delay); err != nil {
+				return err
+			}
+		}
+		return ch.PublishWithContext(ctx, defaultExchange, target, false, false, msg)
+	})
 }
 
-func (q *Queue) ensureReadyQueue(name string) error {
-	if q.channel == nil {
-		return errNilChannel
-	}
+func (q *Queue) ensureReadyQueue(ch channel, name string) error {
 	queueName := q.readyQueueName(name)
-	_, err := q.channel.QueueDeclare(queueName, q.durable, false, false, false, nil)
+	_, err := ch.QueueDeclare(queueName, q.durable, false, false, false, nil)
 	return queueDeclareError(queueName, err)
 }
 
-func (q *Queue) ensureDeadLetterQueue(name string) error {
-	if q.channel == nil {
-		return errNilChannel
-	}
+func (q *Queue) ensureDeadLetterQueue(ch channel, name string) error {
 	queueName := q.deadLetterQueueName(name)
-	_, err := q.channel.QueueDeclare(queueName, q.durable, false, false, false, nil)
+	_, err := ch.QueueDeclare(queueName, q.durable, false, false, false, nil)
 	return queueDeclareError(queueName, err)
 }
 
-func (q *Queue) ensureDelayQueue(queueName, delayQueueName string, delay time.Duration) error {
+func (q *Queue) ensureDelayQueue(ch channel, queueName, delayQueueName string, delay time.Duration) error {
 	expires := delay + q.delayQueueTTL
-	_, err := q.channel.QueueDeclare(delayQueueName, q.durable, false, false, false, amqp.Table{
+	_, err := ch.QueueDeclare(delayQueueName, q.durable, false, false, false, amqp.Table{
 		"x-message-ttl":             durationMillis(delay),
 		"x-expires":                 durationMillis(expires),
 		"x-dead-letter-exchange":    defaultExchange,
 		"x-dead-letter-routing-key": q.readyQueueName(queueName),
 	})
 	return queueDeclareError(delayQueueName, err)
+}
+
+func (q *Queue) openChannel(ctx context.Context) (channel, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if q.opener == nil {
+		return nil, errNilChannelOpener
+	}
+	ch, err := q.opener(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if ch == nil {
+		return nil, errNilChannel
+	}
+	return ch, nil
+}
+
+func (q *Queue) withChannel(ctx context.Context, fn func(channel) error) error {
+	ch, err := q.openChannel(ctx)
+	if err != nil {
+		return err
+	}
+	err = fn(ch)
+	closeErr := ch.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
 }
 
 func (q *Queue) readyQueueName(name string) string {

--- a/queue/adapter/rabbitmq/queue.go
+++ b/queue/adapter/rabbitmq/queue.go
@@ -1,0 +1,216 @@
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-fries/fries/queue/v3"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+const defaultExchange = ""
+
+var errNilChannel = errors.New("queue/adapter/rabbitmq: channel is nil")
+
+// Channel is the subset of an AMQP 0.9.1 channel used by Queue.
+type Channel interface {
+	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+	Get(queue string, autoAck bool) (amqp.Delivery, bool, error)
+}
+
+// Queue stores and consumes queue tasks with RabbitMQ.
+type Queue struct {
+	channel       Channel
+	prefix        string
+	durable       bool
+	delayQueueTTL time.Duration
+}
+
+var _ queue.Queue = (*Queue)(nil)
+
+// NewQueue creates a RabbitMQ queue adapter using channel.
+func NewQueue(channel Channel, opts ...Option) *Queue {
+	c := newConfig(opts...)
+	return &Queue{
+		channel:       channel,
+		prefix:        c.prefix,
+		durable:       c.durable,
+		delayQueueTTL: c.delayQueueTTL,
+	}
+}
+
+// Enqueue stores task in a ready queue or delay queue.
+func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if task == nil {
+		return nil
+	}
+
+	task = task.Clone()
+	if task.Queue == "" {
+		task.Queue = queue.DefaultQueue
+	}
+	return q.publishTask(ctx, task, delayFromAvailableAt(time.Now().UTC(), task.AvailableAt))
+}
+
+// Dequeue returns one available task lease from queueName.
+func (q *Queue) Dequeue(ctx context.Context, queueName string, _ time.Duration) (queue.Lease, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if queueName == "" {
+		queueName = queue.DefaultQueue
+	}
+	if err := q.ensureReadyQueue(queueName); err != nil {
+		return nil, err
+	}
+
+	delivery, ok, err := q.channel.Get(q.readyQueueName(queueName), false)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, queue.ErrNoTask
+	}
+
+	return leaseFromDelivery(delivery)
+}
+
+// Ack acknowledges a leased RabbitMQ delivery.
+func (q *Queue) Ack(ctx context.Context, lease queue.Lease) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	l, ok := lease.(*rabbitLease)
+	if !ok || l == nil || l.task == nil {
+		return nil
+	}
+	return l.delivery.Ack(false)
+}
+
+// Retry republishes a leased task after delay and acknowledges the original delivery.
+func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if lease == nil || lease.Task() == nil {
+		return nil
+	}
+
+	task := lease.Task().Clone()
+	task.AvailableAt = time.Now().UTC().Add(delay)
+	if err := q.publishTask(ctx, task, delay); err != nil {
+		return err
+	}
+	return q.Ack(ctx, lease)
+}
+
+// DeadLetter publishes a leased task to the dead-letter queue and acknowledges the original delivery.
+func (q *Queue) DeadLetter(ctx context.Context, lease queue.Lease, reason string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if lease == nil || lease.Task() == nil {
+		return nil
+	}
+
+	task := lease.Task().Clone()
+	if task.Metadata == nil {
+		task.Metadata = make(map[string]string)
+	}
+	task.Metadata[deadReasonKey] = reason
+
+	if err := q.ensureDeadLetterQueue(task.Queue); err != nil {
+		return err
+	}
+	msg, err := publishingFromTask(task)
+	if err != nil {
+		return err
+	}
+	msg.Headers = amqp.Table{deadReasonKey: reason}
+	if err := q.channel.PublishWithContext(ctx, defaultExchange, q.deadLetterQueueName(task.Queue), false, false, msg); err != nil {
+		return err
+	}
+	return q.Ack(ctx, lease)
+}
+
+func (q *Queue) publishTask(ctx context.Context, task *queue.Task, delay time.Duration) error {
+	if q.channel == nil {
+		return errNilChannel
+	}
+	if err := q.ensureReadyQueue(task.Queue); err != nil {
+		return err
+	}
+
+	msg, err := publishingFromTask(task)
+	if err != nil {
+		return err
+	}
+
+	target := q.readyQueueName(task.Queue)
+	if delay > 0 {
+		target = q.delayQueueName(task.Queue, delay)
+		if err := q.ensureDelayQueue(task.Queue, target, delay); err != nil {
+			return err
+		}
+	}
+	return q.channel.PublishWithContext(ctx, defaultExchange, target, false, false, msg)
+}
+
+func (q *Queue) ensureReadyQueue(name string) error {
+	if q.channel == nil {
+		return errNilChannel
+	}
+	queueName := q.readyQueueName(name)
+	_, err := q.channel.QueueDeclare(queueName, q.durable, false, false, false, nil)
+	return queueDeclareError(queueName, err)
+}
+
+func (q *Queue) ensureDeadLetterQueue(name string) error {
+	if q.channel == nil {
+		return errNilChannel
+	}
+	queueName := q.deadLetterQueueName(name)
+	_, err := q.channel.QueueDeclare(queueName, q.durable, false, false, false, nil)
+	return queueDeclareError(queueName, err)
+}
+
+func (q *Queue) ensureDelayQueue(queueName, delayQueueName string, delay time.Duration) error {
+	expires := delay + q.delayQueueTTL
+	_, err := q.channel.QueueDeclare(delayQueueName, q.durable, false, false, false, amqp.Table{
+		"x-message-ttl":             durationMillis(delay),
+		"x-expires":                 durationMillis(expires),
+		"x-dead-letter-exchange":    defaultExchange,
+		"x-dead-letter-routing-key": q.readyQueueName(queueName),
+	})
+	return queueDeclareError(delayQueueName, err)
+}
+
+func (q *Queue) readyQueueName(name string) string {
+	return q.queueName(name)
+}
+
+func (q *Queue) delayQueueName(name string, delay time.Duration) string {
+	return q.queueName(name) + ".delay." + strconv.FormatInt(durationMillis(delay), 10)
+}
+
+func (q *Queue) deadLetterQueueName(name string) string {
+	return q.queueName(name) + ".dead"
+}
+
+func (q *Queue) queueName(name string) string {
+	if name == "" {
+		name = queue.DefaultQueue
+	}
+	name = strings.TrimPrefix(name, ".")
+	if q.prefix == "" {
+		return name
+	}
+	return q.prefix + "." + name
+}

--- a/queue/adapter/rabbitmq/queue.go
+++ b/queue/adapter/rabbitmq/queue.go
@@ -107,6 +107,7 @@ func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, err
 
 	lease, err := leaseFromDelivery(delivery, ch)
 	if err != nil {
+		_ = delivery.Reject(false)
 		_ = ch.Close()
 		return nil, err
 	}

--- a/queue/adapter/rabbitmq/queue.go
+++ b/queue/adapter/rabbitmq/queue.go
@@ -22,6 +22,7 @@ var (
 type channel interface {
 	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
 	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+	Qos(prefetchCount, prefetchSize int, global bool) error
 	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
 	Close() error
 }
@@ -34,6 +35,7 @@ type Queue struct {
 	prefix        string
 	durable       bool
 	delayQueueTTL time.Duration
+	prefetch      int
 }
 
 var _ queue.Queue = (*Queue)(nil)
@@ -58,6 +60,7 @@ func newQueue(opener channelOpener, opts ...Option) *Queue {
 		prefix:        c.prefix,
 		durable:       c.durable,
 		delayQueueTTL: c.delayQueueTTL,
+		prefetch:      c.prefetch,
 	}
 }
 
@@ -91,6 +94,10 @@ func (q *Queue) NewConsumer(ctx context.Context, queueName string) (queue.Consum
 		return nil, err
 	}
 	if err := q.ensureReadyQueue(ch, queueName); err != nil {
+		_ = ch.Close()
+		return nil, err
+	}
+	if err := ch.Qos(q.prefetch, 0, false); err != nil {
 		_ = ch.Close()
 		return nil, err
 	}

--- a/queue/adapter/rabbitmq/queue.go
+++ b/queue/adapter/rabbitmq/queue.go
@@ -22,7 +22,7 @@ var (
 type channel interface {
 	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
 	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
-	Get(queue string, autoAck bool) (amqp.Delivery, bool, error)
+	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
 	Close() error
 }
 
@@ -77,8 +77,8 @@ func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
 	return q.publishTask(ctx, task, delayFromAvailableAt(time.Now().UTC(), task.AvailableAt))
 }
 
-// Dequeue returns one available task lease from queueName.
-func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, error) {
+// NewConsumer creates a RabbitMQ consumer for queueName.
+func (q *Queue) NewConsumer(ctx context.Context, queueName string) (queue.Consumer, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -95,94 +95,16 @@ func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, err
 		return nil, err
 	}
 
-	delivery, ok, err := ch.Get(q.readyQueueName(queueName), false)
+	deliveries, err := ch.Consume(q.readyQueueName(queueName), "", false, false, false, false, nil)
 	if err != nil {
 		_ = ch.Close()
 		return nil, err
 	}
-	if !ok {
-		_ = ch.Close()
-		return nil, queue.ErrNoTask
-	}
-
-	lease, err := leaseFromDelivery(delivery, ch)
-	if err != nil {
-		_ = delivery.Reject(false)
-		_ = ch.Close()
-		return nil, err
-	}
-	return lease, nil
-}
-
-// Ack acknowledges a leased RabbitMQ delivery.
-func (q *Queue) Ack(ctx context.Context, lease queue.Lease) error {
-	if err := ctx.Err(); err != nil {
-		closeLease(lease)
-		return err
-	}
-	l, ok := lease.(*rabbitLease)
-	if !ok || l == nil || l.task == nil {
-		return nil
-	}
-	err := l.delivery.Ack(false)
-	closeErr := l.close()
-	if err != nil {
-		return err
-	}
-	return closeErr
-}
-
-// Retry republishes a leased task after delay and acknowledges the original delivery.
-func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duration) error {
-	if err := ctx.Err(); err != nil {
-		closeLease(lease)
-		return err
-	}
-	if lease == nil || lease.Task() == nil {
-		return nil
-	}
-
-	task := lease.Task().Clone()
-	task.AvailableAt = time.Now().UTC().Add(delay)
-	if err := q.publishTask(ctx, task, delay); err != nil {
-		closeLease(lease)
-		return err
-	}
-	return q.Ack(ctx, lease)
-}
-
-// DeadLetter publishes a leased task to the dead-letter queue and acknowledges the original delivery.
-func (q *Queue) DeadLetter(ctx context.Context, lease queue.Lease, reason string) error {
-	if err := ctx.Err(); err != nil {
-		closeLease(lease)
-		return err
-	}
-	if lease == nil || lease.Task() == nil {
-		return nil
-	}
-
-	task := lease.Task().Clone()
-	if task.Metadata == nil {
-		task.Metadata = make(map[string]string)
-	}
-	task.Metadata[deadReasonKey] = reason
-
-	msg, err := publishingFromTask(task)
-	if err != nil {
-		return err
-	}
-	msg.Headers = amqp.Table{deadReasonKey: reason}
-	err = q.withChannel(ctx, func(ch channel) error {
-		if err := q.ensureDeadLetterQueue(ch, task.Queue); err != nil {
-			return err
-		}
-		return ch.PublishWithContext(ctx, defaultExchange, q.deadLetterQueueName(task.Queue), false, false, msg)
-	})
-	if err != nil {
-		closeLease(lease)
-		return err
-	}
-	return q.Ack(ctx, lease)
+	return &consumer{
+		queue:      q,
+		channel:    ch,
+		deliveries: deliveries,
+	}, nil
 }
 
 func (q *Queue) publishTask(ctx context.Context, task *queue.Task, delay time.Duration) error {

--- a/queue/adapter/rabbitmq/queue.go
+++ b/queue/adapter/rabbitmq/queue.go
@@ -60,7 +60,7 @@ func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
 }
 
 // Dequeue returns one available task lease from queueName.
-func (q *Queue) Dequeue(ctx context.Context, queueName string, _ time.Duration) (queue.Lease, error) {
+func (q *Queue) Dequeue(ctx context.Context, queueName string) (queue.Lease, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/queue/adapter/rabbitmq/queue_test.go
+++ b/queue/adapter/rabbitmq/queue_test.go
@@ -127,7 +127,13 @@ func newTestQueue(opener *fakeChannelOpener, opts ...Option) *Queue {
 }
 
 type fakeAcknowledger struct {
-	acks []uint64
+	acks    []uint64
+	rejects []rejectCall
+}
+
+type rejectCall struct {
+	tag     uint64
+	requeue bool
 }
 
 func (a *fakeAcknowledger) Ack(tag uint64, _ bool) error {
@@ -139,7 +145,8 @@ func (*fakeAcknowledger) Nack(uint64, bool, bool) error {
 	return nil
 }
 
-func (*fakeAcknowledger) Reject(uint64, bool) error {
+func (a *fakeAcknowledger) Reject(tag uint64, requeue bool) error {
+	a.rejects = append(a.rejects, rejectCall{tag: tag, requeue: requeue})
 	return nil
 }
 
@@ -258,6 +265,28 @@ func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
 
 	require.NoError(t, q.Ack(t.Context(), lease))
 	assert.Equal(t, []uint64{42}, ack.acks)
+	assert.Equal(t, 1, ch.closed)
+}
+
+func TestQueue_DequeueRejectsMalformedDelivery(t *testing.T) {
+	t.Parallel()
+
+	ack := &fakeAcknowledger{}
+	ch := &fakeChannel{
+		deliveries: []amqp.Delivery{{
+			Body:         []byte("{"),
+			DeliveryTag:  43,
+			Acknowledger: ack,
+		}},
+	}
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
+
+	lease, err := q.Dequeue(t.Context(), "emails")
+
+	require.Error(t, err)
+	assert.Nil(t, lease)
+	assert.Empty(t, ack.acks)
+	assert.Equal(t, []rejectCall{{tag: 43, requeue: false}}, ack.rejects)
 	assert.Equal(t, 1, ch.closed)
 }
 

--- a/queue/adapter/rabbitmq/queue_test.go
+++ b/queue/adapter/rabbitmq/queue_test.go
@@ -184,7 +184,7 @@ func TestQueue_DequeueReturnsNoTask(t *testing.T) {
 	ch := &fakeChannel{}
 	q := NewQueue(ch)
 
-	lease, err := q.Dequeue(t.Context(), "", time.Minute)
+	lease, err := q.Dequeue(t.Context(), "")
 
 	require.ErrorIs(t, err, queue.ErrNoTask)
 	assert.Nil(t, lease)
@@ -208,7 +208,7 @@ func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
 	}
 	q := NewQueue(ch, WithPrefix("app"))
 
-	lease, err := q.Dequeue(t.Context(), "emails", time.Minute)
+	lease, err := q.Dequeue(t.Context(), "emails")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	assert.Equal(t, 3, lease.Task().Attempt)

--- a/queue/adapter/rabbitmq/queue_test.go
+++ b/queue/adapter/rabbitmq/queue_test.go
@@ -30,14 +30,22 @@ type publishCall struct {
 	msg       amqp.Publishing
 }
 
+type qosCall struct {
+	prefetchCount int
+	prefetchSize  int
+	global        bool
+}
+
 type fakeChannel struct {
 	declareErr error
 	publishErr error
+	qosErr     error
 	consumeErr error
 	closeErr   error
 	deliveries []amqp.Delivery
 	declares   []declareCall
 	publishes  []publishCall
+	qoses      []qosCall
 	closed     int
 }
 
@@ -79,6 +87,15 @@ func (c *fakeChannel) PublishWithContext(
 		msg:       msg,
 	})
 	return c.publishErr
+}
+
+func (c *fakeChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
+	c.qoses = append(c.qoses, qosCall{
+		prefetchCount: prefetchCount,
+		prefetchSize:  prefetchSize,
+		global:        global,
+	})
+	return c.qosErr
 }
 
 func (c *fakeChannel) Consume(
@@ -166,6 +183,7 @@ func TestQueue_ConfigDefaultsAndOptions(t *testing.T) {
 		WithPrefix("app."),
 		WithDurable(false),
 		WithDelayQueueTTL(2*time.Hour),
+		WithPrefetch(7),
 	)
 
 	assert.Equal(t, "app.critical", q.readyQueueName("critical"))
@@ -173,6 +191,7 @@ func TestQueue_ConfigDefaultsAndOptions(t *testing.T) {
 	assert.Equal(t, "app.critical.delay.1500", q.delayQueueName("critical", 1500*time.Millisecond))
 	assert.False(t, q.durable)
 	assert.Equal(t, 2*time.Hour, q.delayQueueTTL)
+	assert.Equal(t, 7, q.prefetch)
 }
 
 func TestQueue_EnqueuePublishesReadyTask(t *testing.T) {
@@ -252,6 +271,36 @@ func TestQueue_ReceiveReturnsErrorWhenDeliveriesClose(t *testing.T) {
 	assert.Nil(t, delivery)
 	require.Len(t, ch.declares, 1)
 	assert.Equal(t, "default", ch.declares[0].name)
+	assert.Equal(t, []qosCall{{prefetchCount: defaultPrefetch}}, ch.qoses)
+}
+
+func TestQueue_NewConsumerConfiguresPrefetch(t *testing.T) {
+	t.Parallel()
+
+	ch := &fakeChannel{}
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}}, WithPrefetch(3))
+
+	consumer, err := q.NewConsumer(t.Context(), "emails")
+	require.NoError(t, err)
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	assert.Equal(t, []qosCall{{prefetchCount: 3}}, ch.qoses)
+}
+
+func TestQueue_NewConsumerReturnsQosError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("qos failed")
+	ch := &fakeChannel{qosErr: wantErr}
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
+
+	consumer, err := q.NewConsumer(t.Context(), "emails")
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, consumer)
+	assert.Equal(t, 1, ch.closed)
 }
 
 func TestQueue_ReceiveDecodesTaskAndAck(t *testing.T) {

--- a/queue/adapter/rabbitmq/queue_test.go
+++ b/queue/adapter/rabbitmq/queue_test.go
@@ -1,0 +1,296 @@
+package rabbitmq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-fries/fries/queue/v3"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type declareCall struct {
+	name       string
+	durable    bool
+	autoDelete bool
+	exclusive  bool
+	noWait     bool
+	args       amqp.Table
+}
+
+type publishCall struct {
+	exchange  string
+	key       string
+	mandatory bool
+	immediate bool
+	msg       amqp.Publishing
+}
+
+type fakeChannel struct {
+	declareErr error
+	publishErr error
+	getErr     error
+	deliveries []amqp.Delivery
+	declares   []declareCall
+	publishes  []publishCall
+}
+
+func (c *fakeChannel) QueueDeclare(
+	name string,
+	durable bool,
+	autoDelete bool,
+	exclusive bool,
+	noWait bool,
+	args amqp.Table,
+) (amqp.Queue, error) {
+	c.declares = append(c.declares, declareCall{
+		name:       name,
+		durable:    durable,
+		autoDelete: autoDelete,
+		exclusive:  exclusive,
+		noWait:     noWait,
+		args:       args,
+	})
+	if c.declareErr != nil {
+		return amqp.Queue{}, c.declareErr
+	}
+	return amqp.Queue{Name: name}, nil
+}
+
+func (c *fakeChannel) PublishWithContext(
+	_ context.Context,
+	exchange string,
+	key string,
+	mandatory bool,
+	immediate bool,
+	msg amqp.Publishing,
+) error {
+	c.publishes = append(c.publishes, publishCall{
+		exchange:  exchange,
+		key:       key,
+		mandatory: mandatory,
+		immediate: immediate,
+		msg:       msg,
+	})
+	return c.publishErr
+}
+
+func (c *fakeChannel) Get(string, bool) (amqp.Delivery, bool, error) {
+	if c.getErr != nil {
+		return amqp.Delivery{}, false, c.getErr
+	}
+	if len(c.deliveries) == 0 {
+		return amqp.Delivery{}, false, nil
+	}
+	delivery := c.deliveries[0]
+	c.deliveries = c.deliveries[1:]
+	return delivery, true, nil
+}
+
+type fakeAcknowledger struct {
+	acks []uint64
+}
+
+func (a *fakeAcknowledger) Ack(tag uint64, _ bool) error {
+	a.acks = append(a.acks, tag)
+	return nil
+}
+
+func (*fakeAcknowledger) Nack(uint64, bool, bool) error {
+	return nil
+}
+
+func (*fakeAcknowledger) Reject(uint64, bool) error {
+	return nil
+}
+
+func TestQueue_ConfigDefaultsAndOptions(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueue(&fakeChannel{}, WithPrefix("app."), WithDurable(false), WithDelayQueueTTL(2*time.Hour))
+
+	assert.Equal(t, "app.critical", q.readyQueueName("critical"))
+	assert.Equal(t, "app.critical.dead", q.deadLetterQueueName("critical"))
+	assert.Equal(t, "app.critical.delay.1500", q.delayQueueName("critical", 1500*time.Millisecond))
+	assert.False(t, q.durable)
+	assert.Equal(t, 2*time.Hour, q.delayQueueTTL)
+}
+
+func TestQueue_EnqueuePublishesReadyTask(t *testing.T) {
+	t.Parallel()
+
+	ch := &fakeChannel{}
+	q := NewQueue(ch, WithPrefix("app"))
+	task := &queue.Task{
+		ID:      "task-1",
+		Type:    "send_email",
+		Queue:   "emails",
+		Payload: []byte("hello"),
+	}
+
+	err := q.Enqueue(t.Context(), task)
+	require.NoError(t, err)
+
+	require.Len(t, ch.declares, 1)
+	assert.Equal(t, "app.emails", ch.declares[0].name)
+	assert.True(t, ch.declares[0].durable)
+
+	require.Len(t, ch.publishes, 1)
+	assert.Equal(t, "", ch.publishes[0].exchange)
+	assert.Equal(t, "app.emails", ch.publishes[0].key)
+	assert.Equal(t, amqp.Persistent, ch.publishes[0].msg.DeliveryMode)
+	assert.Equal(t, contentTypeJSON, ch.publishes[0].msg.ContentType)
+	assert.Equal(t, "task-1", ch.publishes[0].msg.MessageId)
+
+	var stored queue.Task
+	require.NoError(t, json.Unmarshal(ch.publishes[0].msg.Body, &stored))
+	assert.Equal(t, "send_email", stored.Type)
+	assert.Equal(t, []byte("hello"), stored.Payload)
+}
+
+func TestQueue_EnqueuePublishesDelayedTask(t *testing.T) {
+	t.Parallel()
+
+	ch := &fakeChannel{}
+	q := NewQueue(ch, WithDelayQueueTTL(2*time.Second))
+	task := &queue.Task{
+		ID:    "task-1",
+		Type:  "send_email",
+		Queue: "emails",
+	}
+
+	err := q.publishTask(t.Context(), task, 1500*time.Millisecond)
+	require.NoError(t, err)
+
+	require.Len(t, ch.declares, 2)
+	assert.Equal(t, "emails", ch.declares[0].name)
+	assert.Equal(t, "emails.delay.1500", ch.declares[1].name)
+	assert.Equal(t, int64(1500), ch.declares[1].args["x-message-ttl"])
+	assert.Equal(t, int64(3500), ch.declares[1].args["x-expires"])
+	assert.Equal(t, "", ch.declares[1].args["x-dead-letter-exchange"])
+	assert.Equal(t, "emails", ch.declares[1].args["x-dead-letter-routing-key"])
+
+	require.Len(t, ch.publishes, 1)
+	assert.Equal(t, "emails.delay.1500", ch.publishes[0].key)
+}
+
+func TestQueue_DequeueReturnsNoTask(t *testing.T) {
+	t.Parallel()
+
+	ch := &fakeChannel{}
+	q := NewQueue(ch)
+
+	lease, err := q.Dequeue(t.Context(), "", time.Minute)
+
+	require.ErrorIs(t, err, queue.ErrNoTask)
+	assert.Nil(t, lease)
+	require.Len(t, ch.declares, 1)
+	assert.Equal(t, "default", ch.declares[0].name)
+}
+
+func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
+	t.Parallel()
+
+	task := &queue.Task{ID: "task-1", Type: "send_email", Queue: "emails", Attempt: 2}
+	body, err := json.Marshal(task)
+	require.NoError(t, err)
+	ack := &fakeAcknowledger{}
+	ch := &fakeChannel{
+		deliveries: []amqp.Delivery{{
+			Body:         body,
+			DeliveryTag:  42,
+			Acknowledger: ack,
+		}},
+	}
+	q := NewQueue(ch, WithPrefix("app"))
+
+	lease, err := q.Dequeue(t.Context(), "emails", time.Minute)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, 3, lease.Task().Attempt)
+
+	require.NoError(t, q.Ack(t.Context(), lease))
+	assert.Equal(t, []uint64{42}, ack.acks)
+}
+
+func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
+	t.Parallel()
+
+	ack := &fakeAcknowledger{}
+	ch := &fakeChannel{}
+	q := NewQueue(ch)
+	lease := &rabbitLease{
+		task: &queue.Task{
+			ID:    "task-1",
+			Type:  "send_email",
+			Queue: "emails",
+		},
+		delivery: amqp.Delivery{DeliveryTag: 7, Acknowledger: ack},
+	}
+
+	err := q.Retry(t.Context(), lease, 2*time.Second)
+	require.NoError(t, err)
+
+	require.Len(t, ch.declares, 2)
+	assert.Equal(t, "emails", ch.declares[0].name)
+	assert.Equal(t, "emails.delay.2000", ch.declares[1].name)
+	assert.Equal(t, int64(2000), ch.declares[1].args["x-message-ttl"])
+	require.Len(t, ch.publishes, 1)
+	assert.Equal(t, "emails.delay.2000", ch.publishes[0].key)
+	assert.Equal(t, []uint64{7}, ack.acks)
+}
+
+func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
+	t.Parallel()
+
+	ack := &fakeAcknowledger{}
+	ch := &fakeChannel{}
+	q := NewQueue(ch)
+	lease := &rabbitLease{
+		task: &queue.Task{
+			ID:    "task-1",
+			Type:  "send_email",
+			Queue: "emails",
+		},
+		delivery: amqp.Delivery{DeliveryTag: 8, Acknowledger: ack},
+	}
+
+	err := q.DeadLetter(t.Context(), lease, "retry exhausted")
+	require.NoError(t, err)
+
+	require.Len(t, ch.declares, 1)
+	assert.Equal(t, "emails.dead", ch.declares[0].name)
+	require.Len(t, ch.publishes, 1)
+	assert.Equal(t, "emails.dead", ch.publishes[0].key)
+	assert.Equal(t, "retry exhausted", ch.publishes[0].msg.Headers[deadReasonKey])
+	assert.Equal(t, []uint64{8}, ack.acks)
+
+	var stored queue.Task
+	require.NoError(t, json.Unmarshal(ch.publishes[0].msg.Body, &stored))
+	assert.Equal(t, "retry exhausted", stored.Metadata[deadReasonKey])
+}
+
+func TestQueue_NilChannelReturnsError(t *testing.T) {
+	t.Parallel()
+
+	q := NewQueue(nil)
+
+	err := q.Enqueue(t.Context(), &queue.Task{Type: "send_email"})
+
+	require.ErrorIs(t, err, errNilChannel)
+}
+
+func TestQueue_PropagatesChannelErrors(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("declare failed")
+	q := NewQueue(&fakeChannel{declareErr: wantErr})
+
+	err := q.Enqueue(t.Context(), &queue.Task{Type: "send_email"})
+
+	require.ErrorIs(t, err, wantErr)
+}

--- a/queue/adapter/rabbitmq/queue_test.go
+++ b/queue/adapter/rabbitmq/queue_test.go
@@ -33,7 +33,7 @@ type publishCall struct {
 type fakeChannel struct {
 	declareErr error
 	publishErr error
-	getErr     error
+	consumeErr error
 	closeErr   error
 	deliveries []amqp.Delivery
 	declares   []declareCall
@@ -81,16 +81,24 @@ func (c *fakeChannel) PublishWithContext(
 	return c.publishErr
 }
 
-func (c *fakeChannel) Get(string, bool) (amqp.Delivery, bool, error) {
-	if c.getErr != nil {
-		return amqp.Delivery{}, false, c.getErr
+func (c *fakeChannel) Consume(
+	string,
+	string,
+	bool,
+	bool,
+	bool,
+	bool,
+	amqp.Table,
+) (<-chan amqp.Delivery, error) {
+	if c.consumeErr != nil {
+		return nil, c.consumeErr
 	}
-	if len(c.deliveries) == 0 {
-		return amqp.Delivery{}, false, nil
+	deliveries := make(chan amqp.Delivery, len(c.deliveries))
+	for _, delivery := range c.deliveries {
+		deliveries <- delivery
 	}
-	delivery := c.deliveries[0]
-	c.deliveries = c.deliveries[1:]
-	return delivery, true, nil
+	close(deliveries)
+	return deliveries, nil
 }
 
 func (c *fakeChannel) Close() error {
@@ -227,22 +235,26 @@ func TestQueue_EnqueuePublishesDelayedTask(t *testing.T) {
 	assert.Equal(t, 1, ch.closed)
 }
 
-func TestQueue_DequeueReturnsNoTask(t *testing.T) {
+func TestQueue_ReceiveReturnsErrorWhenDeliveriesClose(t *testing.T) {
 	t.Parallel()
 
 	ch := &fakeChannel{}
 	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
 
-	lease, err := q.Dequeue(t.Context(), "")
+	consumer, err := q.NewConsumer(t.Context(), "")
+	require.NoError(t, err)
+	defer func() {
+		_ = consumer.Close()
+	}()
+	delivery, err := consumer.Receive(t.Context())
 
-	require.ErrorIs(t, err, queue.ErrNoTask)
-	assert.Nil(t, lease)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, delivery)
 	require.Len(t, ch.declares, 1)
 	assert.Equal(t, "default", ch.declares[0].name)
-	assert.Equal(t, 1, ch.closed)
 }
 
-func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
+func TestQueue_ReceiveDecodesTaskAndAck(t *testing.T) {
 	t.Parallel()
 
 	task := &queue.Task{ID: "task-1", Type: "send_email", Queue: "emails", Attempt: 2}
@@ -258,17 +270,22 @@ func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
 	}
 	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}}, WithPrefix("app"))
 
-	lease, err := q.Dequeue(t.Context(), "emails")
+	consumer, err := q.NewConsumer(t.Context(), "emails")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	assert.Equal(t, 3, lease.Task().Attempt)
+	defer func() {
+		_ = consumer.Close()
+	}()
+	delivery, err := consumer.Receive(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, delivery)
+	assert.Equal(t, 3, delivery.Task().Attempt)
 
-	require.NoError(t, q.Ack(t.Context(), lease))
+	require.NoError(t, delivery.Ack(t.Context()))
 	assert.Equal(t, []uint64{42}, ack.acks)
-	assert.Equal(t, 1, ch.closed)
+	assert.Zero(t, ch.closed)
 }
 
-func TestQueue_DequeueRejectsMalformedDelivery(t *testing.T) {
+func TestQueue_ReceiveRejectsMalformedDelivery(t *testing.T) {
 	t.Parallel()
 
 	ack := &fakeAcknowledger{}
@@ -281,13 +298,17 @@ func TestQueue_DequeueRejectsMalformedDelivery(t *testing.T) {
 	}
 	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
 
-	lease, err := q.Dequeue(t.Context(), "emails")
+	consumer, err := q.NewConsumer(t.Context(), "emails")
+	require.NoError(t, err)
+	defer func() {
+		_ = consumer.Close()
+	}()
+	delivery, err := consumer.Receive(t.Context())
 
 	require.Error(t, err)
-	assert.Nil(t, lease)
+	assert.Nil(t, delivery)
 	assert.Empty(t, ack.acks)
 	assert.Equal(t, []rejectCall{{tag: 43, requeue: false}}, ack.rejects)
-	assert.Equal(t, 1, ch.closed)
 }
 
 func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
@@ -295,19 +316,18 @@ func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
 
 	ack := &fakeAcknowledger{}
 	ch := &fakeChannel{}
-	leaseCh := &fakeChannel{}
 	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
-	lease := &rabbitLease{
+	delivery := &delivery{
+		queue: q,
 		task: &queue.Task{
 			ID:    "task-1",
 			Type:  "send_email",
 			Queue: "emails",
 		},
 		delivery: amqp.Delivery{DeliveryTag: 7, Acknowledger: ack},
-		closer:   leaseCh,
 	}
 
-	err := q.Retry(t.Context(), lease, 2*time.Second)
+	err := delivery.Retry(t.Context(), 2*time.Second)
 	require.NoError(t, err)
 
 	require.Len(t, ch.declares, 2)
@@ -318,7 +338,6 @@ func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
 	assert.Equal(t, "emails.delay.2000", ch.publishes[0].key)
 	assert.Equal(t, []uint64{7}, ack.acks)
 	assert.Equal(t, 1, ch.closed)
-	assert.Equal(t, 1, leaseCh.closed)
 }
 
 func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
@@ -326,19 +345,18 @@ func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
 
 	ack := &fakeAcknowledger{}
 	ch := &fakeChannel{}
-	leaseCh := &fakeChannel{}
 	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
-	lease := &rabbitLease{
+	delivery := &delivery{
+		queue: q,
 		task: &queue.Task{
 			ID:    "task-1",
 			Type:  "send_email",
 			Queue: "emails",
 		},
 		delivery: amqp.Delivery{DeliveryTag: 8, Acknowledger: ack},
-		closer:   leaseCh,
 	}
 
-	err := q.DeadLetter(t.Context(), lease, "retry exhausted")
+	err := delivery.DeadLetter(t.Context(), "retry exhausted")
 	require.NoError(t, err)
 
 	require.Len(t, ch.declares, 1)
@@ -352,29 +370,24 @@ func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
 	require.NoError(t, json.Unmarshal(ch.publishes[0].msg.Body, &stored))
 	assert.Equal(t, "retry exhausted", stored.Metadata[deadReasonKey])
 	assert.Equal(t, 1, ch.closed)
-	assert.Equal(t, 1, leaseCh.closed)
 }
 
-func TestQueue_AckWithCanceledContextClosesLease(t *testing.T) {
+func TestQueue_AckWithCanceledContextDoesNotAck(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	ack := &fakeAcknowledger{}
-	leaseCh := &fakeChannel{}
-	q := newTestQueue(&fakeChannelOpener{})
-	lease := &rabbitLease{
+	delivery := &delivery{
 		task:     &queue.Task{ID: "task-1", Type: "send_email", Queue: "emails"},
 		delivery: amqp.Delivery{DeliveryTag: 9, Acknowledger: ack},
-		closer:   leaseCh,
 	}
 
-	err := q.Ack(ctx, lease)
+	err := delivery.Ack(ctx)
 
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Empty(t, ack.acks)
-	assert.Equal(t, 1, leaseCh.closed)
 }
 
 func TestQueue_NilChannelReturnsError(t *testing.T) {

--- a/queue/adapter/rabbitmq/queue_test.go
+++ b/queue/adapter/rabbitmq/queue_test.go
@@ -34,9 +34,11 @@ type fakeChannel struct {
 	declareErr error
 	publishErr error
 	getErr     error
+	closeErr   error
 	deliveries []amqp.Delivery
 	declares   []declareCall
 	publishes  []publishCall
+	closed     int
 }
 
 func (c *fakeChannel) QueueDeclare(
@@ -91,6 +93,39 @@ func (c *fakeChannel) Get(string, bool) (amqp.Delivery, bool, error) {
 	return delivery, true, nil
 }
 
+func (c *fakeChannel) Close() error {
+	c.closed++
+	return c.closeErr
+}
+
+type fakeChannelOpener struct {
+	channels []*fakeChannel
+	err      error
+	opened   []*fakeChannel
+}
+
+func (o *fakeChannelOpener) openChannel(context.Context) (channel, error) {
+	if o.err != nil {
+		return nil, o.err
+	}
+	var ch *fakeChannel
+	if len(o.channels) > 0 {
+		ch = o.channels[0]
+		o.channels = o.channels[1:]
+	} else {
+		ch = &fakeChannel{}
+	}
+	if ch == nil {
+		return nil, nil
+	}
+	o.opened = append(o.opened, ch)
+	return ch, nil
+}
+
+func newTestQueue(opener *fakeChannelOpener, opts ...Option) *Queue {
+	return newQueue(opener.openChannel, opts...)
+}
+
 type fakeAcknowledger struct {
 	acks []uint64
 }
@@ -111,7 +146,12 @@ func (*fakeAcknowledger) Reject(uint64, bool) error {
 func TestQueue_ConfigDefaultsAndOptions(t *testing.T) {
 	t.Parallel()
 
-	q := NewQueue(&fakeChannel{}, WithPrefix("app."), WithDurable(false), WithDelayQueueTTL(2*time.Hour))
+	q := newTestQueue(
+		&fakeChannelOpener{},
+		WithPrefix("app."),
+		WithDurable(false),
+		WithDelayQueueTTL(2*time.Hour),
+	)
 
 	assert.Equal(t, "app.critical", q.readyQueueName("critical"))
 	assert.Equal(t, "app.critical.dead", q.deadLetterQueueName("critical"))
@@ -124,7 +164,7 @@ func TestQueue_EnqueuePublishesReadyTask(t *testing.T) {
 	t.Parallel()
 
 	ch := &fakeChannel{}
-	q := NewQueue(ch, WithPrefix("app"))
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}}, WithPrefix("app"))
 	task := &queue.Task{
 		ID:      "task-1",
 		Type:    "send_email",
@@ -150,13 +190,14 @@ func TestQueue_EnqueuePublishesReadyTask(t *testing.T) {
 	require.NoError(t, json.Unmarshal(ch.publishes[0].msg.Body, &stored))
 	assert.Equal(t, "send_email", stored.Type)
 	assert.Equal(t, []byte("hello"), stored.Payload)
+	assert.Equal(t, 1, ch.closed)
 }
 
 func TestQueue_EnqueuePublishesDelayedTask(t *testing.T) {
 	t.Parallel()
 
 	ch := &fakeChannel{}
-	q := NewQueue(ch, WithDelayQueueTTL(2*time.Second))
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}}, WithDelayQueueTTL(2*time.Second))
 	task := &queue.Task{
 		ID:    "task-1",
 		Type:  "send_email",
@@ -176,13 +217,14 @@ func TestQueue_EnqueuePublishesDelayedTask(t *testing.T) {
 
 	require.Len(t, ch.publishes, 1)
 	assert.Equal(t, "emails.delay.1500", ch.publishes[0].key)
+	assert.Equal(t, 1, ch.closed)
 }
 
 func TestQueue_DequeueReturnsNoTask(t *testing.T) {
 	t.Parallel()
 
 	ch := &fakeChannel{}
-	q := NewQueue(ch)
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
 
 	lease, err := q.Dequeue(t.Context(), "")
 
@@ -190,6 +232,7 @@ func TestQueue_DequeueReturnsNoTask(t *testing.T) {
 	assert.Nil(t, lease)
 	require.Len(t, ch.declares, 1)
 	assert.Equal(t, "default", ch.declares[0].name)
+	assert.Equal(t, 1, ch.closed)
 }
 
 func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
@@ -206,7 +249,7 @@ func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
 			Acknowledger: ack,
 		}},
 	}
-	q := NewQueue(ch, WithPrefix("app"))
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}}, WithPrefix("app"))
 
 	lease, err := q.Dequeue(t.Context(), "emails")
 	require.NoError(t, err)
@@ -215,6 +258,7 @@ func TestQueue_DequeueDecodesTaskAndAck(t *testing.T) {
 
 	require.NoError(t, q.Ack(t.Context(), lease))
 	assert.Equal(t, []uint64{42}, ack.acks)
+	assert.Equal(t, 1, ch.closed)
 }
 
 func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
@@ -222,7 +266,8 @@ func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
 
 	ack := &fakeAcknowledger{}
 	ch := &fakeChannel{}
-	q := NewQueue(ch)
+	leaseCh := &fakeChannel{}
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
 	lease := &rabbitLease{
 		task: &queue.Task{
 			ID:    "task-1",
@@ -230,6 +275,7 @@ func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
 			Queue: "emails",
 		},
 		delivery: amqp.Delivery{DeliveryTag: 7, Acknowledger: ack},
+		closer:   leaseCh,
 	}
 
 	err := q.Retry(t.Context(), lease, 2*time.Second)
@@ -242,6 +288,8 @@ func TestQueue_RetryPublishesDelayedTaskAndAcksOriginal(t *testing.T) {
 	require.Len(t, ch.publishes, 1)
 	assert.Equal(t, "emails.delay.2000", ch.publishes[0].key)
 	assert.Equal(t, []uint64{7}, ack.acks)
+	assert.Equal(t, 1, ch.closed)
+	assert.Equal(t, 1, leaseCh.closed)
 }
 
 func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
@@ -249,7 +297,8 @@ func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
 
 	ack := &fakeAcknowledger{}
 	ch := &fakeChannel{}
-	q := NewQueue(ch)
+	leaseCh := &fakeChannel{}
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{ch}})
 	lease := &rabbitLease{
 		task: &queue.Task{
 			ID:    "task-1",
@@ -257,6 +306,7 @@ func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
 			Queue: "emails",
 		},
 		delivery: amqp.Delivery{DeliveryTag: 8, Acknowledger: ack},
+		closer:   leaseCh,
 	}
 
 	err := q.DeadLetter(t.Context(), lease, "retry exhausted")
@@ -272,12 +322,36 @@ func TestQueue_DeadLetterPublishesReasonAndAcksOriginal(t *testing.T) {
 	var stored queue.Task
 	require.NoError(t, json.Unmarshal(ch.publishes[0].msg.Body, &stored))
 	assert.Equal(t, "retry exhausted", stored.Metadata[deadReasonKey])
+	assert.Equal(t, 1, ch.closed)
+	assert.Equal(t, 1, leaseCh.closed)
+}
+
+func TestQueue_AckWithCanceledContextClosesLease(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	ack := &fakeAcknowledger{}
+	leaseCh := &fakeChannel{}
+	q := newTestQueue(&fakeChannelOpener{})
+	lease := &rabbitLease{
+		task:     &queue.Task{ID: "task-1", Type: "send_email", Queue: "emails"},
+		delivery: amqp.Delivery{DeliveryTag: 9, Acknowledger: ack},
+		closer:   leaseCh,
+	}
+
+	err := q.Ack(ctx, lease)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, ack.acks)
+	assert.Equal(t, 1, leaseCh.closed)
 }
 
 func TestQueue_NilChannelReturnsError(t *testing.T) {
 	t.Parallel()
 
-	q := NewQueue(nil)
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{nil}})
 
 	err := q.Enqueue(t.Context(), &queue.Task{Type: "send_email"})
 
@@ -288,7 +362,7 @@ func TestQueue_PropagatesChannelErrors(t *testing.T) {
 	t.Parallel()
 
 	wantErr := errors.New("declare failed")
-	q := NewQueue(&fakeChannel{declareErr: wantErr})
+	q := newTestQueue(&fakeChannelOpener{channels: []*fakeChannel{{declareErr: wantErr}}})
 
 	err := q.Enqueue(t.Context(), &queue.Task{Type: "send_email"})
 

--- a/queue/adapter/redis/README.md
+++ b/queue/adapter/redis/README.md
@@ -51,5 +51,5 @@ and exhausted tasks in a dead-letter stream. Consumer groups are created lazily
 with `XGROUP CREATE ... MKSTREAM`.
 
 `WithClaimMinIdle` controls how long a pending stream message must remain idle
-before `Dequeue` can claim it for redelivery. Set it to `0` to disable pending
-message claims during dequeue.
+before a consumer can claim it for redelivery. Set it to `0` to disable pending
+message claims during receive.

--- a/queue/adapter/redis/README.md
+++ b/queue/adapter/redis/README.md
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-fries/fries/queue/v3"
 	"github.com/go-fries/fries/queue/adapter/redis/v3"
@@ -28,6 +29,7 @@ func main() {
 		redis.WithPrefix("app"),
 		redis.WithGroup("workers"),
 		redis.WithConsumer("worker-1"),
+		redis.WithClaimMinIdle(5*time.Minute),
 	)
 
 	producer := queue.NewProducer(q)
@@ -47,3 +49,7 @@ func main() {
 The queue stores ready tasks in Redis Streams, delayed tasks in a sorted set,
 and exhausted tasks in a dead-letter stream. Consumer groups are created lazily
 with `XGROUP CREATE ... MKSTREAM`.
+
+`WithClaimMinIdle` controls how long a pending stream message must remain idle
+before `Dequeue` can claim it for redelivery. Set it to `0` to disable pending
+message claims during dequeue.

--- a/queue/adapter/redis/config.go
+++ b/queue/adapter/redis/config.go
@@ -51,7 +51,7 @@ func WithConsumer(consumer string) Option {
 	})
 }
 
-// WithPromoteSize sets the maximum delayed tasks promoted before each dequeue.
+// WithPromoteSize sets the maximum delayed tasks promoted before each receive attempt.
 func WithPromoteSize(size int) Option {
 	return optionFunc(func(c *config) {
 		if size > 0 {
@@ -60,9 +60,9 @@ func WithPromoteSize(size int) Option {
 	})
 }
 
-// WithClaimMinIdle sets how long a pending stream message must remain idle before Dequeue can claim it.
+// WithClaimMinIdle sets how long a pending stream message must remain idle before a consumer can claim it.
 //
-// Set minIdle to 0 to disable pending message claims during Dequeue.
+// Set minIdle to 0 to disable pending message claims during receive.
 func WithClaimMinIdle(minIdle time.Duration) Option {
 	return optionFunc(func(c *config) {
 		if minIdle >= 0 {

--- a/queue/adapter/redis/config.go
+++ b/queue/adapter/redis/config.go
@@ -1,12 +1,16 @@
 package redis
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 type config struct {
-	prefix      string
-	group       string
-	consumer    string
-	promoteSize int
+	prefix       string
+	group        string
+	consumer     string
+	promoteSize  int
+	claimMinIdle time.Duration
 }
 
 // Option configures a Redis queue.
@@ -56,12 +60,24 @@ func WithPromoteSize(size int) Option {
 	})
 }
 
+// WithClaimMinIdle sets how long a pending stream message must remain idle before Dequeue can claim it.
+//
+// Set minIdle to 0 to disable pending message claims during Dequeue.
+func WithClaimMinIdle(minIdle time.Duration) Option {
+	return optionFunc(func(c *config) {
+		if minIdle >= 0 {
+			c.claimMinIdle = minIdle
+		}
+	})
+}
+
 func newConfig(opts ...Option) *config {
 	c := &config{
-		prefix:      "queue",
-		group:       "queue",
-		consumer:    "worker",
-		promoteSize: 100,
+		prefix:       "queue",
+		group:        "queue",
+		consumer:     "worker",
+		promoteSize:  100,
+		claimMinIdle: 5 * time.Minute,
 	}
 	for _, opt := range opts {
 		opt.apply(c)

--- a/queue/adapter/redis/lease.go
+++ b/queue/adapter/redis/lease.go
@@ -1,15 +1,64 @@
 package redis
 
-import "github.com/go-fries/fries/queue/v3"
+import (
+	"context"
+	"encoding/json"
+	"time"
 
-type redisLease struct {
+	"github.com/go-fries/fries/queue/v3"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+type redisDelivery struct {
+	queue    *Queue
 	task     *queue.Task
 	streamID string
 }
 
-func (l *redisLease) Task() *queue.Task {
-	if l == nil {
+func (d *redisDelivery) Task() *queue.Task {
+	if d == nil {
 		return nil
 	}
-	return l.task
+	return d.task
+}
+
+func (d *redisDelivery) Ack(ctx context.Context) error {
+	if d == nil || d.queue == nil || d.task == nil || d.streamID == "" {
+		return nil
+	}
+	return d.queue.redis.XAck(ctx, d.queue.streamKey(d.task.Queue), d.queue.group, d.streamID).Err()
+}
+
+func (d *redisDelivery) Retry(ctx context.Context, delay time.Duration) error {
+	if d == nil || d.task == nil {
+		return nil
+	}
+
+	task := d.task.Clone()
+	task.AvailableAt = time.Now().UTC().Add(delay)
+	if err := d.queue.Enqueue(ctx, task); err != nil {
+		return err
+	}
+	return d.Ack(ctx)
+}
+
+func (d *redisDelivery) DeadLetter(ctx context.Context, reason string) error {
+	if d == nil || d.task == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(d.task)
+	if err != nil {
+		return err
+	}
+	if err := d.queue.redis.XAdd(ctx, &goredis.XAddArgs{
+		Stream: d.queue.deadLetterKey(d.task.Queue),
+		Values: map[string]any{
+			taskField:       data,
+			deadReasonField: reason,
+		},
+	}).Err(); err != nil {
+		return err
+	}
+	return d.Ack(ctx)
 }

--- a/queue/adapter/redis/message.go
+++ b/queue/adapter/redis/message.go
@@ -12,7 +12,7 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 )
 
-func (q *Queue) claimPending(ctx context.Context, name string, minIdle time.Duration) (queue.Lease, error) {
+func (q *Queue) claimPending(ctx context.Context, name string, minIdle time.Duration) (queue.Delivery, error) {
 	messages, _, err := q.redis.XAutoClaim(ctx, &goredis.XAutoClaimArgs{
 		Stream:   q.streamKey(name),
 		Group:    q.group,
@@ -33,11 +33,11 @@ func (q *Queue) claimPending(ctx context.Context, name string, minIdle time.Dura
 	return q.leaseFromClaimedMessage(ctx, name, messages[0])
 }
 
-func (q *Queue) leaseFromMessage(message goredis.XMessage) (queue.Lease, error) {
+func (q *Queue) leaseFromMessage(message goredis.XMessage) (queue.Delivery, error) {
 	return q.leaseFromMessageWithDeliveryCount(message, 0)
 }
 
-func (q *Queue) leaseFromClaimedMessage(ctx context.Context, name string, message goredis.XMessage) (queue.Lease, error) {
+func (q *Queue) leaseFromClaimedMessage(ctx context.Context, name string, message goredis.XMessage) (queue.Delivery, error) {
 	deliveryCount, err := q.deliveryCount(ctx, name, message.ID)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (q *Queue) deliveryCount(ctx context.Context, name, messageID string) (int6
 	return pending[0].RetryCount, nil
 }
 
-func (q *Queue) leaseFromMessageWithDeliveryCount(message goredis.XMessage, deliveryCount int64) (queue.Lease, error) {
+func (q *Queue) leaseFromMessageWithDeliveryCount(message goredis.XMessage, deliveryCount int64) (queue.Delivery, error) {
 	value, ok := message.Values[taskField]
 	if !ok {
 		return nil, fmt.Errorf("queue/adapter/redis: message %s missing %q field", message.ID, taskField)
@@ -86,7 +86,8 @@ func (q *Queue) leaseFromMessageWithDeliveryCount(message goredis.XMessage, deli
 		return nil, err
 	}
 	task.Attempt = attemptWithDeliveryCount(task.Attempt, deliveryCount)
-	return &redisLease{
+	return &redisDelivery{
+		queue:    q,
 		task:     &task,
 		streamID: message.ID,
 	}, nil

--- a/queue/adapter/redis/message.go
+++ b/queue/adapter/redis/message.go
@@ -12,12 +12,12 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 )
 
-func (q *Queue) claimPending(ctx context.Context, name string, visibilityTimeout time.Duration) (queue.Lease, error) {
+func (q *Queue) claimPending(ctx context.Context, name string, minIdle time.Duration) (queue.Lease, error) {
 	messages, _, err := q.redis.XAutoClaim(ctx, &goredis.XAutoClaimArgs{
 		Stream:   q.streamKey(name),
 		Group:    q.group,
 		Consumer: q.consumer,
-		MinIdle:  visibilityTimeout,
+		MinIdle:  minIdle,
 		Start:    "0-0",
 		Count:    1,
 	}).Result()

--- a/queue/adapter/redis/message.go
+++ b/queue/adapter/redis/message.go
@@ -28,6 +28,44 @@ func (q *Queue) claimPending(ctx context.Context, name string, minIdle time.Dura
 		return nil, err
 	}
 	if len(messages) == 0 {
+		return q.claimPendingWithXClaim(ctx, name, minIdle)
+	}
+	return q.leaseFromClaimedMessage(ctx, name, messages[0])
+}
+
+func (q *Queue) claimPendingWithXClaim(ctx context.Context, name string, minIdle time.Duration) (queue.Delivery, error) {
+	pending, err := q.redis.XPendingExt(ctx, &goredis.XPendingExtArgs{
+		Stream: q.streamKey(name),
+		Group:  q.group,
+		Idle:   minIdle,
+		Start:  "-",
+		End:    "+",
+		Count:  1,
+	}).Result()
+	if errors.Is(err, goredis.Nil) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(pending) == 0 {
+		return nil, nil
+	}
+
+	messages, err := q.redis.XClaim(ctx, &goredis.XClaimArgs{
+		Stream:   q.streamKey(name),
+		Group:    q.group,
+		Consumer: q.consumer,
+		MinIdle:  minIdle,
+		Messages: []string{pending[0].ID},
+	}).Result()
+	if errors.Is(err, goredis.Nil) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 0 {
 		return nil, nil
 	}
 	return q.leaseFromClaimedMessage(ctx, name, messages[0])

--- a/queue/adapter/redis/queue.go
+++ b/queue/adapter/redis/queue.go
@@ -13,6 +13,7 @@ import (
 const (
 	taskField       = "task"
 	deadReasonField = "reason"
+	receiveBlock    = time.Second
 )
 
 // Queue stores and consumes queue tasks with Redis Streams.
@@ -68,25 +69,68 @@ func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
 	return q.addToStream(ctx, task.Queue, data)
 }
 
-// Dequeue returns a task lease from a Redis stream consumer group.
-func (q *Queue) Dequeue(ctx context.Context, name string) (queue.Lease, error) {
+// NewConsumer creates a Redis Streams consumer for name.
+func (q *Queue) NewConsumer(ctx context.Context, name string) (queue.Consumer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if name == "" {
 		name = queue.DefaultQueue
 	}
 	if err := q.ensureGroup(ctx, name); err != nil {
 		return nil, err
 	}
+
+	consumerCtx, cancel := context.WithCancel(context.Background())
+	return &consumer{
+		queue:  q,
+		name:   name,
+		ctx:    consumerCtx,
+		cancel: cancel,
+	}, nil
+}
+
+type consumer struct {
+	queue  *Queue
+	name   string
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (c *consumer) Receive(ctx context.Context) (queue.Delivery, error) {
+	receiveCtx, cancel := context.WithCancel(ctx)
+	stop := context.AfterFunc(c.ctx, cancel)
+	defer func() {
+		stop()
+		cancel()
+	}()
+
+	for {
+		delivery, err := c.queue.receive(receiveCtx, c.name)
+		if errors.Is(err, queue.ErrNoTask) {
+			continue
+		}
+		return delivery, err
+	}
+}
+
+func (c *consumer) Close() error {
+	c.cancel()
+	return nil
+}
+
+func (q *Queue) receive(ctx context.Context, name string) (queue.Delivery, error) {
 	if err := q.promoteDue(ctx, name); err != nil {
 		return nil, err
 	}
 
 	if q.claimMinIdle > 0 {
-		lease, err := q.claimPending(ctx, name, q.claimMinIdle)
+		delivery, err := q.claimPending(ctx, name, q.claimMinIdle)
 		if err != nil {
 			return nil, err
 		}
-		if lease != nil {
-			return lease, nil
+		if delivery != nil {
+			return delivery, nil
 		}
 	}
 
@@ -95,7 +139,7 @@ func (q *Queue) Dequeue(ctx context.Context, name string) (queue.Lease, error) {
 		Consumer: q.consumer,
 		Streams:  []string{q.streamKey(name), ">"},
 		Count:    1,
-		Block:    -1,
+		Block:    receiveBlock,
 	}).Result()
 	if errors.Is(err, goredis.Nil) {
 		return nil, queue.ErrNoTask
@@ -108,57 +152,4 @@ func (q *Queue) Dequeue(ctx context.Context, name string) (queue.Lease, error) {
 	}
 
 	return q.leaseFromMessage(streams[0].Messages[0])
-}
-
-// Ack acknowledges a leased stream message.
-func (q *Queue) Ack(ctx context.Context, lease queue.Lease) error {
-	l, ok := lease.(*redisLease)
-	if !ok || l == nil || l.task == nil || l.streamID == "" {
-		return nil
-	}
-	return q.redis.XAck(ctx, q.streamKey(l.task.Queue), q.group, l.streamID).Err()
-}
-
-// Retry re-enqueues a leased task and acknowledges the original stream message.
-func (q *Queue) Retry(ctx context.Context, lease queue.Lease, delay time.Duration) error {
-	if lease == nil {
-		return nil
-	}
-	task := lease.Task()
-	if task == nil {
-		return nil
-	}
-
-	task = task.Clone()
-	task.AvailableAt = time.Now().UTC().Add(delay)
-	if err := q.Enqueue(ctx, task); err != nil {
-		return err
-	}
-	return q.Ack(ctx, lease)
-}
-
-// DeadLetter writes a leased task to the dead-letter stream and acknowledges the original message.
-func (q *Queue) DeadLetter(ctx context.Context, lease queue.Lease, reason string) error {
-	if lease == nil {
-		return nil
-	}
-	task := lease.Task()
-	if task == nil {
-		return nil
-	}
-
-	data, err := json.Marshal(task)
-	if err != nil {
-		return err
-	}
-	if err := q.redis.XAdd(ctx, &goredis.XAddArgs{
-		Stream: q.deadLetterKey(task.Queue),
-		Values: map[string]any{
-			taskField:       data,
-			deadReasonField: reason,
-		},
-	}).Err(); err != nil {
-		return err
-	}
-	return q.Ack(ctx, lease)
 }

--- a/queue/adapter/redis/queue.go
+++ b/queue/adapter/redis/queue.go
@@ -17,11 +17,12 @@ const (
 
 // Queue stores and consumes queue tasks with Redis Streams.
 type Queue struct {
-	redis       goredis.UniversalClient
-	prefix      string
-	group       string
-	consumer    string
-	promoteSize int
+	redis        goredis.UniversalClient
+	prefix       string
+	group        string
+	consumer     string
+	promoteSize  int
+	claimMinIdle time.Duration
 }
 
 var _ queue.Queue = (*Queue)(nil)
@@ -30,11 +31,12 @@ var _ queue.Queue = (*Queue)(nil)
 func NewQueue(redis goredis.UniversalClient, opts ...Option) *Queue {
 	c := newConfig(opts...)
 	q := &Queue{
-		redis:       redis,
-		prefix:      c.prefix,
-		group:       c.group,
-		consumer:    c.consumer,
-		promoteSize: c.promoteSize,
+		redis:        redis,
+		prefix:       c.prefix,
+		group:        c.group,
+		consumer:     c.consumer,
+		promoteSize:  c.promoteSize,
+		claimMinIdle: c.claimMinIdle,
 	}
 	return q
 }
@@ -67,7 +69,7 @@ func (q *Queue) Enqueue(ctx context.Context, task *queue.Task) error {
 }
 
 // Dequeue returns a task lease from a Redis stream consumer group.
-func (q *Queue) Dequeue(ctx context.Context, name string, visibilityTimeout time.Duration) (queue.Lease, error) {
+func (q *Queue) Dequeue(ctx context.Context, name string) (queue.Lease, error) {
 	if name == "" {
 		name = queue.DefaultQueue
 	}
@@ -78,8 +80,8 @@ func (q *Queue) Dequeue(ctx context.Context, name string, visibilityTimeout time
 		return nil, err
 	}
 
-	if visibilityTimeout > 0 {
-		lease, err := q.claimPending(ctx, name, visibilityTimeout)
+	if q.claimMinIdle > 0 {
+		lease, err := q.claimPending(ctx, name, q.claimMinIdle)
 		if err != nil {
 			return nil, err
 		}

--- a/queue/adapter/redis/queue_test.go
+++ b/queue/adapter/redis/queue_test.go
@@ -241,7 +241,7 @@ func TestQueue_LeaseFromMessageErrors(t *testing.T) {
 func TestQueue_OptionsUseDefaultsAndIgnoreInvalidValues(t *testing.T) {
 	t.Parallel()
 
-	q := NewQueue(nil, WithPrefix(""), WithGroup(""), WithConsumer(""), WithPromoteSize(0))
+	q := NewQueue(nil, WithPrefix(""), WithGroup(""), WithConsumer(""), WithPromoteSize(0), WithClaimMinIdle(-time.Second))
 
 	assert.Equal(t, "queue:critical:stream", q.streamKey("critical"))
 	assert.Equal(t, "queue:critical:delayed", q.delayedKey("critical"))
@@ -249,12 +249,13 @@ func TestQueue_OptionsUseDefaultsAndIgnoreInvalidValues(t *testing.T) {
 	assert.Equal(t, "queue", q.group)
 	assert.Equal(t, "worker", q.consumer)
 	assert.Equal(t, 100, q.promoteSize)
+	assert.Equal(t, 5*time.Minute, q.claimMinIdle)
 }
 
 func TestQueue_Options(t *testing.T) {
 	t.Parallel()
 
-	q := NewQueue(nil, WithPrefix("app:"), WithGroup("workers"), WithConsumer("worker-1"), WithPromoteSize(10))
+	q := NewQueue(nil, WithPrefix("app:"), WithGroup("workers"), WithConsumer("worker-1"), WithPromoteSize(10), WithClaimMinIdle(30*time.Second))
 
 	assert.Equal(t, "app:critical:stream", q.streamKey("critical"))
 	assert.Equal(t, "app:critical:delayed", q.delayedKey("critical"))
@@ -262,6 +263,7 @@ func TestQueue_Options(t *testing.T) {
 	assert.Equal(t, "workers", q.group)
 	assert.Equal(t, "worker-1", q.consumer)
 	assert.Equal(t, 10, q.promoteSize)
+	assert.Equal(t, 30*time.Second, q.claimMinIdle)
 }
 
 func TestQueue_NoopOperations(t *testing.T) {
@@ -295,7 +297,7 @@ func TestQueue_EnqueueDequeueAck(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -306,7 +308,7 @@ func TestQueue_EnqueueDequeueAck(t *testing.T) {
 
 	require.NoError(t, q.Ack(ctx, lease))
 
-	_, err = q.Dequeue(ctx, "critical", time.Minute)
+	_, err = q.Dequeue(ctx, "critical")
 	require.ErrorIs(t, err, queue.ErrNoTask)
 }
 
@@ -325,7 +327,7 @@ func TestQueue_EnqueueDoesNotMutateTask(t *testing.T) {
 
 	assert.Empty(t, task.Queue)
 
-	lease, err := q.Dequeue(ctx, queue.DefaultQueue, time.Minute)
+	lease, err := q.Dequeue(ctx, queue.DefaultQueue)
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -341,11 +343,11 @@ func TestQueue_RetryReenqueuesAndAcksLease(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NoError(t, q.Retry(ctx, lease, 0))
 
-	lease, err = q.Dequeue(ctx, "critical", time.Minute)
+	lease, err = q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -356,13 +358,13 @@ func TestQueue_RetryReenqueuesAndAcksLease(t *testing.T) {
 func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 	t.Parallel()
 
-	q, client := newRedisTestQueue(t)
+	q, client := newRedisTestQueue(t, WithClaimMinIdle(time.Millisecond))
 	ctx := t.Context()
 
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -376,7 +378,7 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 
 	var claimed queue.Lease
 	require.Eventually(t, func() bool {
-		got, err := q.Dequeue(ctx, "critical", time.Millisecond)
+		got, err := q.Dequeue(ctx, "critical")
 		if errors.Is(err, queue.ErrNoTask) {
 			return false
 		}
@@ -395,20 +397,20 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 	t.Parallel()
 
-	q, client := newRedisTestQueue(t)
+	q, client := newRedisTestQueue(t, WithClaimMinIdle(time.Millisecond))
 	ctx := t.Context()
 
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
 	require.Equal(t, 1, lease.Task().Attempt)
 	require.NoError(t, q.Retry(ctx, lease, 0))
 
-	lease, err = q.Dequeue(ctx, "critical", time.Minute)
+	lease, err = q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -422,7 +424,7 @@ func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 
 	var claimed queue.Lease
 	require.Eventually(t, func() bool {
-		got, err := q.Dequeue(ctx, "critical", time.Millisecond)
+		got, err := q.Dequeue(ctx, "critical")
 		if errors.Is(err, queue.ErrNoTask) {
 			return false
 		}
@@ -447,7 +449,7 @@ func TestQueue_DeadLetterWritesReasonAndAcksLease(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NoError(t, q.DeadLetter(ctx, lease, "failed"))
 
@@ -456,7 +458,7 @@ func TestQueue_DeadLetterWritesReasonAndAcksLease(t *testing.T) {
 	require.Len(t, messages, 1)
 	assert.Equal(t, "failed", messages[0].Values[deadReasonField])
 
-	_, err = q.Dequeue(ctx, "critical", time.Minute)
+	_, err = q.Dequeue(ctx, "critical")
 	require.ErrorIs(t, err, queue.ErrNoTask)
 }
 
@@ -469,12 +471,12 @@ func TestQueue_DelayedTaskPromotion(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"), queue.WithDelay(20*time.Millisecond))
 	require.NoError(t, err)
 
-	_, err = q.Dequeue(ctx, "critical", time.Minute)
+	_, err = q.Dequeue(ctx, "critical")
 	require.ErrorIs(t, err, queue.ErrNoTask)
 
 	var lease queue.Lease
 	require.Eventually(t, func() bool {
-		got, err := q.Dequeue(ctx, "critical", time.Minute)
+		got, err := q.Dequeue(ctx, "critical")
 		if errors.Is(err, queue.ErrNoTask) {
 			return false
 		}
@@ -487,7 +489,7 @@ func TestQueue_DelayedTaskPromotion(t *testing.T) {
 	assert.Equal(t, "send_email", lease.Task().Type)
 }
 
-func newRedisTestQueue(t *testing.T) (*Queue, *goredis.Client) {
+func newRedisTestQueue(t *testing.T, opts ...Option) (*Queue, *goredis.Client) {
 	t.Helper()
 
 	addr := os.Getenv("REDIS_ADDR")
@@ -504,7 +506,13 @@ func newRedisTestQueue(t *testing.T) (*Queue, *goredis.Client) {
 	}
 
 	prefix := "queue-test:" + sanitizeRedisKey(t.Name()) + ":" + strconv.FormatInt(time.Now().UnixNano(), 10)
-	q := NewQueue(client, WithPrefix(prefix), WithGroup("workers"), WithConsumer("worker-1"), WithPromoteSize(10))
+	options := append([]Option{
+		WithPrefix(prefix),
+		WithGroup("workers"),
+		WithConsumer("worker-1"),
+		WithPromoteSize(10),
+	}, opts...)
+	q := NewQueue(client, options...)
 
 	t.Cleanup(func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(t.Context()), 2*time.Second)

--- a/queue/adapter/redis/queue_test.go
+++ b/queue/adapter/redis/queue_test.go
@@ -22,6 +22,8 @@ type redisClientStub struct {
 
 	xAutoClaimMessages []goredis.XMessage
 	xAutoClaimErr      error
+	xClaimMessages     []goredis.XMessage
+	xClaimErr          error
 	xPendingExt        []goredis.XPendingExt
 	xPendingExtErr     error
 }
@@ -30,6 +32,13 @@ func (c *redisClientStub) XAutoClaim(ctx context.Context, _ *goredis.XAutoClaimA
 	cmd := goredis.NewXAutoClaimCmd(ctx)
 	cmd.SetVal(c.xAutoClaimMessages, "0-0")
 	cmd.SetErr(c.xAutoClaimErr)
+	return cmd
+}
+
+func (c *redisClientStub) XClaim(ctx context.Context, _ *goredis.XClaimArgs) *goredis.XMessageSliceCmd {
+	cmd := goredis.NewXMessageSliceCmd(ctx)
+	cmd.SetVal(c.xClaimMessages)
+	cmd.SetErr(c.xClaimErr)
 	return cmd
 }
 
@@ -173,6 +182,51 @@ func TestQueue_ClaimPendingReturnsXAutoClaimError(t *testing.T) {
 
 	wantErr := errors.New("xautoclaim failed")
 	q := NewQueue(&redisClientStub{xAutoClaimErr: wantErr})
+
+	_, err := q.claimPending(t.Context(), "critical", time.Second)
+
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestQueue_ClaimPendingFallsBackToXClaim(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(&queue.Task{ID: "task-1", Type: "send_email"})
+	require.NoError(t, err)
+	client := &redisClientStub{
+		xPendingExt: []goredis.XPendingExt{
+			{ID: "1-0", Idle: time.Second, RetryCount: 2},
+		},
+		xClaimMessages: []goredis.XMessage{
+			{
+				ID: "1-0",
+				Values: map[string]any{
+					taskField: string(data),
+				},
+			},
+		},
+	}
+	q := NewQueue(client)
+
+	delivery, err := q.claimPending(t.Context(), "critical", time.Second)
+
+	require.NoError(t, err)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "task-1", delivery.Task().ID)
+	assert.Equal(t, 2, delivery.Task().Attempt)
+}
+
+func TestQueue_ClaimPendingReturnsXClaimError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("xclaim failed")
+	q := NewQueue(&redisClientStub{
+		xPendingExt: []goredis.XPendingExt{
+			{ID: "1-0", Idle: time.Second},
+		},
+		xClaimErr: wantErr,
+	})
 
 	_, err := q.claimPending(t.Context(), "critical", time.Second)
 
@@ -378,8 +432,9 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 	assert.Equal(t, 0, stored.Attempt)
 
 	var claimed queue.Delivery
+	claimer := q.withConsumer("worker-2")
 	require.Eventually(t, func() bool {
-		got, err := receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+		got, err := receiveCriticalWithTimeout(ctx, claimer, 50*time.Millisecond)
 		if errors.Is(err, context.DeadlineExceeded) {
 			return false
 		}
@@ -424,8 +479,9 @@ func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 	assert.Equal(t, 1, stored.Attempt)
 
 	var claimed queue.Delivery
+	claimer := q.withConsumer("worker-2")
 	require.Eventually(t, func() bool {
-		got, err := receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+		got, err := receiveCriticalWithTimeout(ctx, claimer, 50*time.Millisecond)
 		if errors.Is(err, context.DeadlineExceeded) {
 			return false
 		}
@@ -505,6 +561,12 @@ func receiveCriticalWithTimeout(ctx context.Context, q *Queue, timeout time.Dura
 	receiveCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return receive(receiveCtx, q, "critical")
+}
+
+func (q *Queue) withConsumer(consumer string) *Queue {
+	clone := *q
+	clone.consumer = consumer
+	return &clone
 }
 
 func newRedisTestQueue(t *testing.T, opts ...Option) (*Queue, *goredis.Client) {

--- a/queue/adapter/redis/queue_test.go
+++ b/queue/adapter/redis/queue_test.go
@@ -40,7 +40,7 @@ func (c *redisClientStub) XPendingExt(ctx context.Context, _ *goredis.XPendingEx
 	return cmd
 }
 
-func TestQueue_LeaseFromMessage(t *testing.T) {
+func TestQueue_DeliveryFromMessage(t *testing.T) {
 	t.Parallel()
 
 	q := NewQueue(nil)
@@ -54,60 +54,60 @@ func TestQueue_LeaseFromMessage(t *testing.T) {
 	data, err := json.Marshal(task)
 	require.NoError(t, err)
 
-	lease, err := q.leaseFromMessage(goredis.XMessage{
+	delivery, err := q.leaseFromMessage(goredis.XMessage{
 		ID: "1-0",
 		Values: map[string]any{
 			taskField: string(data),
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
 
-	l, ok := lease.(*redisLease)
+	l, ok := delivery.(*redisDelivery)
 	require.True(t, ok)
 	assert.Equal(t, "1-0", l.streamID)
-	assert.Equal(t, 3, lease.Task().Attempt)
-	assert.Equal(t, "hello", string(lease.Task().Payload))
+	assert.Equal(t, 3, delivery.Task().Attempt)
+	assert.Equal(t, "hello", string(delivery.Task().Payload))
 }
 
-func TestQueue_LeaseFromMessageAcceptsBytes(t *testing.T) {
+func TestQueue_DeliveryFromMessageAcceptsBytes(t *testing.T) {
 	t.Parallel()
 
 	q := NewQueue(nil)
 	data, err := json.Marshal(&queue.Task{ID: "task-1", Type: "send_email"})
 	require.NoError(t, err)
 
-	lease, err := q.leaseFromMessage(goredis.XMessage{
+	delivery, err := q.leaseFromMessage(goredis.XMessage{
 		ID: "1-0",
 		Values: map[string]any{
 			taskField: data,
 		},
 	})
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, "task-1", lease.Task().ID)
-	assert.Equal(t, 1, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "task-1", delivery.Task().ID)
+	assert.Equal(t, 1, delivery.Task().Attempt)
 }
 
-func TestQueue_LeaseFromMessageWithDeliveryCount(t *testing.T) {
+func TestQueue_DeliveryFromMessageWithDeliveryCount(t *testing.T) {
 	t.Parallel()
 
 	q := NewQueue(nil)
 	data, err := json.Marshal(&queue.Task{ID: "task-1", Type: "send_email", Attempt: 1})
 	require.NoError(t, err)
 
-	lease, err := q.leaseFromMessageWithDeliveryCount(goredis.XMessage{
+	delivery, err := q.leaseFromMessageWithDeliveryCount(goredis.XMessage{
 		ID: "1-0",
 		Values: map[string]any{
 			taskField: data,
 		},
 	}, 2)
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, 3, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, 3, delivery.Task().Attempt)
 }
 
 func TestAttemptWithDeliveryCount(t *testing.T) {
@@ -190,7 +190,7 @@ func TestQueue_DeliveryCountReturnsXPendingExtError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr)
 }
 
-func TestQueue_LeaseFromMessageErrors(t *testing.T) {
+func TestQueue_DeliveryFromMessageErrors(t *testing.T) {
 	t.Parallel()
 
 	q := NewQueue(nil)
@@ -270,25 +270,26 @@ func TestQueue_NoopOperations(t *testing.T) {
 	t.Parallel()
 
 	q := NewQueue(nil)
+	var nilDelivery *redisDelivery
 
 	require.NoError(t, q.Enqueue(t.Context(), nil))
-	require.NoError(t, q.Ack(t.Context(), nil))
-	require.NoError(t, q.Ack(t.Context(), queue.NewLease(&queue.Task{})))
-	require.NoError(t, q.Retry(t.Context(), nil, 0))
-	require.NoError(t, q.Retry(t.Context(), queue.NewLease(nil), 0))
-	require.NoError(t, q.DeadLetter(t.Context(), nil, "failed"))
-	require.NoError(t, q.DeadLetter(t.Context(), queue.NewLease(nil), "failed"))
+	require.NoError(t, nilDelivery.Ack(t.Context()))
+	require.NoError(t, nilDelivery.Retry(t.Context(), 0))
+	require.NoError(t, nilDelivery.DeadLetter(t.Context(), "failed"))
+	require.NoError(t, (&redisDelivery{queue: q}).Ack(t.Context()))
+	require.NoError(t, (&redisDelivery{queue: q}).Retry(t.Context(), 0))
+	require.NoError(t, (&redisDelivery{queue: q}).DeadLetter(t.Context(), "failed"))
 }
 
-func TestRedisLease_TaskNilReceiver(t *testing.T) {
+func TestRedisDelivery_TaskNilReceiver(t *testing.T) {
 	t.Parallel()
 
-	var lease *redisLease
+	var delivery *redisDelivery
 
-	assert.Nil(t, lease.Task())
+	assert.Nil(t, delivery.Task())
 }
 
-func TestQueue_EnqueueDequeueAck(t *testing.T) {
+func TestQueue_EnqueueReceiveAck(t *testing.T) {
 	t.Parallel()
 
 	q, _ := newRedisTestQueue(t)
@@ -297,19 +298,19 @@ func TestQueue_EnqueueDequeueAck(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, "send_email", lease.Task().Type)
-	assert.Equal(t, "critical", lease.Task().Queue)
-	assert.Equal(t, []byte("hello"), lease.Task().Payload)
-	assert.Equal(t, 1, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "send_email", delivery.Task().Type)
+	assert.Equal(t, "critical", delivery.Task().Queue)
+	assert.Equal(t, []byte("hello"), delivery.Task().Payload)
+	assert.Equal(t, 1, delivery.Task().Attempt)
 
-	require.NoError(t, q.Ack(ctx, lease))
+	require.NoError(t, delivery.Ack(ctx))
 
-	_, err = q.Dequeue(ctx, "critical")
-	require.ErrorIs(t, err, queue.ErrNoTask)
+	_, err = receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestQueue_EnqueueDoesNotMutateTask(t *testing.T) {
@@ -327,14 +328,14 @@ func TestQueue_EnqueueDoesNotMutateTask(t *testing.T) {
 
 	assert.Empty(t, task.Queue)
 
-	lease, err := q.Dequeue(ctx, queue.DefaultQueue)
+	delivery, err := receive(ctx, q, queue.DefaultQueue)
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, queue.DefaultQueue, lease.Task().Queue)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, queue.DefaultQueue, delivery.Task().Queue)
 }
 
-func TestQueue_RetryReenqueuesAndAcksLease(t *testing.T) {
+func TestQueue_RetryReenqueuesAndAcksDelivery(t *testing.T) {
 	t.Parallel()
 
 	q, _ := newRedisTestQueue(t)
@@ -343,16 +344,16 @@ func TestQueue_RetryReenqueuesAndAcksLease(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NoError(t, q.Retry(ctx, lease, 0))
+	require.NoError(t, delivery.Retry(ctx, 0))
 
-	lease, err = q.Dequeue(ctx, "critical")
+	delivery, err = receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, "send_email", lease.Task().Type)
-	assert.Equal(t, 2, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "send_email", delivery.Task().Type)
+	assert.Equal(t, 2, delivery.Task().Attempt)
 }
 
 func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
@@ -364,11 +365,11 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, 1, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, 1, delivery.Task().Attempt)
 
 	messages, err := client.XRange(ctx, q.streamKey("critical"), "-", "+").Result()
 	require.NoError(t, err)
@@ -376,10 +377,10 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 	stored := taskFromMessage(t, messages[0])
 	assert.Equal(t, 0, stored.Attempt)
 
-	var claimed queue.Lease
+	var claimed queue.Delivery
 	require.Eventually(t, func() bool {
-		got, err := q.Dequeue(ctx, "critical")
-		if errors.Is(err, queue.ErrNoTask) {
+		got, err := receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+		if errors.Is(err, context.DeadlineExceeded) {
 			return false
 		}
 		require.NoError(t, err)
@@ -391,7 +392,7 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 	require.NotNil(t, claimed.Task())
 	assert.Equal(t, "send_email", claimed.Task().Type)
 	assert.Equal(t, 2, claimed.Task().Attempt)
-	require.NoError(t, q.Ack(ctx, claimed))
+	require.NoError(t, claimed.Ack(ctx))
 }
 
 func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
@@ -403,18 +404,18 @@ func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	require.Equal(t, 1, lease.Task().Attempt)
-	require.NoError(t, q.Retry(ctx, lease, 0))
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	require.Equal(t, 1, delivery.Task().Attempt)
+	require.NoError(t, delivery.Retry(ctx, 0))
 
-	lease, err = q.Dequeue(ctx, "critical")
+	delivery, err = receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, 2, lease.Task().Attempt)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, 2, delivery.Task().Attempt)
 
 	messages, err := client.XRange(ctx, q.streamKey("critical"), "-", "+").Result()
 	require.NoError(t, err)
@@ -422,10 +423,10 @@ func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 	stored := taskFromMessage(t, messages[1])
 	assert.Equal(t, 1, stored.Attempt)
 
-	var claimed queue.Lease
+	var claimed queue.Delivery
 	require.Eventually(t, func() bool {
-		got, err := q.Dequeue(ctx, "critical")
-		if errors.Is(err, queue.ErrNoTask) {
+		got, err := receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+		if errors.Is(err, context.DeadlineExceeded) {
 			return false
 		}
 		require.NoError(t, err)
@@ -437,10 +438,10 @@ func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 	require.NotNil(t, claimed.Task())
 	assert.Equal(t, "send_email", claimed.Task().Type)
 	assert.Equal(t, 3, claimed.Task().Attempt)
-	require.NoError(t, q.Ack(ctx, claimed))
+	require.NoError(t, claimed.Ack(ctx))
 }
 
-func TestQueue_DeadLetterWritesReasonAndAcksLease(t *testing.T) {
+func TestQueue_DeadLetterWritesReasonAndAcksDelivery(t *testing.T) {
 	t.Parallel()
 
 	q, client := newRedisTestQueue(t)
@@ -449,17 +450,17 @@ func TestQueue_DeadLetterWritesReasonAndAcksLease(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"))
 	require.NoError(t, err)
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := receive(ctx, q, "critical")
 	require.NoError(t, err)
-	require.NoError(t, q.DeadLetter(ctx, lease, "failed"))
+	require.NoError(t, delivery.DeadLetter(ctx, "failed"))
 
 	messages, err := client.XRange(ctx, q.deadLetterKey("critical"), "-", "+").Result()
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
 	assert.Equal(t, "failed", messages[0].Values[deadReasonField])
 
-	_, err = q.Dequeue(ctx, "critical")
-	require.ErrorIs(t, err, queue.ErrNoTask)
+	_, err = receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestQueue_DelayedTaskPromotion(t *testing.T) {
@@ -471,22 +472,39 @@ func TestQueue_DelayedTaskPromotion(t *testing.T) {
 	_, err := queue.NewProducer(q).Enqueue(ctx, "send_email", []byte("hello"), queue.WithQueue("critical"), queue.WithDelay(20*time.Millisecond))
 	require.NoError(t, err)
 
-	_, err = q.Dequeue(ctx, "critical")
-	require.ErrorIs(t, err, queue.ErrNoTask)
+	_, err = receiveCriticalWithTimeout(ctx, q, 20*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	var lease queue.Lease
+	var delivery queue.Delivery
 	require.Eventually(t, func() bool {
-		got, err := q.Dequeue(ctx, "critical")
-		if errors.Is(err, queue.ErrNoTask) {
+		got, err := receiveCriticalWithTimeout(ctx, q, 50*time.Millisecond)
+		if errors.Is(err, context.DeadlineExceeded) {
 			return false
 		}
 		require.NoError(t, err)
-		lease = got
+		delivery = got
 		return true
 	}, time.Second, 10*time.Millisecond)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
-	assert.Equal(t, "send_email", lease.Task().Type)
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
+	assert.Equal(t, "send_email", delivery.Task().Type)
+}
+
+func receive(ctx context.Context, q *Queue, queueName string) (queue.Delivery, error) {
+	consumer, err := q.NewConsumer(ctx, queueName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+	return consumer.Receive(ctx)
+}
+
+func receiveCriticalWithTimeout(ctx context.Context, q *Queue, timeout time.Duration) (queue.Delivery, error) {
+	receiveCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return receive(receiveCtx, q, "critical")
 }
 
 func newRedisTestQueue(t *testing.T, opts ...Option) (*Queue, *goredis.Client) {

--- a/queue/adapter/redis/queue_test.go
+++ b/queue/adapter/redis/queue_test.go
@@ -431,17 +431,9 @@ func TestQueue_ClaimPendingIncrementsAttempt(t *testing.T) {
 	stored := taskFromMessage(t, messages[0])
 	assert.Equal(t, 0, stored.Attempt)
 
-	var claimed queue.Delivery
 	claimer := q.withConsumer("worker-2")
-	require.Eventually(t, func() bool {
-		got, err := receiveCriticalWithTimeout(ctx, claimer, 50*time.Millisecond)
-		if errors.Is(err, context.DeadlineExceeded) {
-			return false
-		}
-		require.NoError(t, err)
-		claimed = got
-		return true
-	}, time.Second, 10*time.Millisecond)
+	claimed, err := claimer.claimPending(ctx, "critical", 0)
+	require.NoError(t, err)
 
 	require.NotNil(t, claimed)
 	require.NotNil(t, claimed.Task())
@@ -478,17 +470,9 @@ func TestQueue_ClaimRetriedPendingIncrementsAttempt(t *testing.T) {
 	stored := taskFromMessage(t, messages[1])
 	assert.Equal(t, 1, stored.Attempt)
 
-	var claimed queue.Delivery
 	claimer := q.withConsumer("worker-2")
-	require.Eventually(t, func() bool {
-		got, err := receiveCriticalWithTimeout(ctx, claimer, 50*time.Millisecond)
-		if errors.Is(err, context.DeadlineExceeded) {
-			return false
-		}
-		require.NoError(t, err)
-		claimed = got
-		return true
-	}, time.Second, 10*time.Millisecond)
+	claimed, err := claimer.claimPending(ctx, "critical", 0)
+	require.NoError(t, err)
 
 	require.NotNil(t, claimed)
 	require.NotNil(t, claimed.Task())

--- a/queue/errors.go
+++ b/queue/errors.go
@@ -3,7 +3,7 @@ package queue
 import "errors"
 
 var (
-	// ErrNoTask is returned when a queue has no task available for dequeue.
+	// ErrNoTask is returned by queue implementations when no task is immediately available.
 	ErrNoTask = errors.New("queue: no task available")
 	// ErrInvalidTaskType is returned when enqueueing a task without a type.
 	ErrInvalidTaskType = errors.New("queue: task type is required")

--- a/queue/examples/tasker/main.go
+++ b/queue/examples/tasker/main.go
@@ -70,7 +70,6 @@ func run() error {
 	worker := queue.NewWorker(
 		q,
 		queue.HandleTasker[SendEmail](tasker),
-		queue.WithPollInterval(10*time.Millisecond),
 	)
 
 	errs := make(chan error, 1)

--- a/queue/kratos/server/server_test.go
+++ b/queue/kratos/server/server_test.go
@@ -27,24 +27,8 @@ func (q *blockingQueue) Enqueue(context.Context, *queue.Task) error {
 	return nil
 }
 
-func (q *blockingQueue) Dequeue(ctx context.Context, _ string) (queue.Lease, error) {
-	q.once.Do(func() {
-		close(q.started)
-	})
-	<-ctx.Done()
-	return nil, ctx.Err()
-}
-
-func (q *blockingQueue) Ack(context.Context, queue.Lease) error {
-	return nil
-}
-
-func (q *blockingQueue) Retry(context.Context, queue.Lease, time.Duration) error {
-	return nil
-}
-
-func (q *blockingQueue) DeadLetter(context.Context, queue.Lease, string) error {
-	return nil
+func (q *blockingQueue) NewConsumer(context.Context, string) (queue.Consumer, error) {
+	return blockingConsumer{queue: q}, nil
 }
 
 type dequeueErrorQueue struct {
@@ -55,20 +39,8 @@ func (q dequeueErrorQueue) Enqueue(context.Context, *queue.Task) error {
 	return nil
 }
 
-func (q dequeueErrorQueue) Dequeue(context.Context, string) (queue.Lease, error) {
+func (q dequeueErrorQueue) NewConsumer(context.Context, string) (queue.Consumer, error) {
 	return nil, q.err
-}
-
-func (q dequeueErrorQueue) Ack(context.Context, queue.Lease) error {
-	return nil
-}
-
-func (q dequeueErrorQueue) Retry(context.Context, queue.Lease, time.Duration) error {
-	return nil
-}
-
-func (q dequeueErrorQueue) DeadLetter(context.Context, queue.Lease, string) error {
-	return nil
 }
 
 type singleTaskQueue struct {
@@ -86,28 +58,65 @@ func (q *singleTaskQueue) Enqueue(context.Context, *queue.Task) error {
 	return nil
 }
 
-func (q *singleTaskQueue) Dequeue(ctx context.Context, _ string) (queue.Lease, error) {
+func (q *singleTaskQueue) NewConsumer(context.Context, string) (queue.Consumer, error) {
+	return &singleTaskConsumer{queue: q}, nil
+}
+
+type blockingConsumer struct {
+	queue *blockingQueue
+}
+
+func (c blockingConsumer) Receive(ctx context.Context) (queue.Delivery, error) {
+	c.queue.once.Do(func() {
+		close(c.queue.started)
+	})
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingConsumer) Close() error {
+	return nil
+}
+
+type singleTaskConsumer struct {
+	queue *singleTaskQueue
+}
+
+func (c *singleTaskConsumer) Receive(ctx context.Context) (queue.Delivery, error) {
+	q := c.queue
 	q.mu.Lock()
 	task := q.task
 	q.task = nil
 	q.mu.Unlock()
 	if task != nil {
-		return queue.NewLease(task), nil
+		return noopDelivery{task: task}, nil
 	}
 
 	<-ctx.Done()
 	return nil, ctx.Err()
 }
 
-func (q *singleTaskQueue) Ack(context.Context, queue.Lease) error {
+func (c *singleTaskConsumer) Close() error {
 	return nil
 }
 
-func (q *singleTaskQueue) Retry(context.Context, queue.Lease, time.Duration) error {
+type noopDelivery struct {
+	task *queue.Task
+}
+
+func (d noopDelivery) Task() *queue.Task {
+	return d.task
+}
+
+func (noopDelivery) Ack(context.Context) error {
 	return nil
 }
 
-func (q *singleTaskQueue) DeadLetter(context.Context, queue.Lease, string) error {
+func (noopDelivery) Retry(context.Context, time.Duration) error {
+	return nil
+}
+
+func (noopDelivery) DeadLetter(context.Context, string) error {
 	return nil
 }
 

--- a/queue/kratos/server/server_test.go
+++ b/queue/kratos/server/server_test.go
@@ -27,7 +27,7 @@ func (q *blockingQueue) Enqueue(context.Context, *queue.Task) error {
 	return nil
 }
 
-func (q *blockingQueue) Dequeue(ctx context.Context, _ string, _ time.Duration) (queue.Lease, error) {
+func (q *blockingQueue) Dequeue(ctx context.Context, _ string) (queue.Lease, error) {
 	q.once.Do(func() {
 		close(q.started)
 	})
@@ -55,7 +55,7 @@ func (q dequeueErrorQueue) Enqueue(context.Context, *queue.Task) error {
 	return nil
 }
 
-func (q dequeueErrorQueue) Dequeue(context.Context, string, time.Duration) (queue.Lease, error) {
+func (q dequeueErrorQueue) Dequeue(context.Context, string) (queue.Lease, error) {
 	return nil, q.err
 }
 
@@ -86,7 +86,7 @@ func (q *singleTaskQueue) Enqueue(context.Context, *queue.Task) error {
 	return nil
 }
 
-func (q *singleTaskQueue) Dequeue(ctx context.Context, _ string, _ time.Duration) (queue.Lease, error) {
+func (q *singleTaskQueue) Dequeue(ctx context.Context, _ string) (queue.Lease, error) {
 	q.mu.Lock()
 	task := q.task
 	q.task = nil

--- a/queue/producer_test.go
+++ b/queue/producer_test.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -28,14 +29,14 @@ func TestProducer_EnqueueCopiesTaskData(t *testing.T) {
 	payload[0] = 'x'
 	metadata["trace"] = "2"
 
-	lease, err := q.Dequeue(ctx, DefaultQueue)
+	delivery, err := q.Receive(ctx, DefaultQueue)
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
 
 	assert.Equal(t, "task-1", task.ID)
-	assert.Equal(t, "hello", string(lease.Task().Payload))
-	assert.Equal(t, "1", lease.Task().Metadata["trace"])
+	assert.Equal(t, "hello", string(delivery.Task().Payload))
+	assert.Equal(t, "1", delivery.Task().Metadata["trace"])
 }
 
 func TestProducer_RejectsEmptyTaskType(t *testing.T) {
@@ -84,8 +85,10 @@ func TestProducer_EnqueueSetsDefaultsAndOptions(t *testing.T) {
 	assert.Equal(t, time.UTC, task.AvailableAt.Location())
 	assert.GreaterOrEqual(t, task.AvailableAt.Sub(task.CreatedAt), 20*time.Millisecond)
 
-	_, err = q.Dequeue(ctx, DefaultQueue)
-	require.ErrorIs(t, err, ErrNoTask)
+	receiveCtx, cancel := context.WithTimeout(ctx, time.Millisecond)
+	defer cancel()
+	_, err = q.Receive(receiveCtx, DefaultQueue)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestProducer_OptionsIgnoreEmptyOrInvalidValues(t *testing.T) {

--- a/queue/producer_test.go
+++ b/queue/producer_test.go
@@ -28,7 +28,7 @@ func TestProducer_EnqueueCopiesTaskData(t *testing.T) {
 	payload[0] = 'x'
 	metadata["trace"] = "2"
 
-	lease, err := q.Dequeue(ctx, DefaultQueue, time.Minute)
+	lease, err := q.Dequeue(ctx, DefaultQueue)
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())
@@ -84,7 +84,7 @@ func TestProducer_EnqueueSetsDefaultsAndOptions(t *testing.T) {
 	assert.Equal(t, time.UTC, task.AvailableAt.Location())
 	assert.GreaterOrEqual(t, task.AvailableAt.Sub(task.CreatedAt), 20*time.Millisecond)
 
-	_, err = q.Dequeue(ctx, DefaultQueue, time.Minute)
+	_, err = q.Dequeue(ctx, DefaultQueue)
 	require.ErrorIs(t, err, ErrNoTask)
 }
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,20 +1,11 @@
 package queue
 
-import (
-	"context"
-	"time"
-)
+import "context"
 
-// Queue stores tasks and manages task delivery state.
+// Queue stores tasks and creates consumers for task delivery.
 type Queue interface {
 	// Enqueue stores a task for future delivery.
 	Enqueue(ctx context.Context, task *Task) error
-	// Dequeue returns an available task lease from the queue.
-	Dequeue(ctx context.Context, queue string) (Lease, error)
-	// Ack marks a leased task as successfully processed.
-	Ack(ctx context.Context, lease Lease) error
-	// Retry releases a leased task for another attempt after delay.
-	Retry(ctx context.Context, lease Lease, delay time.Duration) error
-	// DeadLetter moves a leased task out of normal processing with a reason.
-	DeadLetter(ctx context.Context, lease Lease, reason string) error
+	// NewConsumer creates a consumer for queue.
+	NewConsumer(ctx context.Context, queue string) (Consumer, error)
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -10,7 +10,7 @@ type Queue interface {
 	// Enqueue stores a task for future delivery.
 	Enqueue(ctx context.Context, task *Task) error
 	// Dequeue returns an available task lease from the queue.
-	Dequeue(ctx context.Context, queue string, visibilityTimeout time.Duration) (Lease, error)
+	Dequeue(ctx context.Context, queue string) (Lease, error)
 	// Ack marks a leased task as successfully processed.
 	Ack(ctx context.Context, lease Lease) error
 	// Retry releases a leased task for another attempt after delay.

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,6 +1,9 @@
 package queue
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Queue stores tasks and creates consumers for task delivery.
 type Queue interface {
@@ -8,4 +11,27 @@ type Queue interface {
 	Enqueue(ctx context.Context, task *Task) error
 	// NewConsumer creates a consumer for queue.
 	NewConsumer(ctx context.Context, queue string) (Consumer, error)
+}
+
+// Consumer receives task deliveries from a queue.
+type Consumer interface {
+	// Receive blocks until a delivery is available or ctx is canceled.
+	Receive(ctx context.Context) (Delivery, error)
+	// Close stops the consumer and releases backend resources.
+	Close() error
+}
+
+// Delivery represents one delivery attempt of a task.
+//
+// Queue implementations may attach backend-specific acknowledgement state to a
+// delivery. That delivery state is intentionally separate from Task.Metadata.
+type Delivery interface {
+	// Task returns the delivered task envelope.
+	Task() *Task
+	// Ack marks the delivery as successfully processed.
+	Ack(ctx context.Context) error
+	// Retry releases the delivery for another attempt after delay.
+	Retry(ctx context.Context, delay time.Duration) error
+	// DeadLetter moves the delivery out of normal processing with a reason.
+	DeadLetter(ctx context.Context, reason string) error
 }

--- a/queue/task.go
+++ b/queue/task.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"maps"
 	"time"
 )
@@ -65,27 +66,54 @@ func (t *Task) Clone() *Task {
 	return &cloned
 }
 
-// Lease represents one delivery attempt of a task.
-//
-// Queue implementations may attach backend-specific acknowledgement state to a
-// lease. That delivery state is intentionally separate from Task.Metadata.
-type Lease interface {
-	// Task returns the delivered task envelope.
-	Task() *Task
+// Consumer receives task deliveries from a queue.
+type Consumer interface {
+	// Receive blocks until a delivery is available or ctx is canceled.
+	Receive(ctx context.Context) (Delivery, error)
+	// Close stops the consumer and releases backend resources.
+	Close() error
 }
 
-type taskLease struct {
+// Delivery represents one delivery attempt of a task.
+//
+// Queue implementations may attach backend-specific acknowledgement state to a
+// delivery. That delivery state is intentionally separate from Task.Metadata.
+type Delivery interface {
+	// Task returns the delivered task envelope.
+	Task() *Task
+	// Ack marks the delivery as successfully processed.
+	Ack(ctx context.Context) error
+	// Retry releases the delivery for another attempt after delay.
+	Retry(ctx context.Context, delay time.Duration) error
+	// DeadLetter moves the delivery out of normal processing with a reason.
+	DeadLetter(ctx context.Context, reason string) error
+}
+
+type noopDelivery struct {
 	task *Task
 }
 
-// NewLease creates a basic lease for queue implementations that do not need extra delivery state.
-func NewLease(task *Task) Lease {
-	return &taskLease{task: task}
+// NewDelivery creates a basic delivery for tests and queue implementations that
+// do not need backend-specific acknowledgement state.
+func NewDelivery(task *Task) Delivery {
+	return &noopDelivery{task: task}
 }
 
-func (l *taskLease) Task() *Task {
-	if l == nil {
+func (d *noopDelivery) Task() *Task {
+	if d == nil {
 		return nil
 	}
-	return l.task
+	return d.task
+}
+
+func (*noopDelivery) Ack(ctx context.Context) error {
+	return ctx.Err()
+}
+
+func (*noopDelivery) Retry(ctx context.Context, _ time.Duration) error {
+	return ctx.Err()
+}
+
+func (*noopDelivery) DeadLetter(ctx context.Context, _ string) error {
+	return ctx.Err()
 }

--- a/queue/task.go
+++ b/queue/task.go
@@ -66,29 +66,6 @@ func (t *Task) Clone() *Task {
 	return &cloned
 }
 
-// Consumer receives task deliveries from a queue.
-type Consumer interface {
-	// Receive blocks until a delivery is available or ctx is canceled.
-	Receive(ctx context.Context) (Delivery, error)
-	// Close stops the consumer and releases backend resources.
-	Close() error
-}
-
-// Delivery represents one delivery attempt of a task.
-//
-// Queue implementations may attach backend-specific acknowledgement state to a
-// delivery. That delivery state is intentionally separate from Task.Metadata.
-type Delivery interface {
-	// Task returns the delivered task envelope.
-	Task() *Task
-	// Ack marks the delivery as successfully processed.
-	Ack(ctx context.Context) error
-	// Retry releases the delivery for another attempt after delay.
-	Retry(ctx context.Context, delay time.Duration) error
-	// DeadLetter moves the delivery out of normal processing with a reason.
-	DeadLetter(ctx context.Context, reason string) error
-}
-
 type noopDelivery struct {
 	task *Task
 }

--- a/queue/task_test.go
+++ b/queue/task_test.go
@@ -52,20 +52,20 @@ func TestTask_CloneNil(t *testing.T) {
 	assert.Nil(t, task.Clone())
 }
 
-func TestLease_Task(t *testing.T) {
+func TestDelivery_Task(t *testing.T) {
 	t.Parallel()
 
 	task := &Task{ID: "task-1"}
-	lease := NewLease(task)
+	delivery := NewDelivery(task)
 
-	require.NotNil(t, lease)
-	assert.Same(t, task, lease.Task())
+	require.NotNil(t, delivery)
+	assert.Same(t, task, delivery.Task())
 }
 
-func TestLease_TaskNilReceiver(t *testing.T) {
+func TestDelivery_TaskNilReceiver(t *testing.T) {
 	t.Parallel()
 
-	var lease *taskLease
+	var delivery *noopDelivery
 
-	assert.Nil(t, lease.Task())
+	assert.Nil(t, delivery.Task())
 }

--- a/queue/test_queue_test.go
+++ b/queue/test_queue_test.go
@@ -10,12 +10,14 @@ type testQueue struct {
 	mu         sync.Mutex
 	queues     map[string][]*Task
 	deadLetter map[string][]*Task
+	notify     chan struct{}
 }
 
 func newTestQueue() *testQueue {
 	return &testQueue{
 		queues:     make(map[string][]*Task),
 		deadLetter: make(map[string][]*Task),
+		notify:     make(chan struct{}),
 	}
 }
 
@@ -36,71 +38,149 @@ func (q *testQueue) Enqueue(ctx context.Context, task *Task) error {
 	defer q.mu.Unlock()
 
 	q.queues[task.Queue] = append(q.queues[task.Queue], task)
+	q.signal()
 	return nil
 }
 
-func (q *testQueue) Dequeue(ctx context.Context, queueName string) (Lease, error) {
+func (q *testQueue) NewConsumer(ctx context.Context, queueName string) (Consumer, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	if queueName == "" {
 		queueName = DefaultQueue
 	}
+	return &testConsumer{
+		queue: q,
+		name:  queueName,
+		done:  make(chan struct{}),
+	}, nil
+}
 
+func (q *testQueue) Receive(ctx context.Context, queueName string) (Delivery, error) {
+	consumer, err := q.NewConsumer(ctx, queueName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+	return consumer.Receive(ctx)
+}
+
+type testConsumer struct {
+	queue *testQueue
+	name  string
+	done  chan struct{}
+	once  sync.Once
+}
+
+func (c *testConsumer) Receive(ctx context.Context) (Delivery, error) {
+	for {
+		task, notify, wait := c.queue.next(c.name)
+		if task != nil {
+			return &testDelivery{queue: c.queue, task: task}, nil
+		}
+
+		var timer *time.Timer
+		var timerC <-chan time.Time
+		if wait > 0 {
+			timer = time.NewTimer(wait)
+			timerC = timer.C
+		}
+
+		select {
+		case <-ctx.Done():
+			stopTestTimer(timer)
+			return nil, ctx.Err()
+		case <-c.done:
+			stopTestTimer(timer)
+			return nil, context.Canceled
+		case <-notify:
+			stopTestTimer(timer)
+		case <-timerC:
+		}
+	}
+}
+
+func (c *testConsumer) Close() error {
+	c.once.Do(func() {
+		close(c.done)
+	})
+	return nil
+}
+
+func (q *testQueue) next(queueName string) (*Task, <-chan struct{}, time.Duration) {
 	now := time.Now().UTC()
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	var wait time.Duration
 	tasks := q.queues[queueName]
 	for i, task := range tasks {
 		if task.AvailableAt.After(now) {
+			delay := task.AvailableAt.Sub(now)
+			if wait == 0 || delay < wait {
+				wait = delay
+			}
 			continue
 		}
 
 		q.queues[queueName] = append(tasks[:i], tasks[i+1:]...)
 		task = task.clone()
 		task.Attempt++
-		return NewLease(task), nil
+		return task, q.notify, 0
 	}
 
-	return nil, ErrNoTask
+	return nil, q.notify, wait
 }
 
-func (q *testQueue) Ack(ctx context.Context, _ Lease) error {
+type testDelivery struct {
+	queue *testQueue
+	task  *Task
+}
+
+func (d *testDelivery) Task() *Task {
+	if d == nil {
+		return nil
+	}
+	return d.task
+}
+
+func (*testDelivery) Ack(ctx context.Context) error {
 	return ctx.Err()
 }
 
-func (q *testQueue) Retry(ctx context.Context, lease Lease, delay time.Duration) error {
+func (d *testDelivery) Retry(ctx context.Context, delay time.Duration) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if lease == nil || lease.Task() == nil {
+	if d == nil || d.task == nil {
 		return nil
 	}
 
-	task := lease.Task().clone()
+	task := d.task.clone()
 	task.AvailableAt = time.Now().UTC().Add(delay)
-	return q.Enqueue(ctx, task)
+	return d.queue.Enqueue(ctx, task)
 }
 
-func (q *testQueue) DeadLetter(ctx context.Context, lease Lease, reason string) error {
+func (d *testDelivery) DeadLetter(ctx context.Context, reason string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if lease == nil || lease.Task() == nil {
+	if d == nil || d.task == nil {
 		return nil
 	}
 
-	task := lease.Task().clone()
+	task := d.task.clone()
 	if task.Metadata == nil {
 		task.Metadata = make(map[string]string)
 	}
 	task.Metadata["queue.dead_letter.reason"] = reason
 
-	q.mu.Lock()
-	defer q.mu.Unlock()
+	d.queue.mu.Lock()
+	defer d.queue.mu.Unlock()
 
-	q.deadLetter[task.Queue] = append(q.deadLetter[task.Queue], task)
+	d.queue.deadLetter[task.Queue] = append(d.queue.deadLetter[task.Queue], task)
 	return nil
 }
 
@@ -118,4 +198,21 @@ func (q *testQueue) DeadLetters(queueName string) []*Task {
 		cloned = append(cloned, task.clone())
 	}
 	return cloned
+}
+
+func (q *testQueue) signal() {
+	close(q.notify)
+	q.notify = make(chan struct{})
+}
+
+func stopTestTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
 }

--- a/queue/test_queue_test.go
+++ b/queue/test_queue_test.go
@@ -39,7 +39,7 @@ func (q *testQueue) Enqueue(ctx context.Context, task *Task) error {
 	return nil
 }
 
-func (q *testQueue) Dequeue(ctx context.Context, queueName string, _ time.Duration) (Lease, error) {
+func (q *testQueue) Dequeue(ctx context.Context, queueName string) (Lease, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/queue/typed_test.go
+++ b/queue/typed_test.go
@@ -66,7 +66,6 @@ func TestHandleForDecodesPayload(t *testing.T) {
 			handled <- task
 			return nil
 		})),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)
@@ -105,7 +104,6 @@ func TestHandleTaskerRegistersTypedHandler(t *testing.T) {
 	worker := NewWorker(
 		q,
 		HandleTasker[emailPayload](tasker),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)
@@ -179,7 +177,6 @@ func TestHandleForWithCodecUsesCustomCodec(t *testing.T) {
 			handled <- task.Payload
 			return nil
 		})),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)
@@ -286,13 +283,13 @@ func TestTaskProducerEnqueueUsesBoundTaskType(t *testing.T) {
 	assert.Equal(t, "send_email", task.Type)
 	assert.Equal(t, "critical", task.Queue)
 
-	lease, err := q.Dequeue(ctx, "critical")
+	delivery, err := q.Receive(ctx, "critical")
 	require.NoError(t, err)
-	require.NotNil(t, lease)
-	require.NotNil(t, lease.Task())
+	require.NotNil(t, delivery)
+	require.NotNil(t, delivery.Task())
 
 	var decoded emailPayload
-	require.NoError(t, json.Unmarshal(lease.Task().Payload, &decoded))
+	require.NoError(t, json.Unmarshal(delivery.Task().Payload, &decoded))
 	assert.Equal(t, 20, decoded.UserID)
 	assert.Equal(t, "digest", decoded.Subject)
 }

--- a/queue/typed_test.go
+++ b/queue/typed_test.go
@@ -286,7 +286,7 @@ func TestTaskProducerEnqueueUsesBoundTaskType(t *testing.T) {
 	assert.Equal(t, "send_email", task.Type)
 	assert.Equal(t, "critical", task.Queue)
 
-	lease, err := q.Dequeue(ctx, "critical", time.Minute)
+	lease, err := q.Dequeue(ctx, "critical")
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.NotNil(t, lease.Task())

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -11,22 +11,20 @@ import (
 )
 
 const (
-	defaultConcurrency       = 1
-	defaultPollInterval      = time.Second
-	defaultVisibilityTimeout = 5 * time.Minute
-	defaultRetryMaxAttempts  = 3
-	defaultRetryDelay        = time.Second
+	defaultConcurrency      = 1
+	defaultPollInterval     = time.Second
+	defaultRetryMaxAttempts = 3
+	defaultRetryDelay       = time.Second
 )
 
 type workerConfig struct {
-	queue             string
-	concurrency       int
-	pollInterval      time.Duration
-	visibilityTimeout time.Duration
-	handlerTimeout    time.Duration
-	retryPolicy       RetryPolicy
-	middleware        []Middleware
-	handlers          map[string]Handler
+	queue          string
+	concurrency    int
+	pollInterval   time.Duration
+	handlerTimeout time.Duration
+	retryPolicy    RetryPolicy
+	middleware     []Middleware
+	handlers       map[string]Handler
 }
 
 // WorkerOption configures a Worker.
@@ -63,15 +61,6 @@ func WithPollInterval(interval time.Duration) WorkerOption {
 	return workerOptionFunc(func(c *workerConfig) {
 		if interval > 0 {
 			c.pollInterval = interval
-		}
-	})
-}
-
-// WithVisibilityTimeout sets how long a leased task can remain unacknowledged before redelivery.
-func WithVisibilityTimeout(timeout time.Duration) WorkerOption {
-	return workerOptionFunc(func(c *workerConfig) {
-		if timeout > 0 {
-			c.visibilityTimeout = timeout
 		}
 	})
 }
@@ -149,12 +138,11 @@ func HandleTasker[T any](tasker Tasker[T]) WorkerOption {
 
 func newWorkerConfig(opts ...WorkerOption) *workerConfig {
 	c := &workerConfig{
-		queue:             DefaultQueue,
-		concurrency:       defaultConcurrency,
-		pollInterval:      defaultPollInterval,
-		visibilityTimeout: defaultVisibilityTimeout,
-		retryPolicy:       FixedRetry(defaultRetryMaxAttempts, defaultRetryDelay),
-		handlers:          make(map[string]Handler),
+		queue:        DefaultQueue,
+		concurrency:  defaultConcurrency,
+		pollInterval: defaultPollInterval,
+		retryPolicy:  FixedRetry(defaultRetryMaxAttempts, defaultRetryDelay),
+		handlers:     make(map[string]Handler),
 	}
 	for _, opt := range opts {
 		opt.apply(c)
@@ -303,7 +291,7 @@ func (w *Worker) loop(pollCtx, handlerCtx context.Context) error {
 		default:
 		}
 
-		lease, err := w.queue.Dequeue(pollCtx, w.config.queue, w.config.visibilityTimeout)
+		lease, err := w.queue.Dequeue(pollCtx, w.config.queue)
 		if errors.Is(err, ErrNoTask) {
 			if err := sleep(pollCtx, w.config.pollInterval); err != nil {
 				return nil

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	defaultConcurrency      = 1
-	defaultPollInterval     = time.Second
 	defaultRetryMaxAttempts = 3
 	defaultRetryDelay       = time.Second
 )
@@ -20,7 +19,6 @@ const (
 type workerConfig struct {
 	queue          string
 	concurrency    int
-	pollInterval   time.Duration
 	handlerTimeout time.Duration
 	retryPolicy    RetryPolicy
 	middleware     []Middleware
@@ -52,15 +50,6 @@ func WithConcurrency(concurrency int) WorkerOption {
 	return workerOptionFunc(func(c *workerConfig) {
 		if concurrency > 0 {
 			c.concurrency = concurrency
-		}
-	})
-}
-
-// WithPollInterval sets how long the worker waits after an empty dequeue.
-func WithPollInterval(interval time.Duration) WorkerOption {
-	return workerOptionFunc(func(c *workerConfig) {
-		if interval > 0 {
-			c.pollInterval = interval
 		}
 	})
 }
@@ -138,11 +127,10 @@ func HandleTasker[T any](tasker Tasker[T]) WorkerOption {
 
 func newWorkerConfig(opts ...WorkerOption) *workerConfig {
 	c := &workerConfig{
-		queue:        DefaultQueue,
-		concurrency:  defaultConcurrency,
-		pollInterval: defaultPollInterval,
-		retryPolicy:  FixedRetry(defaultRetryMaxAttempts, defaultRetryDelay),
-		handlers:     make(map[string]Handler),
+		queue:       DefaultQueue,
+		concurrency: defaultConcurrency,
+		retryPolicy: FixedRetry(defaultRetryMaxAttempts, defaultRetryDelay),
+		handlers:    make(map[string]Handler),
 	}
 	for _, opt := range opts {
 		opt.apply(c)
@@ -284,6 +272,17 @@ func (w *Worker) finish(done chan struct{}) {
 }
 
 func (w *Worker) loop(pollCtx, handlerCtx context.Context) error {
+	consumer, err := w.queue.NewConsumer(pollCtx, w.config.queue)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil
+		}
+		return err
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
 	for {
 		select {
 		case <-pollCtx.Done():
@@ -291,51 +290,45 @@ func (w *Worker) loop(pollCtx, handlerCtx context.Context) error {
 		default:
 		}
 
-		lease, err := w.queue.Dequeue(pollCtx, w.config.queue)
-		if errors.Is(err, ErrNoTask) {
-			if err := sleep(pollCtx, w.config.pollInterval); err != nil {
-				return nil
-			}
-			continue
-		}
+		delivery, err := consumer.Receive(pollCtx)
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return nil
 			}
 			return err
 		}
-		if lease == nil {
+		if delivery == nil {
 			continue
 		}
-		task := lease.Task()
+		task := delivery.Task()
 		if task == nil {
 			continue
 		}
 
-		if err := w.process(handlerCtx, lease); err != nil {
+		if err := w.process(handlerCtx, delivery); err != nil {
 			return err
 		}
 	}
 }
 
-func (w *Worker) process(ctx context.Context, lease Lease) error {
-	task := lease.Task()
+func (w *Worker) process(ctx context.Context, delivery Delivery) error {
+	task := delivery.Task()
 	handler, ok := w.config.handlers[task.Type]
 	if !ok {
-		return w.queue.DeadLetter(ctx, lease, ErrHandlerNotFound.Error())
+		return delivery.DeadLetter(ctx, ErrHandlerNotFound.Error())
 	}
 
 	err := w.handle(ctx, handler, task)
 	if err == nil {
-		return w.queue.Ack(ctx, lease)
+		return delivery.Ack(ctx)
 	}
 
 	delay, ok := w.config.retryPolicy.NextDelay(task, err)
 	if !ok {
-		return w.queue.DeadLetter(ctx, lease, fmt.Sprintf("%s: %v", ErrRetryExhausted, err))
+		return delivery.DeadLetter(ctx, fmt.Sprintf("%s: %v", ErrRetryExhausted, err))
 	}
 
-	return w.queue.Retry(ctx, lease, delay)
+	return delivery.Retry(ctx, delay)
 }
 
 func (w *Worker) handle(ctx context.Context, handler Handler, task *Task) error {
@@ -347,16 +340,4 @@ func (w *Worker) handle(ctx context.Context, handler Handler, task *Task) error 
 	handlerCtx, cancel := context.WithTimeout(ctx, w.config.handlerTimeout)
 	defer cancel()
 	return handler.Handle(handlerCtx, task)
-}
-
-func sleep(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
 }

--- a/queue/worker_test.go
+++ b/queue/worker_test.go
@@ -18,20 +18,8 @@ func (q dequeueErrorQueue) Enqueue(context.Context, *Task) error {
 	return nil
 }
 
-func (q dequeueErrorQueue) Dequeue(context.Context, string) (Lease, error) {
+func (q dequeueErrorQueue) NewConsumer(context.Context, string) (Consumer, error) {
 	return nil, q.err
-}
-
-func (q dequeueErrorQueue) Ack(context.Context, Lease) error {
-	return nil
-}
-
-func (q dequeueErrorQueue) Retry(context.Context, Lease, time.Duration) error {
-	return nil
-}
-
-func (q dequeueErrorQueue) DeadLetter(context.Context, Lease, string) error {
-	return nil
 }
 
 func TestWorker_ConfigDefaults(t *testing.T) {
@@ -40,7 +28,6 @@ func TestWorker_ConfigDefaults(t *testing.T) {
 	config := newWorkerConfig(
 		WithWorkerQueue(""),
 		WithConcurrency(0),
-		WithPollInterval(0),
 		WithHandlerTimeout(0),
 		WithRetryPolicy(nil),
 		WithMiddleware(),
@@ -50,7 +37,6 @@ func TestWorker_ConfigDefaults(t *testing.T) {
 
 	assert.Equal(t, DefaultQueue, config.queue)
 	assert.Equal(t, 1, config.concurrency)
-	assert.Equal(t, time.Second, config.pollInterval)
 	assert.Zero(t, config.handlerTimeout)
 	assert.NotNil(t, config.retryPolicy)
 	assert.Empty(t, config.middleware)
@@ -67,7 +53,6 @@ func TestWorker_ConfigOptions(t *testing.T) {
 	config := newWorkerConfig(
 		WithWorkerQueue("critical"),
 		WithConcurrency(4),
-		WithPollInterval(10*time.Millisecond),
 		WithHandlerTimeout(time.Second),
 		WithRetryPolicy(retryPolicy),
 		WithMiddleware(middleware),
@@ -76,7 +61,6 @@ func TestWorker_ConfigOptions(t *testing.T) {
 
 	assert.Equal(t, "critical", config.queue)
 	assert.Equal(t, 4, config.concurrency)
-	assert.Equal(t, 10*time.Millisecond, config.pollInterval)
 	assert.Equal(t, time.Second, config.handlerTimeout)
 	assert.Equal(t, retryPolicy, config.retryPolicy)
 	assert.Len(t, config.middleware, 1)
@@ -97,7 +81,6 @@ func TestWorker_ProcessesAndAcksTask(t *testing.T) {
 			handled <- task.Clone()
 			return nil
 		})),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)
@@ -118,8 +101,7 @@ func TestWorker_ProcessesAndAcksTask(t *testing.T) {
 	cancel()
 	require.NoError(t, <-errs)
 
-	_, err = q.Dequeue(t.Context(), DefaultQueue)
-	require.ErrorIs(t, err, ErrNoTask)
+	require.Empty(t, q.queues[DefaultQueue])
 }
 
 func TestWorker_RetriesThenDeadLetters(t *testing.T) {
@@ -136,7 +118,6 @@ func TestWorker_RetriesThenDeadLetters(t *testing.T) {
 			seen <- task.Attempt
 			return errors.New("temporary failure")
 		})),
-		WithPollInterval(time.Millisecond),
 		WithRetryPolicy(FixedRetry(2, 0)),
 	)
 
@@ -189,7 +170,6 @@ func TestWorker_ConsumesConfiguredQueue(t *testing.T) {
 			return nil
 		})),
 		WithWorkerQueue("critical"),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)
@@ -250,13 +230,13 @@ func TestWorker_DeadLettersTaskWithoutHandler(t *testing.T) {
 
 	q := newTestQueue()
 	worker := NewWorker(q)
-	lease := NewLease(&Task{
+	delivery := &testDelivery{queue: q, task: &Task{
 		ID:    "task-1",
 		Type:  "unknown",
 		Queue: DefaultQueue,
-	})
+	}}
 
-	err := worker.process(t.Context(), lease)
+	err := worker.process(t.Context(), delivery)
 	require.NoError(t, err)
 
 	deadLetters := q.DeadLetters(DefaultQueue)
@@ -297,7 +277,6 @@ func TestWorker_StopDrainsInFlightTask(t *testing.T) {
 				return ctx.Err()
 			}
 		})),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)
@@ -350,7 +329,6 @@ func TestWorker_StopCancelsInFlightTaskAfterContextDeadline(t *testing.T) {
 			handlerDone <- err
 			return err
 		})),
-		WithPollInterval(time.Millisecond),
 	)
 
 	errs := make(chan error, 1)

--- a/queue/worker_test.go
+++ b/queue/worker_test.go
@@ -18,7 +18,7 @@ func (q dequeueErrorQueue) Enqueue(context.Context, *Task) error {
 	return nil
 }
 
-func (q dequeueErrorQueue) Dequeue(context.Context, string, time.Duration) (Lease, error) {
+func (q dequeueErrorQueue) Dequeue(context.Context, string) (Lease, error) {
 	return nil, q.err
 }
 
@@ -41,7 +41,6 @@ func TestWorker_ConfigDefaults(t *testing.T) {
 		WithWorkerQueue(""),
 		WithConcurrency(0),
 		WithPollInterval(0),
-		WithVisibilityTimeout(0),
 		WithHandlerTimeout(0),
 		WithRetryPolicy(nil),
 		WithMiddleware(),
@@ -52,7 +51,6 @@ func TestWorker_ConfigDefaults(t *testing.T) {
 	assert.Equal(t, DefaultQueue, config.queue)
 	assert.Equal(t, 1, config.concurrency)
 	assert.Equal(t, time.Second, config.pollInterval)
-	assert.Equal(t, 5*time.Minute, config.visibilityTimeout)
 	assert.Zero(t, config.handlerTimeout)
 	assert.NotNil(t, config.retryPolicy)
 	assert.Empty(t, config.middleware)
@@ -70,7 +68,6 @@ func TestWorker_ConfigOptions(t *testing.T) {
 		WithWorkerQueue("critical"),
 		WithConcurrency(4),
 		WithPollInterval(10*time.Millisecond),
-		WithVisibilityTimeout(30*time.Second),
 		WithHandlerTimeout(time.Second),
 		WithRetryPolicy(retryPolicy),
 		WithMiddleware(middleware),
@@ -80,7 +77,6 @@ func TestWorker_ConfigOptions(t *testing.T) {
 	assert.Equal(t, "critical", config.queue)
 	assert.Equal(t, 4, config.concurrency)
 	assert.Equal(t, 10*time.Millisecond, config.pollInterval)
-	assert.Equal(t, 30*time.Second, config.visibilityTimeout)
 	assert.Equal(t, time.Second, config.handlerTimeout)
 	assert.Equal(t, retryPolicy, config.retryPolicy)
 	assert.Len(t, config.middleware, 1)
@@ -122,7 +118,7 @@ func TestWorker_ProcessesAndAcksTask(t *testing.T) {
 	cancel()
 	require.NoError(t, <-errs)
 
-	_, err = q.Dequeue(t.Context(), DefaultQueue, time.Minute)
+	_, err = q.Dequeue(t.Context(), DefaultQueue)
 	require.ErrorIs(t, err, ErrNoTask)
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -106,6 +106,7 @@ module-sets:
       # Queue
       - github.com/go-fries/fries/queue/v3
       - github.com/go-fries/fries/queue/adapter/memory/v3
+      - github.com/go-fries/fries/queue/adapter/rabbitmq/v3
       - github.com/go-fries/fries/queue/adapter/redis/v3
       - github.com/go-fries/fries/queue/kratos/server/v3
       - github.com/go-fries/fries/queue/middleware/recovery/v3


### PR DESCRIPTION
## Summary
Add a RabbitMQ-backed queue adapter and simplify the core queue dequeue contract so broker-specific visibility behavior lives in the adapter that needs it.

## Changes
- Add `queue/adapter/rabbitmq/v3` with task enqueue, dequeue, retry, dead-letter, delay queue, and documentation support
- Manage RabbitMQ AMQP channels internally from a shared connection so callers do not share a single channel across goroutines
- Remove the core `Queue.Dequeue` visibility timeout parameter and move Redis pending-claim behavior behind `redis.WithClaimMinIdle`
- Update memory, Redis, worker, typed queue, and Kratos server tests for the new queue interface
- Register the RabbitMQ adapter in module/version and coverage configuration

## Motivation
- Visibility timeout is Redis-specific and should not leak into the shared queue interface
- RabbitMQ channel lifecycle needs to be handled by the adapter to avoid unsafe concurrent channel sharing in worker/producer usage

## Breaking Changes
- `queue.Queue.Dequeue` now accepts only `(ctx, queueName)`
- `queue.WithVisibilityTimeout` has been removed; Redis pending claim timing is configured with `redis.WithClaimMinIdle`
- RabbitMQ adapter construction uses `rabbitmq.NewQueue(conn, ...)` with an AMQP connection instead of a shared channel

## Testing
- `go test -count=1 ./...` for `queue`, `queue/adapter/memory`, `queue/adapter/redis`, `queue/adapter/rabbitmq`, `queue/kratos/server`, and `queue/examples/tasker`
- `make lint/./queue`
- `make lint/./queue/adapter/memory`
- `make lint/./queue/adapter/redis`
- `make lint/./queue/adapter/rabbitmq`
- `make lint/./queue/kratos/server`
- `make build/./queue/adapter/rabbitmq`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RabbitMQ adapter: released with durable queues, delayed tasks (TTL + dead-lettering), configurable prefix and consumer prefetch.
  * Redis adapter: added WithClaimMinIdle to control pending-message claim behavior.

* **Refactor**
  * Queue API reworked from a dequeue/lease model to a consumer/delivery model; workers and adapters use Consumer.Receive and Delivery ack/retry/dead-letter.

* **Documentation**
  * Added RabbitMQ adapter README with usage and behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->