### PR TITLE
refactor(ent): use math/rand/v2 in multidriver

### DIFF
--- a/ent/multidriver/policy.go
+++ b/ent/multidriver/policy.go
@@ -1,7 +1,7 @@
 package multidriver
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync/atomic"
 
 	"entgo.io/ent/dialect"
@@ -34,6 +34,6 @@ func StrictRoundRobinPolicy() Policy {
 
 func RandomPolicy() Policy {
 	return PolicyFunc(func(drivers []dialect.Driver) dialect.Driver {
-		return drivers[rand.Intn(len(drivers))]
+		return drivers[rand.IntN(len(drivers))]
 	})
 }


### PR DESCRIPTION
## Summary
Migrate the ent multidriver random policy from math/rand to math/rand/v2.

## Changes
- Replace the legacy math/rand import with math/rand/v2
- Update RandomPolicy to use rand.IntN

## Motivation
- Keep repository random helper usage aligned on math/rand/v2 now that modules target Go 1.25

## Testing
- GOCACHE=/private/tmp/go-fries-gocache make test/ent/multidriver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal driver selection implementation to use the latest Go standard library APIs, enhancing compatibility and maintainability with current and future Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->