### PR TITLE
refactor(queue): unify shared queue options

### DIFF
--- a/queue/README.md
+++ b/queue/README.md
@@ -170,8 +170,8 @@ func withObserver(q queue.Queue, handler queue.Handler) (*queue.Producer, *queue
 		// Record metrics, logs, or spans.
 	})
 
-	producer := queue.NewProducer(q, queue.WithProducerObserver(observer))
-	worker := queue.NewWorker(q, queue.WithWorkerObserver(observer), queue.Handle("send_email", handler))
+	producer := queue.NewProducer(q, queue.WithObserver(observer))
+	worker := queue.NewWorker(q, queue.WithObserver(observer), queue.Handle("send_email", handler))
 	return producer, worker
 }
 ```

--- a/queue/adapter/rabbitmq/config.go
+++ b/queue/adapter/rabbitmq/config.go
@@ -18,7 +18,7 @@ type config struct {
 	publisherConfirm bool
 }
 
-// Option configures a RabbitMQ queue adapter.
+// Option is an option that configures a RabbitMQ queue adapter.
 type Option interface {
 	apply(*config)
 }

--- a/queue/adapter/redis/config.go
+++ b/queue/adapter/redis/config.go
@@ -16,7 +16,7 @@ type config struct {
 	deadLetterMaxLen int64
 }
 
-// Option configures a Redis queue.
+// Option is an option that configures a Redis queue.
 type Option interface {
 	apply(*config)
 }

--- a/queue/middleware/recovery/recovery.go
+++ b/queue/middleware/recovery/recovery.go
@@ -34,7 +34,7 @@ type config struct {
 	stackSize int
 }
 
-// Option configures recovery middleware.
+// Option is an option that configures recovery middleware.
 type Option interface {
 	apply(*config)
 }

--- a/queue/observer_test.go
+++ b/queue/observer_test.go
@@ -88,7 +88,7 @@ func TestWorker_ObserverEventsForSuccessfulTask(t *testing.T) {
 	observer := &recordingObserver{}
 	worker := NewWorker(
 		newTestQueue(),
-		WithWorkerQueue("critical"),
+		WithQueue("critical"),
 		WithConsumerName("worker-1"),
 		WithWorkerObserver(observer),
 		Handle("send_email", HandlerFunc(func(context.Context, *Task) error {

--- a/queue/observer_test.go
+++ b/queue/observer_test.go
@@ -41,7 +41,7 @@ func TestProducer_ObserverEvents(t *testing.T) {
 	t.Parallel()
 
 	observer := &recordingObserver{}
-	producer := NewProducer(newTestQueue(), WithProducerObserver(observer))
+	producer := NewProducer(newTestQueue(), WithObserver(observer))
 
 	task, err := producer.Enqueue(
 		t.Context(),
@@ -70,7 +70,7 @@ func TestProducer_ObserverFailureEvent(t *testing.T) {
 
 	wantErr := errors.New("enqueue failed")
 	observer := &recordingObserver{}
-	producer := NewProducer(enqueueErrorQueue{err: wantErr}, WithProducerObserver(observer))
+	producer := NewProducer(enqueueErrorQueue{err: wantErr}, WithObserver(observer))
 
 	task, err := producer.Enqueue(t.Context(), "send_email", nil, WithID("task-1"))
 
@@ -90,7 +90,7 @@ func TestWorker_ObserverEventsForSuccessfulTask(t *testing.T) {
 		newTestQueue(),
 		WithQueue("critical"),
 		WithConsumerName("worker-1"),
-		WithWorkerObserver(observer),
+		WithObserver(observer),
 		Handle("send_email", HandlerFunc(func(context.Context, *Task) error {
 			return nil
 		})),
@@ -132,7 +132,7 @@ func TestWorker_ObserverEventsForSettlementFailure(t *testing.T) {
 	observer := &recordingObserver{}
 	worker := NewWorker(
 		newTestQueue(),
-		WithWorkerObserver(observer),
+		WithObserver(observer),
 		Handle("send_email", HandlerFunc(func(context.Context, *Task) error {
 			return nil
 		})),
@@ -167,7 +167,7 @@ func TestWorker_ObserverEventsForRunLifecycleAndReceive(t *testing.T) {
 	observer := &recordingObserver{}
 	worker := NewWorker(
 		q,
-		WithWorkerObserver(observer),
+		WithObserver(observer),
 		Handle("send_email", HandlerFunc(func(context.Context, *Task) error {
 			return nil
 		})),

--- a/queue/option.go
+++ b/queue/option.go
@@ -1,0 +1,28 @@
+package queue
+
+type queueOption struct {
+	name string
+}
+
+// QueueOption is an option that applies to both task enqueueing and worker consumption.
+type QueueOption interface {
+	EnqueueOption
+	WorkerOption
+}
+
+// WithQueue returns an option that selects the queue used to enqueue or consume tasks.
+func WithQueue(name string) QueueOption {
+	return queueOption{name: name}
+}
+
+func (o queueOption) applyEnqueue(c *enqueueConfig) {
+	if o.name != "" {
+		c.queue = o.name
+	}
+}
+
+func (o queueOption) applyWorker(c *workerConfig) {
+	if o.name != "" {
+		c.queue = o.name
+	}
+}

--- a/queue/option.go
+++ b/queue/option.go
@@ -4,15 +4,30 @@ type queueOption struct {
 	name string
 }
 
+type observerOption struct {
+	observer Observer
+}
+
 // QueueOption is an option that applies to both task enqueueing and worker consumption.
 type QueueOption interface {
 	EnqueueOption
 	WorkerOption
 }
 
+// ObserverOption is an option that applies to both producers and workers.
+type ObserverOption interface {
+	ProducerOption
+	WorkerOption
+}
+
 // WithQueue returns an option that selects the queue used to enqueue or consume tasks.
 func WithQueue(name string) QueueOption {
 	return queueOption{name: name}
+}
+
+// WithObserver returns an option that sets the observer used by producers or workers.
+func WithObserver(observer Observer) ObserverOption {
+	return observerOption{observer: observer}
 }
 
 func (o queueOption) applyEnqueue(c *enqueueConfig) {
@@ -25,4 +40,12 @@ func (o queueOption) applyWorker(c *workerConfig) {
 	if o.name != "" {
 		c.queue = o.name
 	}
+}
+
+func (o observerOption) applyProducer(c *producerConfig) {
+	c.observer = o.observer
+}
+
+func (o observerOption) applyWorker(c *workerConfig) {
+	c.observer = o.observer
 }

--- a/queue/producer.go
+++ b/queue/producer.go
@@ -90,19 +90,6 @@ type ProducerOption interface {
 	applyProducer(*producerConfig)
 }
 
-type producerOptionFunc func(*producerConfig)
-
-func (f producerOptionFunc) applyProducer(c *producerConfig) {
-	f(c)
-}
-
-// WithProducerObserver sets the observer used for producer enqueue events.
-func WithProducerObserver(observer Observer) ProducerOption {
-	return producerOptionFunc(func(c *producerConfig) {
-		c.observer = observer
-	})
-}
-
 func newProducerConfig(opts ...ProducerOption) *producerConfig {
 	c := &producerConfig{}
 	for _, opt := range opts {

--- a/queue/producer.go
+++ b/queue/producer.go
@@ -24,12 +24,12 @@ type producerConfig struct {
 
 // EnqueueOption configures task enqueue behavior.
 type EnqueueOption interface {
-	apply(*enqueueConfig)
+	applyEnqueue(*enqueueConfig)
 }
 
 type enqueueOptionFunc func(*enqueueConfig)
 
-func (f enqueueOptionFunc) apply(c *enqueueConfig) {
+func (f enqueueOptionFunc) applyEnqueue(c *enqueueConfig) {
 	f(c)
 }
 
@@ -37,15 +37,6 @@ func (f enqueueOptionFunc) apply(c *enqueueConfig) {
 func WithID(id string) EnqueueOption {
 	return enqueueOptionFunc(func(c *enqueueConfig) {
 		c.id = id
-	})
-}
-
-// WithQueue sets the queue name for a task.
-func WithQueue(name string) EnqueueOption {
-	return enqueueOptionFunc(func(c *enqueueConfig) {
-		if name != "" {
-			c.queue = name
-		}
 	})
 }
 
@@ -86,7 +77,7 @@ func newEnqueueConfig(opts ...EnqueueOption) *enqueueConfig {
 		queue: DefaultQueue,
 	}
 	for _, opt := range opts {
-		opt.apply(c)
+		opt.applyEnqueue(c)
 	}
 	if c.id == "" {
 		c.id = newID()

--- a/queue/producer.go
+++ b/queue/producer.go
@@ -22,7 +22,7 @@ type producerConfig struct {
 	observer Observer
 }
 
-// EnqueueOption configures task enqueue behavior.
+// EnqueueOption is an option that configures how a task is enqueued.
 type EnqueueOption interface {
 	applyEnqueue(*enqueueConfig)
 }
@@ -85,7 +85,7 @@ func newEnqueueConfig(opts ...EnqueueOption) *enqueueConfig {
 	return c
 }
 
-// ProducerOption configures a Producer.
+// ProducerOption is an option that configures a Producer.
 type ProducerOption interface {
 	applyProducer(*producerConfig)
 }

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -85,13 +85,6 @@ func WithRetryPolicy(policy RetryPolicy) WorkerOption {
 	})
 }
 
-// WithWorkerObserver sets the observer used for worker events.
-func WithWorkerObserver(observer Observer) WorkerOption {
-	return workerOptionFunc(func(c *workerConfig) {
-		c.observer = observer
-	})
-}
-
 // WithMiddleware appends worker middleware around task handlers.
 func WithMiddleware(middleware ...Middleware) WorkerOption {
 	return workerOptionFunc(func(c *workerConfig) {

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -31,22 +31,13 @@ type workerConfig struct {
 
 // WorkerOption configures a Worker.
 type WorkerOption interface {
-	apply(*workerConfig)
+	applyWorker(*workerConfig)
 }
 
 type workerOptionFunc func(*workerConfig)
 
-func (f workerOptionFunc) apply(c *workerConfig) {
+func (f workerOptionFunc) applyWorker(c *workerConfig) {
 	f(c)
-}
-
-// WithWorkerQueue sets the queue name consumed by the worker.
-func WithWorkerQueue(name string) WorkerOption {
-	return workerOptionFunc(func(c *workerConfig) {
-		if name != "" {
-			c.queue = name
-		}
-	})
 }
 
 // WithConsumerName sets the backend consumer identity used by the worker.
@@ -163,7 +154,7 @@ func newWorkerConfig(opts ...WorkerOption) *workerConfig {
 		handlers:          make(map[string]Handler),
 	}
 	for _, opt := range opts {
-		opt.apply(c)
+		opt.applyWorker(c)
 	}
 	return c
 }

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -29,7 +29,7 @@ type workerConfig struct {
 	handlers          map[string]Handler
 }
 
-// WorkerOption configures a Worker.
+// WorkerOption is an option that configures a Worker.
 type WorkerOption interface {
 	applyWorker(*workerConfig)
 }

--- a/queue/worker_test.go
+++ b/queue/worker_test.go
@@ -82,7 +82,7 @@ func TestWorker_ConfigDefaults(t *testing.T) {
 	t.Parallel()
 
 	config := newWorkerConfig(
-		WithWorkerQueue(""),
+		WithQueue(""),
 		WithConsumerName(""),
 		WithConcurrency(0),
 		WithHandlerTimeout(0),
@@ -110,7 +110,7 @@ func TestWorker_ConfigOptions(t *testing.T) {
 	retryPolicy := NoRetry()
 
 	config := newWorkerConfig(
-		WithWorkerQueue("critical"),
+		WithQueue("critical"),
 		WithConsumerName("worker-1"),
 		WithConcurrency(4),
 		WithHandlerTimeout(time.Second),
@@ -232,7 +232,7 @@ func TestWorker_ConsumesConfiguredQueue(t *testing.T) {
 			handled <- struct{}{}
 			return nil
 		})),
-		WithWorkerQueue("critical"),
+		WithQueue("critical"),
 	)
 
 	errs := make(chan error, 1)


### PR DESCRIPTION
## Summary
Consolidate shared queue option APIs so queue selection and observer wiring can be reused across producer and worker contexts.

## Changes
- Add shared `WithQueue` and `WithObserver` options for the queue package
- Remove producer- and worker-specific queue/observer option entry points
- Update queue docs, tests, and option interface comments for the new API shape

## Motivation
- Keep the queue public API smaller and make shared configuration options usable in both relevant call sites

## Breaking Changes
- Replace `WithWorkerQueue` with `WithQueue`
- Replace `WithProducerObserver` and `WithWorkerObserver` with `WithObserver`

## Testing
- `make test/queue test/queue/adapter/memory test/queue/adapter/redis test/queue/adapter/rabbitmq test/queue/middleware/recovery test/queue/kratos/server`
- `make lint/queue lint/queue/adapter/memory lint/queue/adapter/redis lint/queue/adapter/rabbitmq lint/queue/middleware/recovery lint/queue/kratos/server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified observer configuration with a single `WithObserver` option for both producer and worker setup, simplifying API usage.

* **Documentation**
  * Updated README observability example and clarified option type descriptions across adapters and middleware.

* **Refactor**
  * Consolidated option handling for queue and observer configuration for a cleaner API surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->