### PR TITLE
fix(queue): propagate observer lifecycle context

### DIFF
--- a/queue/README.md
+++ b/queue/README.md
@@ -166,8 +166,9 @@ import (
 )
 
 func withObserver(q queue.Queue, handler queue.Handler) (*queue.Producer, *queue.Worker) {
-	observer := queue.ObserverFunc(func(ctx context.Context, event queue.Event) {
+	observer := queue.ObserverFunc(func(ctx context.Context, event queue.Event) context.Context {
 		// Record metrics, logs, or spans.
+		return ctx
 	})
 
 	producer := queue.NewProducer(q, queue.WithObserver(observer))

--- a/queue/README.md
+++ b/queue/README.md
@@ -167,7 +167,8 @@ import (
 
 func withObserver(q queue.Queue, handler queue.Handler) (*queue.Producer, *queue.Worker) {
 	observer := queue.ObserverFunc(func(ctx context.Context, event queue.Event) context.Context {
-		// Record metrics, logs, or spans.
+		// Record metrics, logs, or spans. Return ctx unchanged, or return a
+		// derived context to propagate values through later lifecycle events.
 		return ctx
 	})
 

--- a/queue/observer.go
+++ b/queue/observer.go
@@ -76,8 +76,9 @@ type Event struct {
 //
 // Observer implementations should return quickly and avoid blocking queue
 // processing. Started events may return a lifecycle context used by later
-// events in the same operation. The default observer is nil and emits no
-// events.
+// events in the same operation. Completion events may also return a context
+// used by following settlement events. Returning nil keeps using the input
+// context. The default observer is nil and emits no events.
 type Observer interface {
 	ObserveQueue(ctx context.Context, event Event) context.Context
 }

--- a/queue/observer.go
+++ b/queue/observer.go
@@ -75,19 +75,22 @@ type Event struct {
 // Observer receives queue producer and worker events.
 //
 // Observer implementations should return quickly and avoid blocking queue
-// processing. The default observer is nil and emits no events.
+// processing. Started events may return a lifecycle context used by later
+// events in the same operation. The default observer is nil and emits no
+// events.
 type Observer interface {
-	ObserveQueue(ctx context.Context, event Event)
+	ObserveQueue(ctx context.Context, event Event) context.Context
 }
 
 // ObserverFunc adapts a function to Observer.
-type ObserverFunc func(ctx context.Context, event Event)
+type ObserverFunc func(ctx context.Context, event Event) context.Context
 
 // ObserveQueue calls f(ctx, event).
-func (f ObserverFunc) ObserveQueue(ctx context.Context, event Event) {
+func (f ObserverFunc) ObserveQueue(ctx context.Context, event Event) context.Context {
 	if f != nil {
-		f(ctx, event)
+		return f(ctx, event)
 	}
+	return ctx
 }
 
 func taskInfo(task *Task) TaskInfo {

--- a/queue/observer_test.go
+++ b/queue/observer_test.go
@@ -12,14 +12,17 @@ import (
 )
 
 type recordingObserver struct {
-	mu     sync.Mutex
-	events []Event
+	mu       sync.Mutex
+	events   []Event
+	contexts []context.Context
 }
 
-func (o *recordingObserver) ObserveQueue(_ context.Context, event Event) {
+func (o *recordingObserver) ObserveQueue(ctx context.Context, event Event) context.Context {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.events = append(o.events, event)
+	o.contexts = append(o.contexts, ctx)
+	return ctx
 }
 
 func (o *recordingObserver) Events() []Event {
@@ -35,6 +38,12 @@ func (o *recordingObserver) Kinds() []EventKind {
 		kinds = append(kinds, event.Kind)
 	}
 	return kinds
+}
+
+func (o *recordingObserver) Contexts() []context.Context {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]context.Context(nil), o.contexts...)
 }
 
 func TestProducer_ObserverEvents(t *testing.T) {
@@ -63,6 +72,55 @@ func TestProducer_ObserverEvents(t *testing.T) {
 	}, events[0].Task)
 	assert.Equal(t, time.Second, events[0].Delay)
 	assert.NotEqual(t, string(task.Payload), events[0].Task.ID)
+}
+
+func TestProducer_ObserverPassesLifecycleContext(t *testing.T) {
+	t.Parallel()
+
+	key := contextValueKey("producer-lifecycle")
+	q := &contextRecordingQueue{Queue: newTestQueue(), key: key}
+	var enqueuedValue any
+	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
+		switch event.Kind {
+		case EventEnqueueStarted:
+			return context.WithValue(ctx, key, "enqueue")
+		case EventEnqueued:
+			enqueuedValue = ctx.Value(key)
+		}
+		return ctx
+	})
+	producer := NewProducer(q, WithObserver(observer))
+
+	_, err := producer.Enqueue(t.Context(), "send_email", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "enqueue", q.value)
+	assert.Equal(t, "enqueue", enqueuedValue)
+}
+
+func TestProducer_ObserverNilContextFallsBackToOriginalContext(t *testing.T) {
+	t.Parallel()
+
+	key := contextValueKey("producer-original")
+	q := &contextRecordingQueue{Queue: newTestQueue(), key: key}
+	var enqueuedValue any
+	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
+		switch event.Kind {
+		case EventEnqueueStarted:
+			return nil
+		case EventEnqueued:
+			enqueuedValue = ctx.Value(key)
+		}
+		return ctx
+	})
+	producer := NewProducer(q, WithObserver(observer))
+	ctx := context.WithValue(t.Context(), key, "original")
+
+	_, err := producer.Enqueue(ctx, "send_email", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "original", q.value)
+	assert.Equal(t, "original", enqueuedValue)
 }
 
 func TestProducer_ObserverFailureEvent(t *testing.T) {
@@ -123,6 +181,75 @@ func TestWorker_ObserverEventsForSuccessfulTask(t *testing.T) {
 		Queue:   "critical",
 		Attempt: 1,
 	}, events[0].Task)
+}
+
+func TestWorker_ObserverPassesHandlerLifecycleContext(t *testing.T) {
+	t.Parallel()
+
+	key := contextValueKey("handler-lifecycle")
+	var handlerValue any
+	var succeededValue any
+	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
+		switch event.Kind {
+		case EventHandlerStarted:
+			return context.WithValue(ctx, key, "handler")
+		case EventHandlerSucceeded:
+			succeededValue = ctx.Value(key)
+		}
+		return ctx
+	})
+	worker := NewWorker(
+		newTestQueue(),
+		WithObserver(observer),
+		Handle("send_email", HandlerFunc(func(ctx context.Context, _ *Task) error {
+			handlerValue = ctx.Value(key)
+			return nil
+		})),
+	)
+	delivery := &recordingDelivery{
+		task: &Task{ID: "task-1", Type: "send_email"},
+	}
+
+	err := worker.process(t.Context(), delivery)
+
+	require.NoError(t, err)
+	assert.Equal(t, "handler", handlerValue)
+	assert.Equal(t, "handler", succeededValue)
+}
+
+func TestWorker_ObserverNilContextFallsBackToOriginalContext(t *testing.T) {
+	t.Parallel()
+
+	key := contextValueKey("handler-original")
+	var handlerValue any
+	var succeededValue any
+	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
+		switch event.Kind {
+		case EventHandlerStarted:
+			return nil
+		case EventHandlerSucceeded:
+			succeededValue = ctx.Value(key)
+		}
+		return ctx
+	})
+	worker := NewWorker(
+		newTestQueue(),
+		WithObserver(observer),
+		Handle("send_email", HandlerFunc(func(ctx context.Context, _ *Task) error {
+			handlerValue = ctx.Value(key)
+			return nil
+		})),
+	)
+	delivery := &recordingDelivery{
+		task: &Task{ID: "task-1", Type: "send_email"},
+	}
+	ctx := context.WithValue(t.Context(), key, "original")
+
+	err := worker.process(ctx, delivery)
+
+	require.NoError(t, err)
+	assert.Equal(t, "original", handlerValue)
+	assert.Equal(t, "original", succeededValue)
 }
 
 func TestWorker_ObserverEventsForSettlementFailure(t *testing.T) {
@@ -200,6 +327,19 @@ func (q enqueueErrorQueue) Enqueue(context.Context, *Task) error {
 
 func (q enqueueErrorQueue) NewConsumer(context.Context, ConsumerConfig) (Consumer, error) {
 	return nil, q.err
+}
+
+type contextValueKey string
+
+type contextRecordingQueue struct {
+	Queue
+	key   any
+	value any
+}
+
+func (q *contextRecordingQueue) Enqueue(ctx context.Context, task *Task) error {
+	q.value = ctx.Value(q.key)
+	return q.Queue.Enqueue(ctx, task)
 }
 
 func hasEventKind(events []Event, kind EventKind) bool {

--- a/queue/observer_test.go
+++ b/queue/observer_test.go
@@ -46,6 +46,15 @@ func (o *recordingObserver) Contexts() []context.Context {
 	return append([]context.Context(nil), o.contexts...)
 }
 
+func TestObserverFuncNilReturnsOriginalContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	var observer ObserverFunc
+
+	assert.Same(t, ctx, observer.ObserveQueue(ctx, Event{}))
+}
+
 func TestProducer_ObserverEvents(t *testing.T) {
 	t.Parallel()
 
@@ -189,12 +198,14 @@ func TestWorker_ObserverPassesHandlerLifecycleContext(t *testing.T) {
 	key := contextValueKey("handler-lifecycle")
 	var handlerValue any
 	var succeededValue any
+	var ackValue any
 	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
 		switch event.Kind {
 		case EventHandlerStarted:
 			return context.WithValue(ctx, key, "handler")
 		case EventHandlerSucceeded:
 			succeededValue = ctx.Value(key)
+			return context.WithValue(ctx, key, "settlement")
 		}
 		return ctx
 	})
@@ -208,6 +219,10 @@ func TestWorker_ObserverPassesHandlerLifecycleContext(t *testing.T) {
 	)
 	delivery := &recordingDelivery{
 		task: &Task{ID: "task-1", Type: "send_email"},
+		ack: func(ctx context.Context) error {
+			ackValue = ctx.Value(key)
+			return nil
+		},
 	}
 
 	err := worker.process(t.Context(), delivery)
@@ -215,6 +230,7 @@ func TestWorker_ObserverPassesHandlerLifecycleContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "handler", handlerValue)
 	assert.Equal(t, "handler", succeededValue)
+	assert.Equal(t, "settlement", ackValue)
 }
 
 func TestWorker_ObserverNilContextFallsBackToOriginalContext(t *testing.T) {
@@ -250,6 +266,42 @@ func TestWorker_ObserverNilContextFallsBackToOriginalContext(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "original", handlerValue)
 	assert.Equal(t, "original", succeededValue)
+}
+
+func TestWorker_ObserverPassesFailedContextToSettlement(t *testing.T) {
+	t.Parallel()
+
+	key := contextValueKey("handler-failed")
+	var ackValue any
+	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
+		switch event.Kind {
+		case EventHandlerStarted:
+			return context.WithValue(ctx, key, "handler")
+		case EventHandlerFailed:
+			assert.Equal(t, "handler", ctx.Value(key))
+			return context.WithValue(ctx, key, "settlement")
+		}
+		return ctx
+	})
+	worker := NewWorker(
+		newTestQueue(),
+		WithObserver(observer),
+		Handle("send_email", HandlerFunc(func(context.Context, *Task) error {
+			return ErrDiscard
+		})),
+	)
+	delivery := &recordingDelivery{
+		task: &Task{ID: "task-1", Type: "send_email"},
+		ack: func(ctx context.Context) error {
+			ackValue = ctx.Value(key)
+			return nil
+		},
+	}
+
+	err := worker.process(t.Context(), delivery)
+
+	require.NoError(t, err)
+	assert.Equal(t, "settlement", ackValue)
 }
 
 func TestWorker_ObserverEventsForSettlementFailure(t *testing.T) {
@@ -315,6 +367,60 @@ func TestWorker_ObserverEventsForRunLifecycleAndReceive(t *testing.T) {
 	assert.True(t, hasEventKind(events, EventWorkerStarted))
 	assert.True(t, hasEventKind(events, EventTaskReceived))
 	assert.True(t, hasEventKind(events, EventWorkerStopped))
+}
+
+func TestWorker_ObserverPassesRunLifecycleContext(t *testing.T) {
+	t.Parallel()
+
+	key := contextValueKey("worker-lifecycle")
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	q := newTestQueue()
+	started := make(chan struct{}, 1)
+	stopped := make(chan struct{}, 1)
+	observer := ObserverFunc(func(ctx context.Context, event Event) context.Context {
+		switch event.Kind {
+		case EventWorkerStarted:
+			started <- struct{}{}
+			return context.WithValue(ctx, key, "worker")
+		case EventWorkerStopped:
+			assert.Equal(t, "worker", ctx.Value(key))
+			stopped <- struct{}{}
+		}
+		return ctx
+	})
+	worker := NewWorker(
+		q,
+		WithObserver(observer),
+		Handle("send_email", HandlerFunc(func(context.Context, *Task) error {
+			return nil
+		})),
+	)
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- worker.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	require.NoError(t, worker.Stop(t.Context()))
+	require.NoError(t, <-errs)
+	require.Eventually(t, func() bool {
+		select {
+		case <-stopped:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
 }
 
 type enqueueErrorQueue struct {

--- a/queue/producer.go
+++ b/queue/producer.go
@@ -130,14 +130,14 @@ func (p *Producer) Enqueue(ctx context.Context, taskType string, payload []byte,
 		CreatedAt:   now,
 		AvailableAt: now.Add(c.delay),
 	}
-	p.observe(ctx, Event{
+	observeCtx := p.observe(ctx, Event{
 		Kind:  EventEnqueueStarted,
 		Queue: task.Queue,
 		Task:  taskInfo(task),
 		Delay: c.delay,
 	})
-	if err := p.queue.Enqueue(ctx, task); err != nil {
-		p.observe(ctx, Event{
+	if err := p.queue.Enqueue(observeCtx, task); err != nil {
+		p.observe(observeCtx, Event{
 			Kind:  EventEnqueueFailed,
 			Queue: task.Queue,
 			Task:  taskInfo(task),
@@ -146,7 +146,7 @@ func (p *Producer) Enqueue(ctx context.Context, taskType string, payload []byte,
 		})
 		return nil, err
 	}
-	p.observe(ctx, Event{
+	p.observe(observeCtx, Event{
 		Kind:  EventEnqueued,
 		Queue: task.Queue,
 		Task:  taskInfo(task),
@@ -155,11 +155,15 @@ func (p *Producer) Enqueue(ctx context.Context, taskType string, payload []byte,
 	return task.clone(), nil
 }
 
-func (p *Producer) observe(ctx context.Context, event Event) {
+func (p *Producer) observe(ctx context.Context, event Event) context.Context {
 	if p == nil || p.observer == nil {
-		return
+		return ctx
 	}
-	p.observer.ObserveQueue(ctx, event)
+	observedCtx := p.observer.ObserveQueue(ctx, event)
+	if observedCtx == nil {
+		return ctx
+	}
+	return observedCtx
 }
 
 // TaskProducer enqueues one task type with a structured payload.

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -184,7 +184,7 @@ func (w *Worker) Run(ctx context.Context) (err error) {
 		interrupt()
 		return errors.New("queue: worker already running")
 	}
-	w.observe(ctx, Event{
+	runObserveCtx := w.observe(ctx, Event{
 		Kind:         EventWorkerStarted,
 		Queue:        w.config.queue,
 		ConsumerName: w.config.consumerName,
@@ -193,7 +193,7 @@ func (w *Worker) Run(ctx context.Context) (err error) {
 		stop()
 		interrupt()
 		w.finish(lifecycleDone)
-		w.observe(context.WithoutCancel(ctx), Event{
+		w.observe(context.WithoutCancel(runObserveCtx), Event{
 			Kind:         EventWorkerStopped,
 			Queue:        w.config.queue,
 			ConsumerName: w.config.consumerName,
@@ -366,12 +366,12 @@ func (w *Worker) process(ctx context.Context, delivery Delivery) error {
 	ctx = w.observe(ctx, w.event(EventHandlerStarted, task))
 	err := w.handle(ctx, handler, task)
 	if err == nil {
-		w.observe(ctx, w.event(EventHandlerSucceeded, task))
+		ctx = w.observe(ctx, w.event(EventHandlerSucceeded, task))
 		return w.ack(ctx, delivery)
 	}
 	failedEvent := w.event(EventHandlerFailed, task)
 	failedEvent.Err = err
-	w.observe(ctx, failedEvent)
+	ctx = w.observe(ctx, failedEvent)
 	if errors.Is(err, ErrDiscard) {
 		return w.ack(ctx, delivery)
 	}

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -363,7 +363,7 @@ func (w *Worker) process(ctx context.Context, delivery Delivery) error {
 		return w.deadLetter(ctx, delivery, ErrHandlerNotFound.Error())
 	}
 
-	w.observe(ctx, w.event(EventHandlerStarted, task))
+	ctx = w.observe(ctx, w.event(EventHandlerStarted, task))
 	err := w.handle(ctx, handler, task)
 	if err == nil {
 		w.observe(ctx, w.event(EventHandlerSucceeded, task))
@@ -459,11 +459,15 @@ func (w *Worker) handle(ctx context.Context, handler Handler, task *Task) error 
 	return handler.Handle(handlerCtx, task)
 }
 
-func (w *Worker) observe(ctx context.Context, event Event) {
+func (w *Worker) observe(ctx context.Context, event Event) context.Context {
 	if w == nil || w.config == nil || w.config.observer == nil {
-		return
+		return ctx
 	}
-	w.config.observer.ObserveQueue(ctx, event)
+	observedCtx := w.config.observer.ObserveQueue(ctx, event)
+	if observedCtx == nil {
+		return ctx
+	}
+	return observedCtx
 }
 
 func (w *Worker) event(kind EventKind, task *Task) Event {


### PR DESCRIPTION
## Summary
Allow queue observers to return a lifecycle context from started events so producers and workers can carry that context through matching completion events.

## Changes
- Change `Observer` and `ObserverFunc` to return `context.Context`
- Propagate `enqueue.started` context through enqueue execution and `enqueue.succeeded`/`enqueue.failed`
- Propagate `handler.started` context through handler execution, handler completion events, and settlement events
- Keep nil observer behavior safe and fall back to the original context when an observer returns nil
- Add focused tests for producer enqueue and worker handler lifecycle context propagation

## Motivation
- Tracing-style observers need started events to establish lifecycle context that is reused by corresponding succeeded or failed events

## Testing
- `go test ./...` in the queue module
- `make lint/queue`

## Breaking Changes
- `queue.Observer` implementations and `queue.ObserverFunc` callbacks now need to return a `context.Context`; return the input context when no replacement is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Observer callbacks can now return and propagate a modified context through queue operations, enabling better context management for request tracing and data flow control.

* **Documentation**
  * Updated observability examples with the new observer callback signature.

* **Tests**
  * Expanded test coverage validating context propagation through queue lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->