### PR TITLE
feat(queue): add producer queue and metadata defaults

### DIFF
--- a/queue/option.go
+++ b/queue/option.go
@@ -1,12 +1,6 @@
 package queue
 
-type queueOption struct {
-	name string
-}
-
-type observerOption struct {
-	observer Observer
-}
+import "maps"
 
 // QueueOption is an option that applies to producers, task enqueueing, and worker consumption.
 type QueueOption interface {
@@ -21,14 +15,13 @@ type ObserverOption interface {
 	WorkerOption
 }
 
+type queueOption struct {
+	name string
+}
+
 // WithQueue returns an option that selects the queue used to enqueue or consume tasks.
 func WithQueue(name string) QueueOption {
 	return queueOption{name: name}
-}
-
-// WithObserver returns an option that sets the observer used by producers or workers.
-func WithObserver(observer Observer) ObserverOption {
-	return observerOption{observer: observer}
 }
 
 func (o queueOption) applyEnqueue(c *enqueueConfig) {
@@ -49,10 +42,48 @@ func (o queueOption) applyWorker(c *workerConfig) {
 	}
 }
 
+type observerOption struct {
+	observer Observer
+}
+
+// WithObserver returns an option that sets the observer used by producers or workers.
+func WithObserver(observer Observer) ObserverOption {
+	return observerOption{observer: observer}
+}
+
 func (o observerOption) applyProducer(c *producerConfig) {
 	c.observer = o.observer
 }
 
 func (o observerOption) applyWorker(c *workerConfig) {
 	c.observer = o.observer
+}
+
+type metadataOption struct {
+	metadata map[string]string
+}
+
+// WithMetadata adds default or task-specific metadata values.
+func WithMetadata(metadata map[string]string) metadataOption {
+	return metadataOption{metadata: metadata}
+}
+
+func (o metadataOption) applyProducer(c *producerConfig) {
+	if len(o.metadata) == 0 {
+		return
+	}
+	if c.metadata == nil {
+		c.metadata = make(map[string]string, len(o.metadata))
+	}
+	maps.Copy(c.metadata, o.metadata)
+}
+
+func (o metadataOption) applyEnqueue(c *enqueueConfig) {
+	if len(o.metadata) == 0 {
+		return
+	}
+	if c.metadata == nil {
+		c.metadata = make(map[string]string, len(o.metadata))
+	}
+	maps.Copy(c.metadata, o.metadata)
 }

--- a/queue/option.go
+++ b/queue/option.go
@@ -15,6 +15,12 @@ type ObserverOption interface {
 	WorkerOption
 }
 
+// MetadataOption is an option that applies to both producers and task enqueueing.
+type MetadataOption interface {
+	ProducerOption
+	EnqueueOption
+}
+
 type queueOption struct {
 	name string
 }
@@ -64,7 +70,7 @@ type metadataOption struct {
 }
 
 // WithMetadata adds default or task-specific metadata values.
-func WithMetadata(metadata map[string]string) metadataOption {
+func WithMetadata(metadata map[string]string) MetadataOption {
 	return metadataOption{metadata: metadata}
 }
 

--- a/queue/option.go
+++ b/queue/option.go
@@ -8,8 +8,9 @@ type observerOption struct {
 	observer Observer
 }
 
-// QueueOption is an option that applies to both task enqueueing and worker consumption.
+// QueueOption is an option that applies to producers, task enqueueing, and worker consumption.
 type QueueOption interface {
+	ProducerOption
 	EnqueueOption
 	WorkerOption
 }
@@ -31,6 +32,12 @@ func WithObserver(observer Observer) ObserverOption {
 }
 
 func (o queueOption) applyEnqueue(c *enqueueConfig) {
+	if o.name != "" {
+		c.queue = o.name
+	}
+}
+
+func (o queueOption) applyProducer(c *producerConfig) {
 	if o.name != "" {
 		c.queue = o.name
 	}

--- a/queue/producer.go
+++ b/queue/producer.go
@@ -19,6 +19,7 @@ type enqueueConfig struct {
 }
 
 type producerConfig struct {
+	queue    string
 	observer Observer
 }
 
@@ -72,9 +73,12 @@ func WithDelay(delay time.Duration) EnqueueOption {
 	})
 }
 
-func newEnqueueConfig(opts ...EnqueueOption) *enqueueConfig {
+func newEnqueueConfig(queueName string, opts ...EnqueueOption) *enqueueConfig {
+	if queueName == "" {
+		queueName = DefaultQueue
+	}
 	c := &enqueueConfig{
-		queue: DefaultQueue,
+		queue: queueName,
 	}
 	for _, opt := range opts {
 		opt.applyEnqueue(c)
@@ -91,7 +95,9 @@ type ProducerOption interface {
 }
 
 func newProducerConfig(opts ...ProducerOption) *producerConfig {
-	c := &producerConfig{}
+	c := &producerConfig{
+		queue: DefaultQueue,
+	}
 	for _, opt := range opts {
 		opt.applyProducer(c)
 	}
@@ -100,16 +106,18 @@ func newProducerConfig(opts ...ProducerOption) *producerConfig {
 
 // Producer creates tasks in a queue.
 type Producer struct {
-	queue    Queue
-	observer Observer
+	queue     Queue
+	queueName string
+	observer  Observer
 }
 
 // NewProducer creates a producer that writes to q.
 func NewProducer(q Queue, opts ...ProducerOption) *Producer {
 	c := newProducerConfig(opts...)
 	return &Producer{
-		queue:    q,
-		observer: c.observer,
+		queue:     q,
+		queueName: c.queue,
+		observer:  c.observer,
 	}
 }
 
@@ -119,7 +127,7 @@ func (p *Producer) Enqueue(ctx context.Context, taskType string, payload []byte,
 		return nil, ErrInvalidTaskType
 	}
 
-	c := newEnqueueConfig(opts...)
+	c := newEnqueueConfig(p.queueName, opts...)
 	now := time.Now().UTC()
 	task := &Task{
 		ID:          c.id,

--- a/queue/producer.go
+++ b/queue/producer.go
@@ -20,6 +20,7 @@ type enqueueConfig struct {
 
 type producerConfig struct {
 	queue    string
+	metadata map[string]string
 	observer Observer
 }
 
@@ -51,19 +52,6 @@ func WithMetadataValue(key, value string) EnqueueOption {
 	})
 }
 
-// WithMetadata adds task metadata values.
-func WithMetadata(metadata map[string]string) EnqueueOption {
-	return enqueueOptionFunc(func(c *enqueueConfig) {
-		if len(metadata) == 0 {
-			return
-		}
-		if c.metadata == nil {
-			c.metadata = make(map[string]string, len(metadata))
-		}
-		maps.Copy(c.metadata, metadata)
-	})
-}
-
 // WithDelay delays task availability.
 func WithDelay(delay time.Duration) EnqueueOption {
 	return enqueueOptionFunc(func(c *enqueueConfig) {
@@ -73,12 +61,15 @@ func WithDelay(delay time.Duration) EnqueueOption {
 	})
 }
 
-func newEnqueueConfig(queueName string, opts ...EnqueueOption) *enqueueConfig {
+func newEnqueueConfig(queueName string, metadata map[string]string, opts ...EnqueueOption) *enqueueConfig {
 	if queueName == "" {
 		queueName = DefaultQueue
 	}
 	c := &enqueueConfig{
 		queue: queueName,
+	}
+	if len(metadata) > 0 {
+		c.metadata = maps.Clone(metadata)
 	}
 	for _, opt := range opts {
 		opt.applyEnqueue(c)
@@ -108,6 +99,7 @@ func newProducerConfig(opts ...ProducerOption) *producerConfig {
 type Producer struct {
 	queue     Queue
 	queueName string
+	metadata  map[string]string
 	observer  Observer
 }
 
@@ -117,6 +109,7 @@ func NewProducer(q Queue, opts ...ProducerOption) *Producer {
 	return &Producer{
 		queue:     q,
 		queueName: c.queue,
+		metadata:  c.metadata,
 		observer:  c.observer,
 	}
 }
@@ -127,7 +120,7 @@ func (p *Producer) Enqueue(ctx context.Context, taskType string, payload []byte,
 		return nil, ErrInvalidTaskType
 	}
 
-	c := newEnqueueConfig(p.queueName, opts...)
+	c := newEnqueueConfig(p.queueName, p.metadata, opts...)
 	now := time.Now().UTC()
 	task := &Task{
 		ID:          c.id,

--- a/queue/producer_test.go
+++ b/queue/producer_test.go
@@ -91,10 +91,46 @@ func TestProducer_EnqueueSetsDefaultsAndOptions(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+func TestProducer_WithQueueSetsDefaultQueue(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	q := newTestQueue()
+	producer := NewProducer(q, WithQueue("critical"))
+
+	task, err := producer.Enqueue(ctx, "send_email", nil)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, "critical", task.Queue)
+
+	delivery, err := q.Receive(ctx, "critical")
+	require.NoError(t, err)
+	require.NotNil(t, delivery)
+	assert.Equal(t, "critical", delivery.Task().Queue)
+}
+
+func TestProducer_EnqueueQueueOverridesProducerQueue(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	q := newTestQueue()
+	producer := NewProducer(q, WithQueue("critical"))
+
+	task, err := producer.Enqueue(ctx, "send_email", nil, WithQueue("bulk"))
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, "bulk", task.Queue)
+
+	delivery, err := q.Receive(ctx, "bulk")
+	require.NoError(t, err)
+	require.NotNil(t, delivery)
+	assert.Equal(t, "bulk", delivery.Task().Queue)
+}
+
 func TestProducer_OptionsIgnoreEmptyOrInvalidValues(t *testing.T) {
 	t.Parallel()
 
-	task, err := NewProducer(newTestQueue()).Enqueue(
+	task, err := NewProducer(newTestQueue(), WithQueue("")).Enqueue(
 		t.Context(),
 		"send_email",
 		nil,

--- a/queue/producer_test.go
+++ b/queue/producer_test.go
@@ -127,6 +127,36 @@ func TestProducer_EnqueueQueueOverridesProducerQueue(t *testing.T) {
 	assert.Equal(t, "bulk", delivery.Task().Queue)
 }
 
+func TestProducer_WithMetadataSetsDefaultMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	q := newTestQueue()
+	metadata := map[string]string{
+		"source": "api",
+		"tenant": "default",
+	}
+	producer := NewProducer(q, WithMetadata(metadata))
+	metadata["source"] = "mutated"
+
+	task, err := producer.Enqueue(ctx, "send_email", nil, WithMetadata(map[string]string{
+		"tenant": "acme",
+		"trace":  "1",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, map[string]string{
+		"source": "api",
+		"tenant": "acme",
+		"trace":  "1",
+	}, task.Metadata)
+
+	delivery, err := q.Receive(ctx, DefaultQueue)
+	require.NoError(t, err)
+	require.NotNil(t, delivery)
+	assert.Equal(t, task.Metadata, delivery.Task().Metadata)
+}
+
 func TestProducer_OptionsIgnoreEmptyOrInvalidValues(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Add producer-level defaults for queue names and metadata so repeated enqueue calls can share common configuration while still allowing per-task overrides.

## Changes
- Allow `WithQueue` to configure a producer default queue in addition to enqueue and worker usage
- Allow `WithMetadata` to configure producer default metadata and per-enqueue metadata overrides
- Keep shared option implementations grouped in `queue/option.go`
- Add producer tests for default queue selection, queue overrides, metadata copying, and metadata overrides

## Motivation
- Reduces repeated per-task options when a producer consistently targets the same queue or attaches common metadata

## Testing
- `go test -count=1 ./...` in the queue module
- `make lint/./queue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Producers now support configurable default queue names and metadata that apply to all enqueued tasks
  * Queue selection can be overridden on a per-task basis
  * Observer configuration options reorganized

* **Refactor**
  * Metadata API simplified: single key-value pair operations replace bulk metadata map updates for better control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->