### PR TITLE
feat(slices): restore Contains helper

### DIFF
--- a/slices/README.md
+++ b/slices/README.md
@@ -40,7 +40,7 @@ func main() {
 - `Unique`, `UniqueBy`, and `UniqueByN` remove duplicate items.
 - `Difference`, `Intersect`, `Only`, `Without`, and `Remove` provide set-like helpers.
 - `Chunk`, `GroupBy`, `GroupByN`, `CountBy`, and `CountByN` split, group, or count items.
-- `First`, `Last`, `Find`, `FindN`, `FindLast`, and `FindLastN` locate items.
+- `First`, `Last`, `Contains`, `Find`, `FindN`, `FindLast`, and `FindLastN` locate items.
 - `Index`, `IndexN`, `LastIndex`, and `LastIndexN` locate item indexes by predicate.
 - `IndexOf` and `LastIndexOf` locate comparable items.
 - `Fill`, `Random`, `Shuffle`, `Min`, `Max`, `Sum`, and `Length` provide utility operations.

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -258,6 +258,15 @@ func IsNotEmpty[S ~[]E, E any](s S) bool {
 	return len(s) > 0
 }
 
+// Contains reports whether e is present in s.
+// Contains is an alias for the standard library [slices.Contains].
+//
+//	Contains([]int{1, 2, 3}, 2) // true
+//	Contains([]string{"a", "b", "c"}, "d") // false
+func Contains[S ~[]E, E comparable](s S, e E) bool {
+	return slices.Contains(s, e)
+}
+
 // IndexOf returns the index of the first occurrence of e in s, or -1 if e is
 // not present.
 //

--- a/slices/slices_test.go
+++ b/slices/slices_test.go
@@ -282,6 +282,20 @@ func TestIsEmptyAndIsNotEmpty(t *testing.T) {
 	assert.False(t, IsNotEmpty(s6))
 }
 
+func TestContains(t *testing.T) {
+	s1 := []int{1, 2, 3}
+	assert.True(t, Contains(s1, 1))
+	assert.False(t, Contains(s1, 4))
+
+	s2 := []string{"1", "2", "3"}
+	assert.True(t, Contains(s2, "1"))
+	assert.False(t, Contains(s2, "4"))
+
+	s3 := []T{{"1"}, {"2"}, {"3"}}
+	assert.True(t, Contains(s3, T{"1"}))
+	assert.False(t, Contains(s3, T{"4"}))
+}
+
 func TestIndexOf(t *testing.T) {
 	s1 := []int{1, 2, 3}
 	assert.Equal(t, 0, IndexOf(s1, 1))


### PR DESCRIPTION
## Summary
Restore the slices Contains helper as a compatibility API while delegating membership checks to the Go standard library.

## Changes
- Add Contains to the slices package as an alias-style wrapper around the standard library slices.Contains
- Reintroduce tests for Contains across comparable value types
- Document Contains in the slices README helper list

## Motivation
- Keep existing github.com/go-fries/fries/slices/v3 callers working without reintroducing custom membership logic

## Testing
- GOCACHE=<writable-cache> make test/slices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Contains` helper for checking element presence in slices.

* **Documentation**
  * Updated helper documentation to reorganize reference placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->