### PR TITLE
chore(ci): run workflows on 4.x

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -3,10 +3,10 @@ name: Go Static Analysis
 on:
   push:
     branches:
-      - 3.x
+      - 4.x
   pull_request:
     branches:
-      - 3.x
+      - 4.x
 
 jobs:
   golangci:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Go Lint
 on:
   push:
     branches:
-      - 3.x
+      - 4.x
   pull_request:
     branches:
-      - 3.x
+      - 4.x
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Go Test
 on:
   push:
     branches:
-      - 3.x
+      - 4.x
   pull_request:
     branches:
-      - 3.x
+      - 4.x
 env:
   GOPROXY: "https://proxy.golang.org"
 


### PR DESCRIPTION
## Summary
Enable the existing CI workflows on the long-lived `4.x` branch.

## Changes
- Point test workflow push and pull request triggers at `4.x`
- Point lint workflow push and pull request triggers at `4.x`
- Point static analysis workflow push and pull request triggers at `4.x`

## Motivation
- `4.x` is the future v4 development branch and needs its own CI coverage while `3.x` remains the default branch
- The `3.x` branch keeps its own workflow configuration, so this branch only needs `4.x` triggers

## Testing
- `git diff --check`