### PR TITLE
chore(docs): update v4 module documentation

### DIFF
--- a/.docs/memories/project-context.md
+++ b/.docs/memories/project-context.md
@@ -4,8 +4,8 @@
 
 - Repository: `go-fries/fries`.
 - Project type: multi-module Go repository.
-- Root module: `github.com/go-fries/fries/v3`.
-- Default local branch observed: `3.x`.
+- Root module on the v4 branch: `github.com/go-fries/fries/v4`.
+- Default repository branch observed: `3.x`.
 - Root Go version in `go.mod`: `1.25.0`.
 
 ## Module Layout

--- a/.docs/memories/project-context.md
+++ b/.docs/memories/project-context.md
@@ -5,7 +5,7 @@
 - Repository: `go-fries/fries`.
 - Project type: multi-module Go repository.
 - Root module on the v4 branch: `github.com/go-fries/fries/v4`.
-- Default repository branch observed: `3.x`.
+- Default repository branch observed: `4.x`.
 - Root Go version in `go.mod`: `1.25.0`.
 
 ## Module Layout

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,18 +81,18 @@ This is a multi-module repository with the following organization:
 
 **Manual Testing Scenarios:**
 - Build and run example applications in `examples/` directory: `cd examples/cache && go build .` (builds successfully, requires Redis to run)
-- Test that imports work with module functionality: Create a simple test program importing key modules like `strings/v3` and `support/v3`
+- Test that imports work with module functionality: Create a simple test program importing key modules like `strings/v4` and `support/v4`
 - Validate module interfaces haven't broken by spot-checking key modules like `support`, `strings`, `errors`
-- Run example test: `cd /tmp && mkdir test_app && cd test_app && go mod init test && echo 'package main; import "github.com/go-fries/fries/strings/v3"; func main() { println(strings.MD5("test")) }' > main.go` then `go mod tidy && go run main.go`
+- Run example test: `cd /tmp && mkdir test_app && cd test_app && go mod init test && echo 'package main; import "github.com/go-fries/fries/strings/v4"; func main() { println(strings.MD5("test")) }' > main.go` then `go mod tidy && go run main.go`
 
 ## Module Development Patterns
 
 This repository follows Go module best practices:
 
 - Each directory with `go.mod` is an independent module
-- Modules are versioned as `v3` (breaking change from v2)  
-- Cross-module dependencies use full import paths: `github.com/go-fries/fries/<module>/v3`
-- All modules maintain backward compatibility within v3
+- Modules are versioned as `v4` (breaking change from v3)
+- Cross-module dependencies use full import paths: `github.com/go-fries/fries/<module>/v4`
+- All modules maintain backward compatibility within v4
 
 ## Common Issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `foundation/`, `event/`, `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`. Runnable samples and integration demos are under `examples/`. Protobuf contracts live in `contract/`, with root Buf configuration in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
+This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v4` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `foundation/`, `event/`, `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`. Runnable samples and integration demos are under `examples/`. Protobuf contracts live in `contract/`, with root Buf configuration in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
 
 Project working notes live under `.docs/`. Use `.docs/plans/` for task plans, phased checklists, and execution notes that coordinate longer work. The `.docs/plans/` directory is tracked, but individual plan files are local-only and should stay ignored. Use `.docs/memories/` for reusable project context that should survive across long-running tasks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,12 @@ The goal is to keep components consistent, maintainable, and predictable for bot
 
 ## Module Layout
 
-This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v3`, and many component directories have their own `go.mod` files.
+This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v4`, and many component directories have their own `go.mod` files.
 
 Keep module boundaries explicit:
 
 - update the nearest `go.mod` for the module being changed
-- keep module paths in `go.mod` suffixed with `/v3`
+- keep module paths in `go.mod` suffixed with `/v4`
 - avoid unnecessary dependencies across components
 - keep framework integrations under the framework or component they adapt
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.25.0-blue)
 [![Package Version](https://badgen.net/github/release/go-fries/fries/stable)](https://github.com/go-fries/fries/releases)
-[![GoDoc](https://pkg.go.dev/badge/github.com/go-fries/fries/v3)](https://pkg.go.dev/github.com/go-fries/fries/v3)
+[![GoDoc](https://pkg.go.dev/badge/github.com/go-fries/fries/v4)](https://pkg.go.dev/github.com/go-fries/fries/v4)
 [![codecov](https://codecov.io/gh/go-fries/fries/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/go-fries/fries)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-fries/fries)](https://goreportcard.com/report/github.com/go-fries/fries)
 [![lint](https://github.com/go-fries/fries/actions/workflows/lint.yml/badge.svg)](https://github.com/go-fries/fries/actions/workflows/lint.yml)
@@ -12,13 +12,13 @@
 > This repository has been migrated from the original `github.com/go-kratos-ecosystem/components`.
 
 > [!IMPORTANT]
-> The v3 may have cases of non-backward compatibility, please use with caution.  
-> Backward compatibility is the default behavior, and any incompatibilities will be noted in the release.
+> The v4 line may include breaking changes compared with v3, please use with caution.
+> Backward compatibility is the default behavior within v4, and any incompatibilities will be noted in the release.
 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/v3
+go get github.com/go-fries/fries/v4
 ```
 
 ## Contributing

--- a/cache/README.md
+++ b/cache/README.md
@@ -5,7 +5,7 @@ A flexible caching library for Go applications, providing a unified API for vari
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/cache/v3
+go get github.com/go-fries/fries/cache/v4
 ```
 
 ## Features
@@ -27,8 +27,8 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
-	redisStore "github.com/go-fries/fries/cache/redis/v3"
-	"github.com/go-fries/fries/cache/v3"
+	redisStore "github.com/go-fries/fries/cache/redis/v4"
+	"github.com/go-fries/fries/cache/v4"
 )
 
 var ctx = context.Background()

--- a/chi/README.md
+++ b/chi/README.md
@@ -13,7 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-kratos/kratos/v2"
 
-	chis "github.com/go-fries/fries/chi/v3"
+	chis "github.com/go-fries/fries/chi/v4"
 )
 
 func main() {

--- a/cloudevents/eventdispatcher/README.md
+++ b/cloudevents/eventdispatcher/README.md
@@ -10,7 +10,7 @@ import (
 	"log"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-fries/fries/cloudevents/eventdispatcher/v3"
+	"github.com/go-fries/fries/cloudevents/eventdispatcher/v4"
 )
 
 type ExampleEvent struct {

--- a/cloudevents/protocol/amqp091/README.md
+++ b/cloudevents/protocol/amqp091/README.md
@@ -14,7 +14,7 @@ This component implements the AMQP 0.9.1 protocol binding for CloudEvents.
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/cloudevents/protocol/amqp091/v3
+go get github.com/go-fries/fries/cloudevents/protocol/amqp091/v4
 ```
 
 ## Usage
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
-	"github.com/go-fries/fries/cloudevents/protocol/amqp091/v3"
+	"github.com/go-fries/fries/cloudevents/protocol/amqp091/v4"
 	"github.com/google/uuid"
 	amqp "github.com/rabbitmq/amqp091-go"
 )

--- a/codec/README.md
+++ b/codec/README.md
@@ -5,9 +5,9 @@ Unified interface for encoding and decoding data, with support for multiple form
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/codec/v3
+go get github.com/go-fries/fries/codec/v4
 # Install specific codecs as needed, e.g.:
-go get github.com/go-fries/fries/codec/json/v3
+go get github.com/go-fries/fries/codec/json/v4
 ```
 
 ## Usage
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/go-fries/fries/codec/json/v3"
+	"github.com/go-fries/fries/codec/json/v4"
 )
 
 var j = json.Codec

--- a/config/README.md
+++ b/config/README.md
@@ -5,7 +5,7 @@ A simple, type-safe utility for propagating configuration values through `contex
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/config/v3
+go get github.com/go-fries/fries/config/v4
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-fries/fries/config/v3"
+	"github.com/go-fries/fries/config/v4"
 )
 
 type AppConfig struct {

--- a/crontab/README.md
+++ b/crontab/README.md
@@ -10,7 +10,7 @@ locations, middleware, and loggers on `*cron.Cron`, then pass that scheduler to
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/crontab/v3
+go get github.com/go-fries/fries/crontab/v4
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ import (
 	"context"
 
 	"github.com/flc1125/go-cron/v4"
-	"github.com/go-fries/fries/crontab/v3"
+	"github.com/go-fries/fries/crontab/v4"
 	"github.com/go-kratos/kratos/v2"
 )
 

--- a/eino/components/embedding/cached/README.md
+++ b/eino/components/embedding/cached/README.md
@@ -10,7 +10,7 @@ This module provides a cache embedder for Eino, which is designed to store and r
 ## Installation
 
 ```shell
-go get github.com/go-fries/fries/eino/components/embedding/cached/v3
+go get github.com/go-fries/fries/eino/components/embedding/cached/v4
 ```
 
 ## Usage
@@ -25,8 +25,8 @@ import (
 	"log"
 
 	"github.com/cloudwego/eino/components/embedding"
-	cachedredis "github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v3"
-	"github.com/go-fries/fries/eino/components/embedding/cached/v3"
+	cachedredis "github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4"
+	"github.com/go-fries/fries/eino/components/embedding/cached/v4"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/env/README.md
+++ b/env/README.md
@@ -5,7 +5,7 @@ Simple utilities for managing application runtime environments (Dev, Prod, Debug
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/env/v3
+go get github.com/go-fries/fries/env/v4
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/go-fries/fries/env/v3"
+	"github.com/go-fries/fries/env/v4"
 )
 
 func main() {

--- a/errors/README.md
+++ b/errors/README.md
@@ -5,7 +5,7 @@ Helper functions for creating and handling Kratos errors with standard HTTP stat
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/errors/v3
+go get github.com/go-fries/fries/errors/v4
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/go-fries/fries/errors/v3"
+	"github.com/go-fries/fries/errors/v4"
 )
 
 func main() {

--- a/event/README.md
+++ b/event/README.md
@@ -5,7 +5,7 @@ A strongly-typed event dispatcher with middleware support, allowing you to decou
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/event/v3
+go get github.com/go-fries/fries/event/v4
 ```
 
 ## Usage
@@ -17,8 +17,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-fries/fries/event/middleware/recovery/v3"
-	"github.com/go-fries/fries/event/v3"
+	"github.com/go-fries/fries/event/middleware/recovery/v4"
+	"github.com/go-fries/fries/event/v4"
 )
 
 type UserEvent struct {

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -5,7 +5,7 @@ A unified filesystem abstraction layer for Go, supporting Local, S3, and OSS sto
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/filesystem/v3
+go get github.com/go-fries/fries/filesystem/v4
 ```
 
 ## Usage
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/go-fries/fries/filesystem/local/v3"
-	"github.com/go-fries/fries/filesystem/v3"
+	"github.com/go-fries/fries/filesystem/local/v4"
+	"github.com/go-fries/fries/filesystem/v4"
 )
 
 func main() {

--- a/foundation/README.md
+++ b/foundation/README.md
@@ -5,7 +5,7 @@ The core kernel of the Fries framework, responsible for managing the application
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/foundation/v3
+go get github.com/go-fries/fries/foundation/v4
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/go-fries/fries/foundation/v3"
+	"github.com/go-fries/fries/foundation/v4"
 )
 
 // ExampleProvider implements the foundation.Provider interface

--- a/gorm/logger/multi/README.md
+++ b/gorm/logger/multi/README.md
@@ -6,7 +6,7 @@ This package provides a GORM logger that dispatches each log call to multiple
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/gorm/logger/multi/v3
+go get github.com/go-fries/fries/gorm/logger/multi/v4
 ```
 
 ## Usage
@@ -15,8 +15,8 @@ go get github.com/go-fries/fries/gorm/logger/multi/v3
 package main
 
 import (
-	"github.com/go-fries/fries/gorm/logger/multi/v3"
-	"github.com/go-fries/fries/gorm/logger/otel/v3"
+	"github.com/go-fries/fries/gorm/logger/multi/v4"
+	"github.com/go-fries/fries/gorm/logger/otel/v4"
 	"go.opentelemetry.io/otel/log/global"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/gorm/logger/otel/README.md
+++ b/gorm/logger/otel/README.md
@@ -5,7 +5,7 @@ This package provides a GORM logger implementation backed by the [OpenTelemetry 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/gorm/logger/otel/v3
+go get github.com/go-fries/fries/gorm/logger/otel/v4
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-fries/fries/gorm/logger/otel/v3"
+	"github.com/go-fries/fries/gorm/logger/otel/v4"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/global"

--- a/gorm/scope/README.md
+++ b/gorm/scope/README.md
@@ -8,7 +8,7 @@ package scope_test
 import (
 	"time"
 
-	"github.com/go-fries/fries/gorm/scope/v3"
+	"github.com/go-fries/fries/gorm/scope/v4"
 	"gorm.io/gorm"
 )
 

--- a/hyperf/jet/README.md
+++ b/hyperf/jet/README.md
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/go-fries/fries/hyperf/jet/v3"
+	"github.com/go-fries/fries/hyperf/jet/v4"
 )
 
 func main() {

--- a/hyperf/jet/middleware/otel/README.md
+++ b/hyperf/jet/middleware/otel/README.md
@@ -18,8 +18,8 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/hyperf/jet/middleware/otel/v3"
-	"github.com/go-fries/fries/hyperf/jet/v3"
+	"github.com/go-fries/fries/hyperf/jet/middleware/otel/v4"
+	"github.com/go-fries/fries/hyperf/jet/v4"
 	"go.opentelemetry.io/otel/attribute"
 )
 

--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -5,7 +5,7 @@ A lightweight JSON-RPC 2.0 client implementation in Go.
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/jsonrpc/v3
+go get github.com/go-fries/fries/jsonrpc/v4
 ```
 
 ## Quick Start
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-fries/fries/jsonrpc/v3"
+	"github.com/go-fries/fries/jsonrpc/v4"
 )
 
 func Logger() jsonrpc.Middleware {

--- a/kratos/log/multi/README.md
+++ b/kratos/log/multi/README.md
@@ -6,7 +6,7 @@ This package provides a Kratos logger that dispatches each log call to multiple
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/kratos/log/multi/v3
+go get github.com/go-fries/fries/kratos/log/multi/v4
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ package main
 import (
 	"os"
 
-	"github.com/go-fries/fries/kratos/log/multi/v3"
+	"github.com/go-fries/fries/kratos/log/multi/v4"
 	"github.com/go-kratos/kratos/v2/log"
 )
 

--- a/kratos/log/otel/README.md
+++ b/kratos/log/otel/README.md
@@ -5,7 +5,7 @@ This package provides a Kratos `log.Logger` implementation backed by the OpenTel
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/kratos/log/otel/v3
+go get github.com/go-fries/fries/kratos/log/otel/v4
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ package main
 
 import (
 	kratoslog "github.com/go-kratos/kratos/v2/log"
-	otelkratos "github.com/go-fries/fries/kratos/log/otel/v3"
+	otelkratos "github.com/go-fries/fries/kratos/log/otel/v4"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log/global"
 )
@@ -49,5 +49,5 @@ OpenTelemetry span from the log context.
 The instrumentation scope name is fixed to the module import path:
 
 ```text
-github.com/go-fries/fries/kratos/log/otel/v3
+github.com/go-fries/fries/kratos/log/otel/v4
 ```

--- a/kratos/middleware/otel/README.md
+++ b/kratos/middleware/otel/README.md
@@ -7,7 +7,7 @@ The package is forked from [tracing](https://github.com/go-kratos/kratos/tree/8b
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/kratos/middleware/otel/v3
+go get github.com/go-fries/fries/kratos/middleware/otel/v4
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ import (
 	"github.com/go-kratos/kratos/v2"
 	"github.com/go-kratos/kratos/v2/transport/http"
 
-	kratosotel "github.com/go-fries/fries/kratos/middleware/otel/v3"
+	kratosotel "github.com/go-fries/fries/kratos/middleware/otel/v4"
 )
 
 func main() {

--- a/mysql/canal/README.md
+++ b/mysql/canal/README.md
@@ -5,7 +5,7 @@ A lightweight and easy-to-use Go library to capture and process MySQL binlog eve
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/mysql/canal/v3
+go get github.com/go-fries/fries/mysql/canal/v4
 ```
 
 ## Usage
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"time"
 
-	positionerredis "github.com/go-fries/fries/mysql/canal/positioner/redis/v3"
-	"github.com/go-fries/fries/mysql/canal/v3"
+	positionerredis "github.com/go-fries/fries/mysql/canal/positioner/redis/v4"
+	"github.com/go-fries/fries/mysql/canal/v4"
 )
 
 type Listener struct {

--- a/otel/otlp/README.md
+++ b/otel/otlp/README.md
@@ -5,7 +5,7 @@ This package provides a configuration for the OpenTelemetry Protocol (OTLP) expo
 ## Installation
 
 ```shell
-go get github.com/go-fries/fries/otel/otlp/v3
+go get github.com/go-fries/fries/otel/otlp/v4
 ```
 
 ## Defaults
@@ -25,7 +25,7 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/otel/otlp/v3"
+	"github.com/go-fries/fries/otel/otlp/v4"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -70,7 +70,7 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/otel/otlp/v3"
+	"github.com/go-fries/fries/otel/otlp/v4"
 )
 
 func main() {
@@ -122,7 +122,7 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/otel/otlp/v3"
+	"github.com/go-fries/fries/otel/otlp/v4"
 )
 
 func main() {

--- a/queue/README.md
+++ b/queue/README.md
@@ -9,15 +9,15 @@ as Redis, RabbitMQ, and memory.
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/queue/v3
+go get github.com/go-fries/fries/queue/v4
 ```
 
 Install the adapter you use as well:
 
 ```bash
-go get github.com/go-fries/fries/queue/adapter/redis/v3
-go get github.com/go-fries/fries/queue/adapter/rabbitmq/v3
-go get github.com/go-fries/fries/queue/adapter/memory/v3
+go get github.com/go-fries/fries/queue/adapter/redis/v4
+go get github.com/go-fries/fries/queue/adapter/rabbitmq/v4
+go get github.com/go-fries/fries/queue/adapter/memory/v4
 ```
 
 ## Basic Usage
@@ -28,8 +28,8 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/queue/adapter/memory/v3"
-	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/adapter/memory/v4"
+	"github.com/go-fries/fries/queue/v4"
 )
 
 func run(ctx context.Context) error {
@@ -67,7 +67,7 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/v4"
 )
 
 type SendEmail struct {
@@ -116,7 +116,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/v4"
 )
 
 func syncUserHandler(rateLimited, invalidPayload, alreadyHandled bool) queue.Handler {
@@ -162,7 +162,7 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/v4"
 )
 
 func withObserver(q queue.Queue, handler queue.Handler) (*queue.Producer, *queue.Worker) {

--- a/queue/adapter/memory/README.md
+++ b/queue/adapter/memory/README.md
@@ -1,11 +1,11 @@
 # Memory Queue
 
-In-memory adapter for `github.com/go-fries/fries/queue/v3`.
+In-memory adapter for `github.com/go-fries/fries/queue/v4`.
 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/queue/adapter/memory/v3
+go get github.com/go-fries/fries/queue/adapter/memory/v4
 ```
 
 ## Usage
@@ -16,8 +16,8 @@ package main
 import (
 	"context"
 
-	"github.com/go-fries/fries/queue/adapter/memory/v3"
-	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/adapter/memory/v4"
+	"github.com/go-fries/fries/queue/v4"
 )
 
 func enqueue(ctx context.Context) error {

--- a/queue/adapter/rabbitmq/README.md
+++ b/queue/adapter/rabbitmq/README.md
@@ -1,11 +1,11 @@
 # RabbitMQ Queue
 
-RabbitMQ AMQP 0.9.1 adapter for `github.com/go-fries/fries/queue/v3`.
+RabbitMQ AMQP 0.9.1 adapter for `github.com/go-fries/fries/queue/v4`.
 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/queue/adapter/rabbitmq/v3
+go get github.com/go-fries/fries/queue/adapter/rabbitmq/v4
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ go get github.com/go-fries/fries/queue/adapter/rabbitmq/v3
 package main
 
 import (
-	rabbitmq "github.com/go-fries/fries/queue/adapter/rabbitmq/v3"
+	rabbitmq "github.com/go-fries/fries/queue/adapter/rabbitmq/v4"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 

--- a/queue/adapter/redis/README.md
+++ b/queue/adapter/redis/README.md
@@ -1,11 +1,11 @@
 # Redis Queue
 
-Redis Streams adapter for `github.com/go-fries/fries/queue/v3`.
+Redis Streams adapter for `github.com/go-fries/fries/queue/v4`.
 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/queue/adapter/redis/v3
+go get github.com/go-fries/fries/queue/adapter/redis/v4
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ package main
 import (
 	"time"
 
-	redis "github.com/go-fries/fries/queue/adapter/redis/v3"
+	redis "github.com/go-fries/fries/queue/adapter/redis/v4"
 	goredis "github.com/redis/go-redis/v9"
 )
 

--- a/queue/examples/tasker/README.md
+++ b/queue/examples/tasker/README.md
@@ -1,6 +1,6 @@
 # Queue Tasker Example
 
-Typed tasker example for `github.com/go-fries/fries/queue/v3`.
+Typed tasker example for `github.com/go-fries/fries/queue/v4`.
 
 ```bash
 go run .

--- a/queue/kratos/server/README.md
+++ b/queue/kratos/server/README.md
@@ -1,11 +1,11 @@
 # Queue Kratos Server
 
-Kratos server adapter for `github.com/go-fries/fries/queue/v3` workers.
+Kratos server adapter for `github.com/go-fries/fries/queue/v4` workers.
 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/queue/kratos/server/v3
+go get github.com/go-fries/fries/queue/kratos/server/v4
 ```
 
 ## Usage
@@ -14,8 +14,8 @@ go get github.com/go-fries/fries/queue/kratos/server/v3
 package main
 
 import (
-	server "github.com/go-fries/fries/queue/kratos/server/v3"
-	"github.com/go-fries/fries/queue/v3"
+	server "github.com/go-fries/fries/queue/kratos/server/v4"
+	"github.com/go-fries/fries/queue/v4"
 	"github.com/go-kratos/kratos/v2"
 )
 

--- a/queue/middleware/recovery/README.md
+++ b/queue/middleware/recovery/README.md
@@ -1,11 +1,11 @@
 # Queue Recovery Middleware
 
-Panic recovery middleware for `github.com/go-fries/fries/queue/v3`.
+Panic recovery middleware for `github.com/go-fries/fries/queue/v4`.
 
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/queue/middleware/recovery/v3
+go get github.com/go-fries/fries/queue/middleware/recovery/v4
 ```
 
 ## Usage
@@ -14,8 +14,8 @@ go get github.com/go-fries/fries/queue/middleware/recovery/v3
 package main
 
 import (
-	"github.com/go-fries/fries/queue/middleware/recovery/v3"
-	"github.com/go-fries/fries/queue/v3"
+	"github.com/go-fries/fries/queue/middleware/recovery/v4"
+	"github.com/go-fries/fries/queue/v4"
 )
 
 func newWorker(q queue.Queue, handler queue.Handler) *queue.Worker {

--- a/signal/README.md
+++ b/signal/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/signal/v3
+go get github.com/go-fries/fries/signal/v4
 ```
 
 ## Example
@@ -18,7 +18,7 @@ import (
 
 	"github.com/go-kratos/kratos/v2"
 
-	"github.com/go-fries/fries/signal/v3"
+	"github.com/go-fries/fries/signal/v4"
 )
 
 func main() {

--- a/slices/README.md
+++ b/slices/README.md
@@ -6,7 +6,7 @@ code.
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/slices/v3
+go get github.com/go-fries/fries/slices/v4
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/go-fries/fries/slices/v3"
+	"github.com/go-fries/fries/slices/v4"
 )
 
 func main() {

--- a/strings/README.md
+++ b/strings/README.md
@@ -5,7 +5,7 @@ This package provides string helper functions for common application code.
 ## Installation
 
 ```bash
-go get github.com/go-fries/fries/strings/v3
+go get github.com/go-fries/fries/strings/v4
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/go-fries/fries/strings/v3"
+	"github.com/go-fries/fries/strings/v4"
 )
 
 func main() {

--- a/support/coordinator/README.md
+++ b/support/coordinator/README.md
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/go-fries/fries/support/v3/coordinator"
+	"github.com/go-fries/fries/support/v4/coordinator"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
Update repository documentation for the v4 module path across the root docs, contribution guidance, internal agent guidance, and component README examples.

## Changes
- Update root README badges, install command, and v4 compatibility wording
- Update CONTRIBUTING, AGENTS, Copilot instructions, and project context wording for the v4 branch
- Replace component README install and import examples from /v3 to /v4

## Motivation
- Keep documentation aligned with the 4.x branch before runtime and API work continues

## Testing
- git diff --check
- rg -n "github.com/go-fries/fries/.*/v3|github.com/go-fries/fries/v3" --glob "*.md" --glob "!go.sum"
- GOCACHE=/private/tmp/go-fries-gocache GOMODCACHE=/private/tmp/go-fries-gomodcache GOLANGCI_LINT_CACHE=/private/tmp/go-fries-lint-cache make build