### PR TITLE
chore(proto): document internal buf lint ignores

### DIFF
--- a/codec/proto/internal/proto/test.proto
+++ b/codec/proto/internal/proto/test.proto
@@ -1,5 +1,8 @@
 syntax = "proto3";
 
+// Internal test proto kept inside the component package.
+// buf:lint:ignore PACKAGE_DIRECTORY_MATCH
+// buf:lint:ignore PACKAGE_VERSION_SUFFIX
 package proto;
 
 option go_package = "github.com/go-fries/fries/codec/proto/v4/internal/proto";

--- a/kratos/middleware/otel/internal/proto/tracing/v1/hello.proto
+++ b/kratos/middleware/otel/internal/proto/tracing/v1/hello.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+// Internal test proto kept inside the component package.
+// buf:lint:ignore PACKAGE_DIRECTORY_MATCH
 package tracing.v1;
 
 option go_package = "tracing/v1;tracingpb";

--- a/kratos/middleware/protovalidate/internal/proto/protovalidate/v1/person.proto
+++ b/kratos/middleware/protovalidate/internal/proto/protovalidate/v1/person.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+// Internal test proto kept inside the component package.
+// buf:lint:ignore PACKAGE_DIRECTORY_MATCH
 package protovalidate.v1;
 
 import "buf/validate/validate.proto";


### PR DESCRIPTION
## Summary
Document local Buf lint ignores on internal test proto files so repository-wide `make buf-lint` can pass without relaxing the global Buf configuration.

## Changes
- Add `buf:lint:ignore PACKAGE_DIRECTORY_MATCH` comments to internal component test protos
- Add `buf:lint:ignore PACKAGE_VERSION_SUFFIX` for the unversioned codec test proto package
- Keep `buf.yaml` unchanged so public proto lint rules remain strict

## Motivation
- Stage 7 readiness checks found that internal test protos intentionally live inside component packages instead of public proto package directories

## Testing
- `BUF_CACHE_DIR=/private/tmp/go-fries-buf-cache make buf-lint`
- `BUF_CACHE_DIR=/private/tmp/go-fries-buf-cache make buf-build`
- `git diff --check`