### PR TITLE
feat(log): add slog multi handler

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -69,6 +69,7 @@ fixes:
   - github.com/go-fries/fries/hyperf/jet/middleware/retry/v4::hyperf/jet/middleware/retry/
   - github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4::hyperf/jet/middleware/timeout/
   - github.com/go-fries/fries/hyperf/jet/middleware/otel/v4::hyperf/jet/middleware/otel/
+  - github.com/go-fries/fries/log/slog/multi/v4::log/slog/multi/
   - github.com/go-fries/fries/kratos/log/multi/v4::kratos/log/multi/
   - github.com/go-fries/fries/kratos/log/otel/v4::kratos/log/otel/
   - github.com/go-fries/fries/kratos/log/syslog/v4::kratos/log/syslog/

--- a/log/slog/multi/README.md
+++ b/log/slog/multi/README.md
@@ -1,0 +1,37 @@
+# slog multi handler
+
+`log/slog/multi` provides a `slog.Handler` that fans out each enabled log record
+to multiple child handlers.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/log/slog/multi/v4
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	slogmulti "github.com/go-fries/fries/log/slog/multi/v4"
+)
+
+func main() {
+	handler := slogmulti.NewHandler(
+		slog.NewTextHandler(os.Stdout, nil),
+		slog.NewJSONHandler(os.Stderr, nil),
+	)
+
+	logger := slog.New(handler)
+	logger.Info("service started", slog.String("service", "api"))
+}
+```
+
+Nil handlers are ignored. A record is handled by each child handler that is
+enabled for the record level. When multiple child handlers return errors, the
+errors are combined with `errors.Join`.

--- a/log/slog/multi/doc.go
+++ b/log/slog/multi/doc.go
@@ -1,0 +1,3 @@
+// Package multi provides a slog handler that dispatches records to multiple
+// child handlers.
+package multi

--- a/log/slog/multi/go.mod
+++ b/log/slog/multi/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/log/slog/multi/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/log/slog/multi/go.sum
+++ b/log/slog/multi/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log/slog/multi/handler.go
+++ b/log/slog/multi/handler.go
@@ -38,6 +38,17 @@ func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
 // Handle dispatches the record to every enabled child handler. Errors returned
 // by child handlers are combined with [errors.Join].
 func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	switch len(h.handlers) {
+	case 0:
+		return nil
+	case 1:
+		handler := h.handlers[0]
+		if !handler.Enabled(ctx, record.Level) {
+			return nil
+		}
+		return handler.Handle(ctx, record.Clone())
+	}
+
 	var errs []error
 	for _, handler := range h.handlers {
 		if !handler.Enabled(ctx, record.Level) {
@@ -53,11 +64,18 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 // WithAttrs returns a new handler whose child handlers include the provided
 // attributes.
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+
 	clone := &Handler{
 		handlers: make([]slog.Handler, 0, len(h.handlers)),
 	}
 	for _, handler := range h.handlers {
-		clone.handlers = append(clone.handlers, handler.WithAttrs(attrs))
+		next := handler.WithAttrs(attrs)
+		if next != nil {
+			clone.handlers = append(clone.handlers, next)
+		}
 	}
 	return clone
 }
@@ -65,11 +83,18 @@ func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 // WithGroup returns a new handler whose child handlers include the provided
 // group.
 func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+
 	clone := &Handler{
 		handlers: make([]slog.Handler, 0, len(h.handlers)),
 	}
 	for _, handler := range h.handlers {
-		clone.handlers = append(clone.handlers, handler.WithGroup(name))
+		next := handler.WithGroup(name)
+		if next != nil {
+			clone.handlers = append(clone.handlers, next)
+		}
 	}
 	return clone
 }

--- a/log/slog/multi/handler.go
+++ b/log/slog/multi/handler.go
@@ -1,0 +1,75 @@
+package multi
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+var _ slog.Handler = (*Handler)(nil)
+
+// Handler dispatches slog records to multiple child handlers.
+type Handler struct {
+	handlers []slog.Handler
+}
+
+// NewHandler creates a [Handler] that dispatches records to each supplied
+// handler. Nil handlers are ignored.
+func NewHandler(handlers ...slog.Handler) *Handler {
+	h := &Handler{}
+	for _, handler := range handlers {
+		if handler != nil {
+			h.handlers = append(h.handlers, handler)
+		}
+	}
+	return h
+}
+
+// Enabled reports whether any child handler is enabled for the provided level.
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, handler := range h.handlers {
+		if handler.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+// Handle dispatches the record to every enabled child handler. Errors returned
+// by child handlers are combined with [errors.Join].
+func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	var errs []error
+	for _, handler := range h.handlers {
+		if !handler.Enabled(ctx, record.Level) {
+			continue
+		}
+		if err := handler.Handle(ctx, record.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// WithAttrs returns a new handler whose child handlers include the provided
+// attributes.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := &Handler{
+		handlers: make([]slog.Handler, 0, len(h.handlers)),
+	}
+	for _, handler := range h.handlers {
+		clone.handlers = append(clone.handlers, handler.WithAttrs(attrs))
+	}
+	return clone
+}
+
+// WithGroup returns a new handler whose child handlers include the provided
+// group.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	clone := &Handler{
+		handlers: make([]slog.Handler, 0, len(h.handlers)),
+	}
+	for _, handler := range h.handlers {
+		clone.handlers = append(clone.handlers, handler.WithGroup(name))
+	}
+	return clone
+}

--- a/log/slog/multi/handler_test.go
+++ b/log/slog/multi/handler_test.go
@@ -67,6 +67,24 @@ func TestHandlerWithAttrsReturnsHandlerWithChildAttributes(t *testing.T) {
 	assert.Equal(t, []slog.Attr{slog.String("service", "api"), slog.Int("attempt", 2)}, (*child.records)[0].handlerAttrs)
 }
 
+func TestHandlerWithAttrsReturnsReceiverWhenAttrsEmpty(t *testing.T) {
+	handler := NewHandler(newRecordingHandler(true))
+
+	assert.Same(t, handler, handler.WithAttrs(nil))
+	assert.Same(t, handler, handler.WithAttrs([]slog.Attr{}))
+}
+
+func TestHandlerWithAttrsIgnoresNilDerivedChildHandlers(t *testing.T) {
+	handler := NewHandler(&nilDerivedHandler{}).WithAttrs([]slog.Attr{slog.String("service", "api")})
+
+	require.NotPanics(t, func() {
+		assert.False(t, handler.Enabled(t.Context(), slog.LevelInfo))
+	})
+	require.NotPanics(t, func() {
+		assert.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
+	})
+}
+
 func TestHandlerWithGroupReturnsHandlerWithChildGroup(t *testing.T) {
 	child := newRecordingHandler(true)
 	handler := NewHandler(child).WithGroup("queue")
@@ -75,6 +93,23 @@ func TestHandlerWithGroupReturnsHandlerWithChildGroup(t *testing.T) {
 
 	require.Len(t, *child.records, 1)
 	assert.Equal(t, []string{"queue"}, (*child.records)[0].groups)
+}
+
+func TestHandlerWithGroupReturnsReceiverWhenNameEmpty(t *testing.T) {
+	handler := NewHandler(newRecordingHandler(true))
+
+	assert.Same(t, handler, handler.WithGroup(""))
+}
+
+func TestHandlerWithGroupIgnoresNilDerivedChildHandlers(t *testing.T) {
+	handler := NewHandler(&nilDerivedHandler{}).WithGroup("queue")
+
+	require.NotPanics(t, func() {
+		assert.False(t, handler.Enabled(t.Context(), slog.LevelInfo))
+	})
+	require.NotPanics(t, func() {
+		assert.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
+	})
 }
 
 func TestHandlerWithAttrsAndWithGroupDoNotMutateOriginalHandler(t *testing.T) {
@@ -141,6 +176,24 @@ func (h *recordingHandler) WithGroup(name string) slog.Handler {
 	clone := *h
 	clone.groups = append(slices.Clone(h.groups), name)
 	return &clone
+}
+
+type nilDerivedHandler struct{}
+
+func (h *nilDerivedHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *nilDerivedHandler) Handle(context.Context, slog.Record) error {
+	return nil
+}
+
+func (h *nilDerivedHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return nil
+}
+
+func (h *nilDerivedHandler) WithGroup(string) slog.Handler {
+	return nil
 }
 
 func timeNow() time.Time {

--- a/log/slog/multi/handler_test.go
+++ b/log/slog/multi/handler_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHandlerDispatchesEnabledRecordsToMultipleHandlers(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	first := newRecordingHandler(true)
 	second := newRecordingHandler(true)
 	disabled := newRecordingHandler(false)
@@ -35,7 +35,7 @@ func TestHandlerDispatchesEnabledRecordsToMultipleHandlers(t *testing.T) {
 func TestHandlerEnabledReturnsFalseWhenNoChildHandlerIsEnabled(t *testing.T) {
 	handler := NewHandler(nil, newRecordingHandler(false), newRecordingHandler(false))
 
-	assert.False(t, handler.Enabled(context.Background(), slog.LevelWarn))
+	assert.False(t, handler.Enabled(t.Context(), slog.LevelWarn))
 }
 
 func TestHandlerJoinsChildHandlerErrors(t *testing.T) {
@@ -47,7 +47,7 @@ func TestHandlerJoinsChildHandlerErrors(t *testing.T) {
 	second.err = secondErr
 	handler := NewHandler(first, second)
 
-	err := handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelError, "failed", 0))
+	err := handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelError, "failed", 0))
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, firstErr)
@@ -61,7 +61,7 @@ func TestHandlerWithAttrsReturnsHandlerWithChildAttributes(t *testing.T) {
 		slog.Int("attempt", 2),
 	})
 
-	require.NoError(t, handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
+	require.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
 
 	require.Len(t, *child.records, 1)
 	assert.Equal(t, []slog.Attr{slog.String("service", "api"), slog.Int("attempt", 2)}, (*child.records)[0].handlerAttrs)
@@ -71,7 +71,7 @@ func TestHandlerWithGroupReturnsHandlerWithChildGroup(t *testing.T) {
 	child := newRecordingHandler(true)
 	handler := NewHandler(child).WithGroup("queue")
 
-	require.NoError(t, handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
+	require.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
 
 	require.Len(t, *child.records, 1)
 	assert.Equal(t, []string{"queue"}, (*child.records)[0].groups)
@@ -82,8 +82,8 @@ func TestHandlerWithAttrsAndWithGroupDoNotMutateOriginalHandler(t *testing.T) {
 	handler := NewHandler(child)
 	derived := handler.WithAttrs([]slog.Attr{slog.String("component", "worker")}).WithGroup("job")
 
-	require.NoError(t, handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "base", 0)))
-	require.NoError(t, derived.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "derived", 0)))
+	require.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "base", 0)))
+	require.NoError(t, derived.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "derived", 0)))
 
 	require.Len(t, *child.records, 2)
 	assert.Empty(t, (*child.records)[0].handlerAttrs)

--- a/log/slog/multi/handler_test.go
+++ b/log/slog/multi/handler_test.go
@@ -1,0 +1,148 @@
+package multi
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerDispatchesEnabledRecordsToMultipleHandlers(t *testing.T) {
+	ctx := context.Background()
+	first := newRecordingHandler(true)
+	second := newRecordingHandler(true)
+	disabled := newRecordingHandler(false)
+	handler := NewHandler(first, nil, disabled, second)
+
+	record := slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)
+	record.AddAttrs(slog.String("request_id", "abc123"))
+
+	assert.True(t, handler.Enabled(ctx, slog.LevelInfo))
+	require.NoError(t, handler.Handle(ctx, record))
+
+	require.Len(t, *first.records, 1)
+	require.Len(t, *second.records, 1)
+	assert.Empty(t, *disabled.records)
+	assert.Equal(t, "hello", (*first.records)[0].message)
+	assert.Equal(t, []slog.Attr{slog.String("request_id", "abc123")}, (*first.records)[0].attrs)
+}
+
+func TestHandlerEnabledReturnsFalseWhenNoChildHandlerIsEnabled(t *testing.T) {
+	handler := NewHandler(nil, newRecordingHandler(false), newRecordingHandler(false))
+
+	assert.False(t, handler.Enabled(context.Background(), slog.LevelWarn))
+}
+
+func TestHandlerJoinsChildHandlerErrors(t *testing.T) {
+	firstErr := errors.New("first")
+	secondErr := errors.New("second")
+	first := newRecordingHandler(true)
+	first.err = firstErr
+	second := newRecordingHandler(true)
+	second.err = secondErr
+	handler := NewHandler(first, second)
+
+	err := handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelError, "failed", 0))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, firstErr)
+	assert.ErrorIs(t, err, secondErr)
+}
+
+func TestHandlerWithAttrsReturnsHandlerWithChildAttributes(t *testing.T) {
+	child := newRecordingHandler(true)
+	handler := NewHandler(child).WithAttrs([]slog.Attr{
+		slog.String("service", "api"),
+		slog.Int("attempt", 2),
+	})
+
+	require.NoError(t, handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
+
+	require.Len(t, *child.records, 1)
+	assert.Equal(t, []slog.Attr{slog.String("service", "api"), slog.Int("attempt", 2)}, (*child.records)[0].handlerAttrs)
+}
+
+func TestHandlerWithGroupReturnsHandlerWithChildGroup(t *testing.T) {
+	child := newRecordingHandler(true)
+	handler := NewHandler(child).WithGroup("queue")
+
+	require.NoError(t, handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "hello", 0)))
+
+	require.Len(t, *child.records, 1)
+	assert.Equal(t, []string{"queue"}, (*child.records)[0].groups)
+}
+
+func TestHandlerWithAttrsAndWithGroupDoNotMutateOriginalHandler(t *testing.T) {
+	child := newRecordingHandler(true)
+	handler := NewHandler(child)
+	derived := handler.WithAttrs([]slog.Attr{slog.String("component", "worker")}).WithGroup("job")
+
+	require.NoError(t, handler.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "base", 0)))
+	require.NoError(t, derived.Handle(context.Background(), slog.NewRecord(timeNow(), slog.LevelInfo, "derived", 0)))
+
+	require.Len(t, *child.records, 2)
+	assert.Empty(t, (*child.records)[0].handlerAttrs)
+	assert.Empty(t, (*child.records)[0].groups)
+	assert.Equal(t, []slog.Attr{slog.String("component", "worker")}, (*child.records)[1].handlerAttrs)
+	assert.Equal(t, []string{"job"}, (*child.records)[1].groups)
+}
+
+type recordedRecord struct {
+	message      string
+	attrs        []slog.Attr
+	handlerAttrs []slog.Attr
+	groups       []string
+}
+
+type recordingHandler struct {
+	enabled bool
+	err     error
+	attrs   []slog.Attr
+	groups  []string
+	records *[]recordedRecord
+}
+
+func newRecordingHandler(enabled bool) *recordingHandler {
+	records := make([]recordedRecord, 0)
+	return &recordingHandler{enabled: enabled, records: &records}
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool {
+	return h.enabled
+}
+
+func (h *recordingHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make([]slog.Attr, 0, record.NumAttrs())
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, attr)
+		return true
+	})
+	*h.records = append(*h.records, recordedRecord{
+		message:      record.Message,
+		attrs:        slices.Clone(attrs),
+		handlerAttrs: slices.Clone(h.attrs),
+		groups:       slices.Clone(h.groups),
+	})
+	return h.err
+}
+
+func (h *recordingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := *h
+	clone.attrs = append(slices.Clone(h.attrs), attrs...)
+	return &clone
+}
+
+func (h *recordingHandler) WithGroup(name string) slog.Handler {
+	clone := *h
+	clone.groups = append(slices.Clone(h.groups), name)
+	return &clone
+}
+
+func timeNow() time.Time {
+	return time.Unix(1710000000, 0)
+}

--- a/log/slog/multi/version.go
+++ b/log/slog/multi/version.go
@@ -1,0 +1,6 @@
+package multi
+
+// Version returns the current release version of this component.
+func Version() string {
+	return "4.0.0"
+}

--- a/log/slog/multi/version_test.go
+++ b/log/slog/multi/version_test.go
@@ -1,0 +1,20 @@
+package multi_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/log/slog/multi/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := multi.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -89,6 +89,9 @@ module-sets:
       # JSON-RPC
       - github.com/go-fries/fries/jsonrpc/v4
 
+      # Log
+      - github.com/go-fries/fries/log/slog/multi/v4
+
       # Kratos
       - github.com/go-fries/fries/kratos/log/multi/v4
       - github.com/go-fries/fries/kratos/log/syslog/v4


### PR DESCRIPTION
## Summary
Add `log/slog/multi`, a standalone `slog.Handler` fan-out module for the v4 slog migration.

## Changes
- Add `multi.Handler` with nil handler filtering, level-aware fan-out, cloned records, and `errors.Join` aggregation
- Add README, version metadata, module registration, and Codecov path mapping
- Cover handler behavior and semver version checks with testify-based tests

## Motivation
- Start the v4 logging migration with a slog-native component that does not depend on Kratos logging APIs

## Testing
- `go test -count=1 ./...` from `log/slog/multi`
- `make test/log/slog/multi`
- `make lint/log/slog/multi`
- `git diff --check`