### PR TITLE
feat(log): add slog syslog handler

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -70,6 +70,7 @@ fixes:
   - github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4::hyperf/jet/middleware/timeout/
   - github.com/go-fries/fries/hyperf/jet/middleware/otel/v4::hyperf/jet/middleware/otel/
   - github.com/go-fries/fries/log/slog/multi/v4::log/slog/multi/
+  - github.com/go-fries/fries/log/slog/syslog/v4::log/slog/syslog/
   - github.com/go-fries/fries/kratos/log/multi/v4::kratos/log/multi/
   - github.com/go-fries/fries/kratos/log/otel/v4::kratos/log/otel/
   - github.com/go-fries/fries/kratos/log/syslog/v4::kratos/log/syslog/

--- a/log/slog/syslog/README.md
+++ b/log/slog/syslog/README.md
@@ -16,11 +16,11 @@ package main
 import (
 	"log/slog"
 
-	slogsyslog "github.com/go-fries/fries/log/slog/syslog/v4"
+	"github.com/go-fries/fries/log/slog/syslog/v4"
 )
 
 func main() {
-	handler, err := slogsyslog.Dial("", "", slogsyslog.WithTag("api"))
+	handler, err := syslog.Dial("", "", syslog.WithTag("api"))
 	if err != nil {
 		panic(err)
 	}

--- a/log/slog/syslog/README.md
+++ b/log/slog/syslog/README.md
@@ -1,0 +1,35 @@
+# slog syslog handler
+
+`log/slog/syslog` provides a `slog.Handler` that writes log records to syslog.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/log/slog/syslog/v4
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"log/slog"
+
+	slogsyslog "github.com/go-fries/fries/log/slog/syslog/v4"
+)
+
+func main() {
+	handler, err := slogsyslog.Dial("", "", slogsyslog.WithTag("api"))
+	if err != nil {
+		panic(err)
+	}
+	defer handler.Close()
+
+	logger := slog.New(handler)
+	logger.Info("service started", slog.String("service", "api"))
+}
+```
+
+Use `NewHandler` with an injected writer when tests should not depend on a real
+syslog service.

--- a/log/slog/syslog/config.go
+++ b/log/slog/syslog/config.go
@@ -7,15 +7,17 @@ import (
 	stdsyslog "log/syslog"
 )
 
+const severityMask stdsyslog.Priority = 0x7
+
 type config struct {
 	level    slog.Leveler
-	priority stdsyslog.Priority
+	facility stdsyslog.Priority
 	tag      string
 }
 
 func newConfig(opts ...Option) *config {
 	cfg := &config{
-		priority: stdsyslog.LOG_USER,
+		facility: stdsyslog.LOG_USER,
 	}
 	for _, opt := range opts {
 		if opt == nil {
@@ -44,10 +46,11 @@ func WithLevel(level slog.Leveler) Option {
 	})
 }
 
-// WithPriority sets the syslog facility used by [Dial].
-func WithPriority(priority stdsyslog.Priority) Option {
+// WithFacility sets the syslog facility used by [Dial]. Severity bits are
+// derived from the slog record level and ignored when facility is stored.
+func WithFacility(facility stdsyslog.Priority) Option {
 	return optionFunc(func(c *config) {
-		c.priority = priority
+		c.facility = facility &^ severityMask
 	})
 }
 

--- a/log/slog/syslog/config.go
+++ b/log/slog/syslog/config.go
@@ -1,0 +1,59 @@
+//go:build !windows && !plan9
+
+package syslog
+
+import (
+	"log/slog"
+	stdsyslog "log/syslog"
+)
+
+type config struct {
+	level    slog.Leveler
+	priority stdsyslog.Priority
+	tag      string
+}
+
+func newConfig(opts ...Option) *config {
+	cfg := &config{
+		priority: stdsyslog.LOG_USER,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt.apply(cfg)
+	}
+	return cfg
+}
+
+// Option configures a [Handler].
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+
+// WithLevel sets the minimum slog level handled by [Handler].
+func WithLevel(level slog.Leveler) Option {
+	return optionFunc(func(c *config) {
+		c.level = level
+	})
+}
+
+// WithPriority sets the syslog facility used by [Dial].
+func WithPriority(priority stdsyslog.Priority) Option {
+	return optionFunc(func(c *config) {
+		c.priority = priority
+	})
+}
+
+// WithTag sets the syslog tag used by [Dial].
+func WithTag(tag string) Option {
+	return optionFunc(func(c *config) {
+		c.tag = tag
+	})
+}

--- a/log/slog/syslog/doc.go
+++ b/log/slog/syslog/doc.go
@@ -1,0 +1,4 @@
+//go:build !windows && !plan9
+
+// Package syslog provides a slog handler that writes records to syslog.
+package syslog

--- a/log/slog/syslog/go.mod
+++ b/log/slog/syslog/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/log/slog/syslog/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/log/slog/syslog/go.sum
+++ b/log/slog/syslog/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log/slog/syslog/handler.go
+++ b/log/slog/syslog/handler.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"strings"
+	"strconv"
+	"sync"
+	"time"
 )
 
 var _ slog.Handler = (*Handler)(nil)
@@ -34,6 +36,7 @@ type attrEntry struct {
 type Handler struct {
 	writer Writer
 	level  slog.Leveler
+	mu     *sync.Mutex
 	attrs  []attrEntry
 	groups []string
 }
@@ -47,6 +50,7 @@ func newHandler(writer Writer, cfg *config) *Handler {
 	return &Handler{
 		writer: writer,
 		level:  cfg.level,
+		mu:     &sync.Mutex{},
 	}
 }
 
@@ -68,6 +72,9 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 	}
 
 	message := h.formatRecord(record)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	switch {
 	case record.Level < slog.LevelInfo:
 		return h.writer.Debug(message)
@@ -113,6 +120,9 @@ func (h *Handler) Close() error {
 	if !ok {
 		return nil
 	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	return closer.Close()
 }
 
@@ -120,6 +130,7 @@ func (h *Handler) clone() *Handler {
 	clone := &Handler{
 		writer: h.writer,
 		level:  h.level,
+		mu:     h.mu,
 		attrs:  slices.Clone(h.attrs),
 		groups: slices.Clone(h.groups),
 	}
@@ -164,14 +175,54 @@ func appendAttr(buf *bytes.Buffer, groups []string, attr slog.Attr) {
 	}
 
 	buf.WriteByte(' ')
-	buf.WriteString(qualifiedKey(groups, attr.Key))
+	writeQualifiedKey(buf, groups, attr.Key)
 	buf.WriteByte('=')
-	buf.WriteString(fmt.Sprint(attr.Value.Any()))
+	appendValue(buf, attr.Value)
 }
 
-func qualifiedKey(groups []string, key string) string {
-	if len(groups) == 0 {
-		return key
+func writeQualifiedKey(buf *bytes.Buffer, groups []string, key string) {
+	for _, group := range groups {
+		buf.WriteString(group)
+		buf.WriteByte('.')
 	}
-	return strings.Join(append(slices.Clone(groups), key), ".")
+	buf.WriteString(key)
+}
+
+func appendValue(buf *bytes.Buffer, value slog.Value) {
+	switch value.Kind() {
+	case slog.KindString:
+		s := value.String()
+		if needsQuoting(s) {
+			buf.WriteString(strconv.Quote(s))
+		} else {
+			buf.WriteString(s)
+		}
+	case slog.KindInt64:
+		buf.WriteString(strconv.FormatInt(value.Int64(), 10))
+	case slog.KindUint64:
+		buf.WriteString(strconv.FormatUint(value.Uint64(), 10))
+	case slog.KindFloat64:
+		buf.WriteString(strconv.FormatFloat(value.Float64(), 'g', -1, 64))
+	case slog.KindBool:
+		buf.WriteString(strconv.FormatBool(value.Bool()))
+	case slog.KindDuration:
+		buf.WriteString(value.Duration().String())
+	case slog.KindTime:
+		buf.WriteString(value.Time().Format(time.RFC3339))
+	default:
+		buf.WriteString(fmt.Sprint(value.Any()))
+	}
+}
+
+func needsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c <= ' ' || c == '=' || c == '"' {
+			return true
+		}
+	}
+	return false
 }

--- a/log/slog/syslog/handler.go
+++ b/log/slog/syslog/handler.go
@@ -1,0 +1,173 @@
+//go:build !windows && !plan9
+
+package syslog
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+)
+
+var _ slog.Handler = (*Handler)(nil)
+
+// Writer writes syslog messages at a selected priority.
+type Writer interface {
+	Debug(string) error
+	Info(string) error
+	Warning(string) error
+	Err(string) error
+}
+
+type attrEntry struct {
+	groups []string
+	attr   slog.Attr
+}
+
+// Handler writes slog records to syslog.
+type Handler struct {
+	writer Writer
+	config *config
+	attrs  []attrEntry
+	groups []string
+}
+
+// NewHandler creates a [Handler] that writes records to writer.
+func NewHandler(writer Writer, opts ...Option) *Handler {
+	return newHandler(writer, newConfig(opts...))
+}
+
+func newHandler(writer Writer, cfg *config) *Handler {
+	return &Handler{
+		writer: writer,
+		config: cfg,
+	}
+}
+
+// Enabled reports whether level is enabled by the handler configuration.
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
+	if h.writer == nil {
+		return false
+	}
+	if h.config.level == nil {
+		return true
+	}
+	return level >= h.config.level.Level()
+}
+
+// Handle writes record to syslog.
+func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+	if !h.Enabled(ctx, record.Level) {
+		return nil
+	}
+
+	message := h.formatRecord(record)
+	switch {
+	case record.Level < slog.LevelInfo:
+		return h.writer.Debug(message)
+	case record.Level < slog.LevelWarn:
+		return h.writer.Info(message)
+	case record.Level < slog.LevelError:
+		return h.writer.Warning(message)
+	default:
+		return h.writer.Err(message)
+	}
+}
+
+// WithAttrs returns a new handler whose records include attrs.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+
+	clone := h.clone()
+	for _, attr := range attrs {
+		clone.attrs = append(clone.attrs, attrEntry{
+			groups: slices.Clone(h.groups),
+			attr:   attr,
+		})
+	}
+	return clone
+}
+
+// WithGroup returns a new handler with name appended to the current group.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+
+	clone := h.clone()
+	clone.groups = append(clone.groups, name)
+	return clone
+}
+
+// Close closes the underlying writer when it implements Close.
+func (h *Handler) Close() error {
+	closer, ok := h.writer.(interface{ Close() error })
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func (h *Handler) clone() *Handler {
+	clone := &Handler{
+		writer: h.writer,
+		config: h.config,
+		attrs:  slices.Clone(h.attrs),
+		groups: slices.Clone(h.groups),
+	}
+	return clone
+}
+
+func (h *Handler) formatRecord(record slog.Record) string {
+	var buf bytes.Buffer
+	buf.WriteString(record.Message)
+	for _, entry := range h.attrs {
+		appendAttr(&buf, entry.groups, entry.attr)
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		appendAttr(&buf, h.groups, attr)
+		return true
+	})
+	return buf.String()
+}
+
+func appendAttr(buf *bytes.Buffer, groups []string, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+
+	if attr.Value.Kind() == slog.KindGroup {
+		attrs := attr.Value.Group()
+		if len(attrs) == 0 {
+			return
+		}
+		if attr.Key != "" {
+			groups = append(slices.Clone(groups), attr.Key)
+		}
+		for _, groupAttr := range attrs {
+			appendAttr(buf, groups, groupAttr)
+		}
+		return
+	}
+
+	if attr.Key == "" {
+		return
+	}
+
+	buf.WriteByte(' ')
+	buf.WriteString(qualifiedKey(groups, attr.Key))
+	buf.WriteByte('=')
+	buf.WriteString(fmt.Sprint(attr.Value.Any()))
+}
+
+func qualifiedKey(groups []string, key string) string {
+	if len(groups) == 0 {
+		return key
+	}
+	return strings.Join(append(slices.Clone(groups), key), ".")
+}

--- a/log/slog/syslog/handler.go
+++ b/log/slog/syslog/handler.go
@@ -15,9 +15,13 @@ var _ slog.Handler = (*Handler)(nil)
 
 // Writer writes syslog messages at a selected priority.
 type Writer interface {
+	// Debug writes a debug-priority syslog message.
 	Debug(string) error
+	// Info writes an info-priority syslog message.
 	Info(string) error
+	// Warning writes a warning-priority syslog message.
 	Warning(string) error
+	// Err writes an error-priority syslog message.
 	Err(string) error
 }
 
@@ -29,7 +33,7 @@ type attrEntry struct {
 // Handler writes slog records to syslog.
 type Handler struct {
 	writer Writer
-	config *config
+	level  slog.Leveler
 	attrs  []attrEntry
 	groups []string
 }
@@ -42,7 +46,7 @@ func NewHandler(writer Writer, opts ...Option) *Handler {
 func newHandler(writer Writer, cfg *config) *Handler {
 	return &Handler{
 		writer: writer,
-		config: cfg,
+		level:  cfg.level,
 	}
 }
 
@@ -51,10 +55,10 @@ func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
 	if h.writer == nil {
 		return false
 	}
-	if h.config.level == nil {
+	if h.level == nil {
 		return true
 	}
-	return level >= h.config.level.Level()
+	return level >= h.level.Level()
 }
 
 // Handle writes record to syslog.
@@ -115,7 +119,7 @@ func (h *Handler) Close() error {
 func (h *Handler) clone() *Handler {
 	clone := &Handler{
 		writer: h.writer,
-		config: h.config,
+		level:  h.level,
 		attrs:  slices.Clone(h.attrs),
 		groups: slices.Clone(h.groups),
 	}

--- a/log/slog/syslog/handler_test.go
+++ b/log/slog/syslog/handler_test.go
@@ -5,6 +5,9 @@ package syslog
 import (
 	"errors"
 	"log/slog"
+	stdsyslog "log/syslog"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -68,6 +71,75 @@ func TestHandlerWithAttrsAndWithGroupQualifiesAttributes(t *testing.T) {
 	assert.Equal(t, "warning", writer.records[0].priority)
 	assert.Contains(t, writer.records[0].message, "service=api")
 	assert.Contains(t, writer.records[0].message, "worker.attempt=3")
+}
+
+func TestHandlerWritesGroupAttributes(t *testing.T) {
+	writer := &recordingWriter{}
+	handler := NewHandler(writer)
+	record := slog.NewRecord(timeNow(), slog.LevelInfo, "job finished", 0)
+	record.AddAttrs(slog.Group(
+		"worker",
+		slog.String("name", "syncer"),
+		slog.Group("job", slog.Int("attempt", 3)),
+		slog.Group("empty"),
+	))
+
+	require.NoError(t, handler.Handle(t.Context(), record))
+
+	require.Len(t, writer.records, 1)
+	assert.Contains(t, writer.records[0].message, "worker.name=syncer")
+	assert.Contains(t, writer.records[0].message, "worker.job.attempt=3")
+	assert.NotContains(t, writer.records[0].message, "empty")
+}
+
+func TestHandlerQuotesStringAttributesWhenNeeded(t *testing.T) {
+	writer := &recordingWriter{}
+	handler := NewHandler(writer)
+	record := slog.NewRecord(timeNow(), slog.LevelInfo, "service started", 0)
+	record.AddAttrs(
+		slog.String("plain", "api"),
+		slog.String("empty", ""),
+		slog.String("space", "api worker"),
+		slog.String("equals", "a=b"),
+		slog.String("quote", `say "hello"`),
+	)
+
+	require.NoError(t, handler.Handle(t.Context(), record))
+
+	require.Len(t, writer.records, 1)
+	assert.Contains(t, writer.records[0].message, "plain=api")
+	assert.Contains(t, writer.records[0].message, `empty=""`)
+	assert.Contains(t, writer.records[0].message, `space="api worker"`)
+	assert.Contains(t, writer.records[0].message, `equals="a=b"`)
+	assert.Contains(t, writer.records[0].message, `quote="say \"hello\""`)
+}
+
+func TestHandlerSerializesConcurrentWrites(t *testing.T) {
+	writer := &serialWriter{}
+	handler := NewHandler(writer)
+	derived := handler.WithGroup("worker")
+
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "base", 0)))
+		}()
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, derived.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "derived", 0)))
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(128), writer.count.Load())
+}
+
+func TestWithFacilityMasksSeverityBits(t *testing.T) {
+	cfg := newConfig(WithFacility(stdsyslog.LOG_LOCAL0 | stdsyslog.LOG_INFO))
+
+	assert.Equal(t, stdsyslog.LOG_LOCAL0, cfg.facility)
 }
 
 func TestHandlerEnabledHonorsMinimumLevel(t *testing.T) {
@@ -141,4 +213,37 @@ func (w *recordingWriter) record(priority, message string) error {
 
 func timeNow() time.Time {
 	return time.Unix(1710000000, 0)
+}
+
+type serialWriter struct {
+	active atomic.Int32
+	count  atomic.Int32
+}
+
+func (w *serialWriter) Debug(string) error {
+	return w.record()
+}
+
+func (w *serialWriter) Info(string) error {
+	return w.record()
+}
+
+func (w *serialWriter) Warning(string) error {
+	return w.record()
+}
+
+func (w *serialWriter) Err(string) error {
+	return w.record()
+}
+
+func (w *serialWriter) record() error {
+	if w.active.Add(1) != 1 {
+		w.active.Add(-1)
+		return errors.New("concurrent write")
+	}
+	defer w.active.Add(-1)
+
+	time.Sleep(time.Millisecond)
+	w.count.Add(1)
+	return nil
 }

--- a/log/slog/syslog/handler_test.go
+++ b/log/slog/syslog/handler_test.go
@@ -1,0 +1,144 @@
+//go:build !windows && !plan9
+
+package syslog
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerWritesRecordToInjectedWriter(t *testing.T) {
+	writer := &recordingWriter{}
+	handler := NewHandler(writer)
+	record := slog.NewRecord(timeNow(), slog.LevelInfo, "service started", 0)
+	record.AddAttrs(slog.String("service", "api"), slog.Int("attempt", 2))
+
+	require.NoError(t, handler.Handle(t.Context(), record))
+
+	require.Len(t, writer.records, 1)
+	assert.Equal(t, "info", writer.records[0].priority)
+	assert.Contains(t, writer.records[0].message, "service started")
+	assert.Contains(t, writer.records[0].message, "service=api")
+	assert.Contains(t, writer.records[0].message, "attempt=2")
+}
+
+func TestHandlerMapsSlogLevelsToSyslogPriorities(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    slog.Level
+		priority string
+	}{
+		{name: "debug", level: slog.LevelDebug, priority: "debug"},
+		{name: "below info", level: slog.LevelInfo - 1, priority: "debug"},
+		{name: "info", level: slog.LevelInfo, priority: "info"},
+		{name: "warn", level: slog.LevelWarn, priority: "warning"},
+		{name: "error", level: slog.LevelError, priority: "err"},
+		{name: "above error", level: slog.LevelError + 4, priority: "err"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &recordingWriter{}
+			handler := NewHandler(writer)
+
+			require.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), tt.level, tt.name, 0)))
+
+			require.Len(t, writer.records, 1)
+			assert.Equal(t, tt.priority, writer.records[0].priority)
+		})
+	}
+}
+
+func TestHandlerWithAttrsAndWithGroupQualifiesAttributes(t *testing.T) {
+	writer := &recordingWriter{}
+	handler := NewHandler(writer).
+		WithAttrs([]slog.Attr{slog.String("service", "api")}).
+		WithGroup("worker")
+	record := slog.NewRecord(timeNow(), slog.LevelWarn, "job failed", 0)
+	record.AddAttrs(slog.Int("attempt", 3))
+
+	require.NoError(t, handler.Handle(t.Context(), record))
+
+	require.Len(t, writer.records, 1)
+	assert.Equal(t, "warning", writer.records[0].priority)
+	assert.Contains(t, writer.records[0].message, "service=api")
+	assert.Contains(t, writer.records[0].message, "worker.attempt=3")
+}
+
+func TestHandlerEnabledHonorsMinimumLevel(t *testing.T) {
+	writer := &recordingWriter{}
+	handler := NewHandler(writer, WithLevel(slog.LevelWarn))
+
+	assert.False(t, handler.Enabled(t.Context(), slog.LevelInfo))
+	assert.True(t, handler.Enabled(t.Context(), slog.LevelError))
+	require.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "ignore", 0)))
+	assert.Empty(t, writer.records)
+}
+
+func TestHandlerReturnsWriterError(t *testing.T) {
+	writerErr := errors.New("write failed")
+	writer := &recordingWriter{err: writerErr}
+	handler := NewHandler(writer)
+
+	err := handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelError, "failed", 0))
+
+	assert.ErrorIs(t, err, writerErr)
+}
+
+func TestHandlerWithEmptyAttrsAndGroupReturnsReceiver(t *testing.T) {
+	handler := NewHandler(&recordingWriter{})
+
+	assert.Same(t, handler, handler.WithAttrs(nil))
+	assert.Same(t, handler, handler.WithAttrs([]slog.Attr{}))
+	assert.Same(t, handler, handler.WithGroup(""))
+}
+
+func TestHandlerNoopsWhenWriterNil(t *testing.T) {
+	handler := NewHandler(nil)
+
+	assert.False(t, handler.Enabled(t.Context(), slog.LevelInfo))
+	assert.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "ignored", 0)))
+}
+
+type recordedWrite struct {
+	priority string
+	message  string
+}
+
+type recordingWriter struct {
+	records []recordedWrite
+	err     error
+}
+
+func (w *recordingWriter) Debug(message string) error {
+	return w.record("debug", message)
+}
+
+func (w *recordingWriter) Info(message string) error {
+	return w.record("info", message)
+}
+
+func (w *recordingWriter) Warning(message string) error {
+	return w.record("warning", message)
+}
+
+func (w *recordingWriter) Err(message string) error {
+	return w.record("err", message)
+}
+
+func (w *recordingWriter) record(priority, message string) error {
+	w.records = append(w.records, recordedWrite{
+		priority: priority,
+		message:  message,
+	})
+	return w.err
+}
+
+func timeNow() time.Time {
+	return time.Unix(1710000000, 0)
+}

--- a/log/slog/syslog/syslog.go
+++ b/log/slog/syslog/syslog.go
@@ -1,0 +1,15 @@
+//go:build !windows && !plan9
+
+package syslog
+
+import stdsyslog "log/syslog"
+
+// Dial connects to syslog and returns a [Handler] backed by the syslog writer.
+func Dial(network, addr string, opts ...Option) (*Handler, error) {
+	cfg := newConfig(opts...)
+	writer, err := stdsyslog.Dial(network, addr, cfg.priority, cfg.tag)
+	if err != nil {
+		return nil, err
+	}
+	return newHandler(writer, cfg), nil
+}

--- a/log/slog/syslog/syslog.go
+++ b/log/slog/syslog/syslog.go
@@ -7,7 +7,7 @@ import stdsyslog "log/syslog"
 // Dial connects to syslog and returns a [Handler] backed by the syslog writer.
 func Dial(network, addr string, opts ...Option) (*Handler, error) {
 	cfg := newConfig(opts...)
-	writer, err := stdsyslog.Dial(network, addr, cfg.priority, cfg.tag)
+	writer, err := stdsyslog.Dial(network, addr, cfg.facility, cfg.tag)
 	if err != nil {
 		return nil, err
 	}

--- a/log/slog/syslog/version.go
+++ b/log/slog/syslog/version.go
@@ -1,0 +1,8 @@
+//go:build !windows && !plan9
+
+package syslog
+
+// Version returns the current release version of this component.
+func Version() string {
+	return "4.0.0"
+}

--- a/log/slog/syslog/version_test.go
+++ b/log/slog/syslog/version_test.go
@@ -1,0 +1,22 @@
+//go:build !windows && !plan9
+
+package syslog_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/log/slog/syslog/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := syslog.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -91,6 +91,7 @@ module-sets:
 
       # Log
       - github.com/go-fries/fries/log/slog/multi/v4
+      - github.com/go-fries/fries/log/slog/syslog/v4
 
       # Kratos
       - github.com/go-fries/fries/kratos/log/multi/v4


### PR DESCRIPTION
## Summary
Add `log/slog/syslog`, a standalone slog handler that writes records to syslog without depending on Kratos logging APIs.

## Changes
- Add an injectable syslog writer interface plus `Dial` for real syslog connections
- Implement slog level filtering, level-to-priority mapping, attrs/groups formatting, version metadata, and README
- Register the module in `versions.yaml` and Codecov path fixes

## Motivation
- Continue the v4 logging migration by replacing the core capability of `kratos/log/syslog` with a slog-native module

## Testing
- `go test -count=1 ./...` from `log/slog/syslog`
- `make test/log/slog/syslog`
- `make lint/log/slog/syslog`
- `git diff --check`