### PR TITLE
refactor(log): migrate otlp lifecycle logs to slog

### DIFF
--- a/otel/otlp/client.go
+++ b/otel/otlp/client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 
-	kratoslog "github.com/go-kratos/kratos/v2/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/log/global"
 )
@@ -142,7 +141,7 @@ func (c *Client) Configure(ctx context.Context) error {
 	}
 	c.configured = true
 
-	kratoslog.Info("OTLP client configured")
+	c.config.logger.InfoContext(ctx, "OTLP client configured")
 
 	return nil
 }
@@ -219,7 +218,7 @@ func (c *Client) Shutdown(ctx context.Context) (err error) {
 	}
 	c.mu.Unlock()
 
-	kratoslog.Infof("OTLP client is shutting down")
+	c.config.logger.InfoContext(ctx, "OTLP client is shutting down")
 
 	for _, provider := range providers {
 		if provider == nil {

--- a/otel/otlp/client_test.go
+++ b/otel/otlp/client_test.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -248,6 +249,32 @@ func TestClientLifecycle(t *testing.T) {
 		assert.Equal(t, int32(1), metricExporter.shutdownCount.Load())
 		assert.Equal(t, int32(1), logExporter.shutdownCount.Load())
 	})
+
+	t.Run("writes lifecycle logs to configured logger", func(t *testing.T) {
+		restoreGlobals := saveGlobalProviders(t)
+		defer restoreGlobals()
+
+		logHandler := &recordingHandler{}
+		client := newTestClient(
+			t,
+			&testTransport{
+				traceExporter:  &testTraceExporter{},
+				metricExporter: &testMetricExporter{},
+				logExporter:    &testLogExporter{},
+			},
+			WithHooks(noopHook{}),
+			WithLogger(slog.New(logHandler)),
+		)
+
+		require.NoError(t, client.Configure(t.Context()))
+		require.NoError(t, client.Shutdown(t.Context()))
+
+		require.Len(t, logHandler.records, 2)
+		assert.Equal(t, slog.LevelInfo, logHandler.records[0].Level)
+		assert.Equal(t, "OTLP client configured", logHandler.records[0].Message)
+		assert.Equal(t, slog.LevelInfo, logHandler.records[1].Level)
+		assert.Equal(t, "OTLP client is shutting down", logHandler.records[1].Message)
+	})
 }
 
 func TestClientSignals(t *testing.T) {
@@ -405,6 +432,27 @@ func (h *blockingHook) Configured(context.Context, *Client) error {
 	})
 	<-h.release
 	return nil
+}
+
+type recordingHandler struct {
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *recordingHandler) Handle(_ context.Context, record slog.Record) error {
+	h.records = append(h.records, record.Clone())
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *recordingHandler) WithGroup(string) slog.Handler {
+	return h
 }
 
 type testTransport struct {

--- a/otel/otlp/config.go
+++ b/otel/otlp/config.go
@@ -2,6 +2,7 @@ package otlp
 
 import (
 	"context"
+	"log/slog"
 	"runtime"
 	"time"
 
@@ -51,6 +52,9 @@ type config struct {
 	tracerProvider trace.TracerProvider
 	meterProvider  metric.MeterProvider
 	loggerProvider log.LoggerProvider
+
+	// internal logging
+	logger *slog.Logger
 
 	// resource options
 	serviceName               string
@@ -136,6 +140,17 @@ func WithMeterProvider(provider metric.MeterProvider) Option {
 func WithLoggerProvider(provider log.LoggerProvider) Option {
 	return optionFunc(func(c *config) {
 		c.loggerProvider = provider
+	})
+}
+
+// WithLogger sets the logger used for client lifecycle logs.
+//
+// When logger is nil, the client uses [slog.Default].
+func WithLogger(logger *slog.Logger) Option {
+	return optionFunc(func(c *config) {
+		if logger != nil {
+			c.logger = logger
+		}
 	})
 }
 
@@ -266,6 +281,7 @@ func newConfig(signals Signal, opts ...Option) *config {
 		logExportInterval:  defaultLogExportInterval,
 		logExportTimeout:   defaultLogExportTimeout,
 		batchQueueSize:     queueSize(),
+		logger:             slog.Default(),
 	}
 	for _, opt := range opts {
 		opt.apply(cfg)

--- a/otel/otlp/config_test.go
+++ b/otel/otlp/config_test.go
@@ -2,6 +2,7 @@ package otlp
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -17,10 +18,13 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	cfg := newConfig(allSignals)
+	cfgWithNilLogger := newConfig(allSignals, WithLogger(nil))
 
 	assert.True(t, cfg.signalEnabled(TraceSignal))
 	assert.True(t, cfg.signalEnabled(MetricSignal))
 	assert.True(t, cfg.signalEnabled(LogSignal))
+	assert.Same(t, slog.Default(), cfg.logger)
+	assert.Same(t, slog.Default(), cfgWithNilLogger.logger)
 	assert.Equal(t, defaultTraceBatchTimeout, cfg.traceBatchTimeout)
 	assert.Equal(t, defaultTraceExportTimeout, cfg.traceExportTimeout)
 	assert.Equal(t, defaultMetricInterval, cfg.metricInterval)
@@ -79,6 +83,7 @@ func TestConfigCoreOptions(t *testing.T) {
 	tracerProvider := sdktrace.NewTracerProvider()
 	meterProvider := sdkmetric.NewMeterProvider()
 	loggerProvider := sdklog.NewLoggerProvider()
+	logger := slog.New(&recordingHandler{})
 	sampler := sdktrace.NeverSample()
 
 	ctx := t.Context()
@@ -95,6 +100,7 @@ func TestConfigCoreOptions(t *testing.T) {
 		WithTracerProvider(tracerProvider),
 		WithMeterProvider(meterProvider),
 		WithLoggerProvider(loggerProvider),
+		WithLogger(logger),
 		WithTraceSampler(sampler),
 	)
 
@@ -103,6 +109,7 @@ func TestConfigCoreOptions(t *testing.T) {
 	assert.Same(t, tracerProvider, cfg.tracerProvider)
 	assert.Same(t, meterProvider, cfg.meterProvider)
 	assert.Same(t, loggerProvider, cfg.loggerProvider)
+	assert.Same(t, logger, cfg.logger)
 	assert.Equal(t, sampler, cfg.traceSampler)
 }
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -6,7 +6,6 @@ replace github.com/go-fries/fries/foundation/v4 => ../../foundation
 
 require (
 	github.com/go-fries/fries/foundation/v4 v4.0.0
-	github.com/go-kratos/kratos/v2 v2.9.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/host v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0

--- a/otel/otlp/go.sum
+++ b/otel/otlp/go.sum
@@ -6,8 +6,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.10.1 h1:dewVBCBT2GaMu1SrNTYxQhgQBethzfhiwvZiLGP/qyY=
 github.com/ebitengine/purego v0.10.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/go-kratos/kratos/v2 v2.9.2 h1:px8GJQBeLpquDKQWQ9zohEWiLA8n4D/pv7aH3asvUvo=
-github.com/go-kratos/kratos/v2 v2.9.2/go.mod h1:Jc7jaeYd4RAPjetun2C+oFAOO7HNMHTT/Z4LxpuEDJM=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -90,8 +88,6 @@ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
-golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
-golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Summary
Migrate `otel/otlp` internal lifecycle logging from Kratos log to slog.

## Changes
- Add `WithLogger(*slog.Logger)` for OTLP client lifecycle logs
- Default nil logger configuration to `slog.Default()`
- Replace `kratoslog.Info` / `kratoslog.Infof` with context-aware slog logging
- Remove the direct `github.com/go-kratos/kratos/v2` dependency from `otel/otlp`
- Cover configured logger behavior in client and config tests

## Motivation
- Continue aligning 4.x logging APIs around slog
- Keep OTel provider setup behavior unchanged while removing Kratos log usage

## Testing
- `go test ./...` in `otel/otlp`
- `make lint/otel/otlp`
- `git diff --check`