### PR TITLE
fix(errors): align with kratos v3 error helpers

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -13,10 +13,16 @@ var (
 	IsForbidden          = errors.IsForbidden
 	IsNotFound           = errors.IsNotFound
 	IsConflict           = errors.IsConflict
+	IsTooManyRequests    = errors.IsTooManyRequests
 	IsInternalServer     = errors.IsInternalServer
 	IsServiceUnavailable = errors.IsServiceUnavailable
 	IsGatewayTimeout     = errors.IsGatewayTimeout
 	IsClientClosed       = errors.IsClientClosed
+	Is                   = errors.Is
+	As                   = errors.As
+	Unwrap               = errors.Unwrap
+	Join                 = errors.Join
+	ErrUnsupported       = errors.ErrUnsupported
 )
 
 // vars
@@ -26,6 +32,8 @@ var (
 	ErrForbidden          = Forbidden(http.StatusText(http.StatusForbidden))
 	ErrNotFound           = NotFound(http.StatusText(http.StatusNotFound))
 	ErrConflict           = Conflict(http.StatusText(http.StatusConflict))
+	ErrTooManyRequests    = TooManyRequests(http.StatusText(http.StatusTooManyRequests))
+	ErrPreconditionFailed = PreconditionFailed(http.StatusText(http.StatusPreconditionFailed))
 	ErrInternalServer     = InternalServer(http.StatusText(http.StatusInternalServerError))
 	ErrServiceUnavailable = ServiceUnavailable(http.StatusText(http.StatusServiceUnavailable))
 	ErrGatewayTimeout     = GatewayTimeout(http.StatusText(http.StatusGatewayTimeout))
@@ -54,6 +62,18 @@ func NotFound(message string) *errors.Error {
 
 func Conflict(message string) *errors.Error {
 	return errors.Conflict(http.StatusText(http.StatusConflict), message)
+}
+
+func TooManyRequests(message string) *errors.Error {
+	return errors.TooManyRequests(http.StatusText(http.StatusTooManyRequests), message)
+}
+
+func PreconditionFailed(message string) *errors.Error {
+	return errors.New(http.StatusPreconditionFailed, http.StatusText(http.StatusPreconditionFailed), message)
+}
+
+func IsPreconditionFailed(err error) bool {
+	return errors.Code(err) == http.StatusPreconditionFailed
 }
 
 func InternalServer(message string) *errors.Error {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,10 +1,14 @@
 package errors
 
 import (
+	stderrors "errors"
+	"fmt"
 	"net/http"
 	"testing"
 
+	kratoserrors "github.com/go-kratos/kratos/v3/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrors(t *testing.T) {
@@ -16,13 +20,16 @@ func TestErrors(t *testing.T) {
 	assert.True(t, IsInternalServer(InternalServer("InternalServer")))
 	assert.True(t, IsServiceUnavailable(ServiceUnavailable("ServiceUnavailable")))
 	assert.True(t, IsGatewayTimeout(GatewayTimeout("GatewayTimeout")))
-	assert.True(t, IsClientClosed(ClientClosed("ClientClosed")))
+	assert.True(t, IsTooManyRequests(TooManyRequests("TooManyRequests")))
+	assert.True(t, IsPreconditionFailed(PreconditionFailed("PreconditionFailed")))
 	assert.True(t, IsClientClosed(ClientClosed("ClientClosed")))
 }
 
 func TestErrors_New(t *testing.T) {
 	assert.True(t, IsForbidden(New(http.StatusForbidden, "Forbidden")))
 	assert.Equal(t, New(http.StatusForbidden, "Forbidden"), Forbidden("Forbidden"))
+	assert.Equal(t, New(http.StatusTooManyRequests, "TooManyRequests"), TooManyRequests("TooManyRequests"))
+	assert.Equal(t, New(http.StatusPreconditionFailed, "PreconditionFailed"), PreconditionFailed("PreconditionFailed"))
 }
 
 func TestErrors_Vars(t *testing.T) {
@@ -34,5 +41,29 @@ func TestErrors_Vars(t *testing.T) {
 	assert.Equal(t, http.StatusText(http.StatusInternalServerError), ErrInternalServer.Message)
 	assert.Equal(t, http.StatusText(http.StatusServiceUnavailable), ErrServiceUnavailable.Message)
 	assert.Equal(t, http.StatusText(http.StatusGatewayTimeout), ErrGatewayTimeout.Message)
+	assert.Equal(t, http.StatusText(http.StatusTooManyRequests), ErrTooManyRequests.Message)
+	assert.Equal(t, http.StatusText(http.StatusPreconditionFailed), ErrPreconditionFailed.Message)
 	assert.Equal(t, "Client Closed", ErrClientClosed.Message)
+}
+
+func TestErrors_WrappedStatusHelpers(t *testing.T) {
+	assert.True(t, IsTooManyRequests(fmt.Errorf("wrapped: %w", TooManyRequests("rate limited"))))
+	assert.True(t, IsPreconditionFailed(fmt.Errorf("wrapped: %w", PreconditionFailed("etag mismatch"))))
+}
+
+func TestErrors_StandardLibraryWrappers(t *testing.T) {
+	sentinel := stderrors.New("sentinel")
+	wrapped := fmt.Errorf("wrapped: %w", sentinel)
+
+	assert.True(t, Is(wrapped, sentinel))
+	assert.Same(t, sentinel, Unwrap(wrapped))
+
+	joined := Join(sentinel, ErrUnsupported)
+	assert.True(t, Is(joined, sentinel))
+	assert.True(t, Is(joined, ErrUnsupported))
+
+	err := fmt.Errorf("wrapped: %w", BadRequest("bad request"))
+	var target *kratoserrors.Error
+	require.True(t, As(err, &target))
+	assert.Equal(t, int32(http.StatusBadRequest), target.Code)
 }


### PR DESCRIPTION
## Summary
Align the `errors` module with the Kratos v3 error helper surface.

## Changes
- Expose Kratos v3 standard-library wrapper helpers through fries errors
- Add 429 Too Many Requests helpers and package-level sentinel value
- Add 412 Precondition Failed helpers and package-level sentinel value
- Cover wrapped status helpers, `As`, `Unwrap`, and `Join` behavior in tests

## Motivation
- Kratos v3 expands its errors package around standard-library wrapping and additional HTTP status helpers; fries v4 should expose the same behavior from its errors facade

## Testing
- `go test ./...` in `errors`
- `make lint/errors`
- `git diff --check`
