### PR TITLE
fix(transport): clarify server closed behavior

### DIFF
--- a/chi/server_test.go
+++ b/chi/server_test.go
@@ -72,6 +72,15 @@ func TestServerStartWritesToConfiguredLogger(t *testing.T) {
 	assert.Equal(t, "[go-chi] server listening on: invalid addr", handler.records[0].Message)
 }
 
+func TestServerStartReturnsServerClosed(t *testing.T) {
+	srv := NewServer(chi.NewRouter(), WithAddr("127.0.0.1:0"))
+	require.NoError(t, srv.server.Close())
+
+	err := srv.Start(t.Context())
+
+	require.ErrorIs(t, err, http.ErrServerClosed)
+}
+
 func TestServerStopWritesToConfiguredLogger(t *testing.T) {
 	handler := &recordingHandler{}
 	srv := NewServer(chi.NewRouter(), WithLogger(slog.New(handler)))

--- a/gin/server_test.go
+++ b/gin/server_test.go
@@ -94,6 +94,15 @@ func TestServerStartWritesToConfiguredLogger(t *testing.T) {
 	assert.Equal(t, "[GIN] server listening on: invalid addr", handler.records[0].Message)
 }
 
+func TestServerStartReturnsServerClosed(t *testing.T) {
+	srv := NewServer(gin.New(), WithAddr("127.0.0.1:0"))
+	require.NoError(t, srv.server.Close())
+
+	err := srv.Start(t.Context())
+
+	require.ErrorIs(t, err, http.ErrServerClosed)
+}
+
 func TestServerStopWritesToConfiguredLogger(t *testing.T) {
 	handler := &recordingHandler{}
 	srv := NewServer(gin.New(), WithLogger(slog.New(handler)))

--- a/http/server/README.md
+++ b/http/server/README.md
@@ -52,7 +52,7 @@ func main() {
 	)
 
 	app := kratos.New(
-		kratos.Server(srv),
+		kratos.Server(server.IgnoreServerClosed(srv)),
 	)
 
 	if err := app.Run(); err != nil {

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -2,7 +2,12 @@ module github.com/go-fries/fries/http/server/v4
 
 go 1.25.0
 
-require github.com/stretchr/testify v1.11.1
+replace github.com/go-fries/fries/contract/v4 => ../../contract
+
+require (
+	github.com/go-fries/fries/contract/v4 v4.0.0
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/http/server/ignore_closed.go
+++ b/http/server/ignore_closed.go
@@ -6,16 +6,24 @@ import (
 	"net/http"
 )
 
-// IgnoreServerClosed returns a [Server] that treats [http.ErrServerClosed] from Start as nil.
-func IgnoreServerClosed(srv Server) Server {
-	return ignoreClosed{srv: srv}
+// IgnoreServerClosed returns a server that treats [http.ErrServerClosed] from Start as nil.
+func IgnoreServerClosed(srv interface {
+	Start(context.Context) error
+	Stop(context.Context) error
+},
+) *IgnoreClosedServer {
+	return &IgnoreClosedServer{srv: srv}
 }
 
-type ignoreClosed struct {
-	srv Server
+// IgnoreClosedServer wraps a server and ignores [http.ErrServerClosed] returned by Start.
+type IgnoreClosedServer struct {
+	srv server
 }
 
-func (s ignoreClosed) Start(ctx context.Context) error {
+var _ server = (*IgnoreClosedServer)(nil)
+
+// Start starts the wrapped server and returns nil for [http.ErrServerClosed].
+func (s *IgnoreClosedServer) Start(ctx context.Context) error {
 	err := s.srv.Start(ctx)
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
@@ -23,6 +31,7 @@ func (s ignoreClosed) Start(ctx context.Context) error {
 	return err
 }
 
-func (s ignoreClosed) Stop(ctx context.Context) error {
+// Stop stops the wrapped server.
+func (s *IgnoreClosedServer) Stop(ctx context.Context) error {
 	return s.srv.Stop(ctx)
 }

--- a/http/server/ignore_closed.go
+++ b/http/server/ignore_closed.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+// IgnoreServerClosed returns a server that treats [http.ErrServerClosed] from Start as nil.
+func IgnoreServerClosed(srv server) server {
+	return ignoreClosed{srv: srv}
+}
+
+type ignoreClosed struct {
+	srv server
+}
+
+func (s ignoreClosed) Start(ctx context.Context) error {
+	err := s.srv.Start(ctx)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func (s ignoreClosed) Stop(ctx context.Context) error {
+	return s.srv.Stop(ctx)
+}

--- a/http/server/ignore_closed.go
+++ b/http/server/ignore_closed.go
@@ -6,22 +6,16 @@ import (
 	"net/http"
 )
 
-// IgnoreServerClosed returns a server that treats [http.ErrServerClosed] from Start as nil.
-func IgnoreServerClosed(srv interface {
-	Start(context.Context) error
-	Stop(context.Context) error
-},
-) IgnoreClosed {
-	return IgnoreClosed{srv: srv}
+// IgnoreServerClosed returns a [Server] that treats [http.ErrServerClosed] from Start as nil.
+func IgnoreServerClosed(srv Server) Server {
+	return ignoreClosed{srv: srv}
 }
 
-// IgnoreClosed wraps a server and ignores [http.ErrServerClosed] returned by Start.
-type IgnoreClosed struct {
-	srv server
+type ignoreClosed struct {
+	srv Server
 }
 
-// Start starts the wrapped server and returns nil for [http.ErrServerClosed].
-func (s IgnoreClosed) Start(ctx context.Context) error {
+func (s ignoreClosed) Start(ctx context.Context) error {
 	err := s.srv.Start(ctx)
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
@@ -29,7 +23,6 @@ func (s IgnoreClosed) Start(ctx context.Context) error {
 	return err
 }
 
-// Stop stops the wrapped server.
-func (s IgnoreClosed) Stop(ctx context.Context) error {
+func (s ignoreClosed) Stop(ctx context.Context) error {
 	return s.srv.Stop(ctx)
 }

--- a/http/server/ignore_closed.go
+++ b/http/server/ignore_closed.go
@@ -4,23 +4,21 @@ import (
 	"context"
 	"errors"
 	"net/http"
+
+	"github.com/go-fries/fries/contract/v4"
 )
 
 // IgnoreServerClosed returns a server that treats [http.ErrServerClosed] from Start as nil.
-func IgnoreServerClosed(srv interface {
-	Start(context.Context) error
-	Stop(context.Context) error
-},
-) *IgnoreClosedServer {
+func IgnoreServerClosed(srv contract.Server) *IgnoreClosedServer {
 	return &IgnoreClosedServer{srv: srv}
 }
 
 // IgnoreClosedServer wraps a server and ignores [http.ErrServerClosed] returned by Start.
 type IgnoreClosedServer struct {
-	srv server
+	srv contract.Server
 }
 
-var _ server = (*IgnoreClosedServer)(nil)
+var _ contract.Server = (*IgnoreClosedServer)(nil)
 
 // Start starts the wrapped server and returns nil for [http.ErrServerClosed].
 func (s *IgnoreClosedServer) Start(ctx context.Context) error {

--- a/http/server/ignore_closed.go
+++ b/http/server/ignore_closed.go
@@ -7,15 +7,21 @@ import (
 )
 
 // IgnoreServerClosed returns a server that treats [http.ErrServerClosed] from Start as nil.
-func IgnoreServerClosed(srv server) server {
-	return ignoreClosed{srv: srv}
+func IgnoreServerClosed(srv interface {
+	Start(context.Context) error
+	Stop(context.Context) error
+},
+) IgnoreClosed {
+	return IgnoreClosed{srv: srv}
 }
 
-type ignoreClosed struct {
+// IgnoreClosed wraps a server and ignores [http.ErrServerClosed] returned by Start.
+type IgnoreClosed struct {
 	srv server
 }
 
-func (s ignoreClosed) Start(ctx context.Context) error {
+// Start starts the wrapped server and returns nil for [http.ErrServerClosed].
+func (s IgnoreClosed) Start(ctx context.Context) error {
 	err := s.srv.Start(ctx)
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
@@ -23,6 +29,7 @@ func (s ignoreClosed) Start(ctx context.Context) error {
 	return err
 }
 
-func (s ignoreClosed) Stop(ctx context.Context) error {
+// Stop stops the wrapped server.
+func (s IgnoreClosed) Stop(ctx context.Context) error {
 	return s.srv.Stop(ctx)
 }

--- a/http/server/ignore_closed_test.go
+++ b/http/server/ignore_closed_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnoreServerClosedSuppressesHTTPServerClosed(t *testing.T) {
+	srv := &fakeServer{startErr: http.ErrServerClosed}
+
+	err := IgnoreServerClosed(srv).Start(t.Context())
+
+	require.NoError(t, err)
+}
+
+func TestIgnoreServerClosedPreservesOtherStartErrors(t *testing.T) {
+	startErr := errors.New("listen failed")
+	srv := &fakeServer{startErr: startErr}
+
+	err := IgnoreServerClosed(srv).Start(t.Context())
+
+	require.ErrorIs(t, err, startErr)
+}
+
+func TestIgnoreServerClosedDelegatesStop(t *testing.T) {
+	stopErr := errors.New("stop failed")
+	srv := &fakeServer{stopErr: stopErr}
+
+	err := IgnoreServerClosed(srv).Stop(t.Context())
+
+	require.ErrorIs(t, err, stopErr)
+	require.True(t, srv.stopped)
+}
+
+type fakeServer struct {
+	startErr error
+	stopErr  error
+	stopped  bool
+}
+
+func (s *fakeServer) Start(context.Context) error {
+	return s.startErr
+}
+
+func (s *fakeServer) Stop(context.Context) error {
+	s.stopped = true
+	return s.stopErr
+}

--- a/http/server/ignore_closed_test.go
+++ b/http/server/ignore_closed_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestIgnoreServerClosedSuppressesHTTPServerClosed(t *testing.T) {
 	srv := &fakeServer{startErr: http.ErrServerClosed}
+	wrapped := server.IgnoreServerClosed(srv)
+	require.IsType(t, &server.IgnoreClosedServer{}, wrapped)
 
-	err := server.IgnoreServerClosed(srv).Start(t.Context())
+	err := wrapped.Start(t.Context())
 
 	require.NoError(t, err)
 }

--- a/http/server/ignore_closed_test.go
+++ b/http/server/ignore_closed_test.go
@@ -1,4 +1,4 @@
-package server
+package server_test
 
 import (
 	"context"
@@ -6,13 +6,14 @@ import (
 	"net/http"
 	"testing"
 
+	server "github.com/go-fries/fries/http/server/v4"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIgnoreServerClosedSuppressesHTTPServerClosed(t *testing.T) {
 	srv := &fakeServer{startErr: http.ErrServerClosed}
 
-	err := IgnoreServerClosed(srv).Start(t.Context())
+	err := server.IgnoreServerClosed(srv).Start(t.Context())
 
 	require.NoError(t, err)
 }
@@ -21,7 +22,7 @@ func TestIgnoreServerClosedPreservesOtherStartErrors(t *testing.T) {
 	startErr := errors.New("listen failed")
 	srv := &fakeServer{startErr: startErr}
 
-	err := IgnoreServerClosed(srv).Start(t.Context())
+	err := server.IgnoreServerClosed(srv).Start(t.Context())
 
 	require.ErrorIs(t, err, startErr)
 }
@@ -30,7 +31,7 @@ func TestIgnoreServerClosedDelegatesStop(t *testing.T) {
 	stopErr := errors.New("stop failed")
 	srv := &fakeServer{stopErr: stopErr}
 
-	err := IgnoreServerClosed(srv).Stop(t.Context())
+	err := server.IgnoreServerClosed(srv).Stop(t.Context())
 
 	require.ErrorIs(t, err, stopErr)
 	require.True(t, srv.stopped)

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -6,20 +6,21 @@ import (
 	"net/http"
 )
 
-type Server struct {
+// Server represents a startable and stoppable HTTP server.
+type Server interface {
+	Start(context.Context) error
+	Stop(context.Context) error
+}
+
+var _ Server = (*HTTPServer)(nil)
+
+type HTTPServer struct {
 	name   string
 	server *http.Server
 	logger *slog.Logger
 }
 
-type server interface {
-	Start(context.Context) error
-	Stop(context.Context) error
-}
-
-var _ server = (*Server)(nil)
-
-func New(srv *http.Server, opts ...Option) *Server {
+func New(srv *http.Server, opts ...Option) *HTTPServer {
 	cfg := newConfig(opts...)
 	if srv == nil {
 		srv = &http.Server{}
@@ -28,7 +29,7 @@ func New(srv *http.Server, opts ...Option) *Server {
 		srv.Addr = cfg.addr
 	}
 
-	s := &Server{
+	s := &HTTPServer{
 		name:   cfg.name,
 		server: srv,
 		logger: cfg.logger,
@@ -36,7 +37,7 @@ func New(srv *http.Server, opts ...Option) *Server {
 	return s
 }
 
-func NewWithHandler(handler http.Handler, opts ...Option) *Server {
+func NewWithHandler(handler http.Handler, opts ...Option) *HTTPServer {
 	srv := &http.Server{
 		Handler: handler,
 		Addr:    ":8080",
@@ -45,12 +46,12 @@ func NewWithHandler(handler http.Handler, opts ...Option) *Server {
 	return New(srv, opts...)
 }
 
-func (s *Server) Start(ctx context.Context) error {
+func (s *HTTPServer) Start(ctx context.Context) error {
 	s.logger.InfoContext(ctx, "["+s.name+"] server listening on: "+s.server.Addr)
 	return s.server.ListenAndServe()
 }
 
-func (s *Server) Stop(ctx context.Context) error {
+func (s *HTTPServer) Stop(ctx context.Context) error {
 	s.logger.InfoContext(ctx, "["+s.name+"] server stopping")
 	return s.server.Shutdown(ctx)
 }

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -6,21 +6,21 @@ import (
 	"net/http"
 )
 
-// Server represents a startable and stoppable HTTP server.
-type Server interface {
-	Start(context.Context) error
-	Stop(context.Context) error
-}
-
-var _ Server = (*server)(nil)
-
-type server struct {
+// Server wraps a standard library HTTP server with Start and Stop methods.
+type Server struct {
 	name   string
 	server *http.Server
 	logger *slog.Logger
 }
 
-func New(srv *http.Server, opts ...Option) Server {
+type server interface {
+	Start(context.Context) error
+	Stop(context.Context) error
+}
+
+var _ server = (*Server)(nil)
+
+func New(srv *http.Server, opts ...Option) *Server {
 	cfg := newConfig(opts...)
 	if srv == nil {
 		srv = &http.Server{}
@@ -29,7 +29,7 @@ func New(srv *http.Server, opts ...Option) Server {
 		srv.Addr = cfg.addr
 	}
 
-	s := &server{
+	s := &Server{
 		name:   cfg.name,
 		server: srv,
 		logger: cfg.logger,
@@ -37,7 +37,7 @@ func New(srv *http.Server, opts ...Option) Server {
 	return s
 }
 
-func NewWithHandler(handler http.Handler, opts ...Option) Server {
+func NewWithHandler(handler http.Handler, opts ...Option) *Server {
 	srv := &http.Server{
 		Handler: handler,
 		Addr:    ":8080",
@@ -46,12 +46,12 @@ func NewWithHandler(handler http.Handler, opts ...Option) Server {
 	return New(srv, opts...)
 }
 
-func (s *server) Start(ctx context.Context) error {
+func (s *Server) Start(ctx context.Context) error {
 	s.logger.InfoContext(ctx, "["+s.name+"] server listening on: "+s.server.Addr)
 	return s.server.ListenAndServe()
 }
 
-func (s *server) Stop(ctx context.Context) error {
+func (s *Server) Stop(ctx context.Context) error {
 	s.logger.InfoContext(ctx, "["+s.name+"] server stopping")
 	return s.server.Shutdown(ctx)
 }

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -12,15 +12,15 @@ type Server interface {
 	Stop(context.Context) error
 }
 
-var _ Server = (*HTTPServer)(nil)
+var _ Server = (*server)(nil)
 
-type HTTPServer struct {
+type server struct {
 	name   string
 	server *http.Server
 	logger *slog.Logger
 }
 
-func New(srv *http.Server, opts ...Option) *HTTPServer {
+func New(srv *http.Server, opts ...Option) Server {
 	cfg := newConfig(opts...)
 	if srv == nil {
 		srv = &http.Server{}
@@ -29,7 +29,7 @@ func New(srv *http.Server, opts ...Option) *HTTPServer {
 		srv.Addr = cfg.addr
 	}
 
-	s := &HTTPServer{
+	s := &server{
 		name:   cfg.name,
 		server: srv,
 		logger: cfg.logger,
@@ -37,7 +37,7 @@ func New(srv *http.Server, opts ...Option) *HTTPServer {
 	return s
 }
 
-func NewWithHandler(handler http.Handler, opts ...Option) *HTTPServer {
+func NewWithHandler(handler http.Handler, opts ...Option) Server {
 	srv := &http.Server{
 		Handler: handler,
 		Addr:    ":8080",
@@ -46,12 +46,12 @@ func NewWithHandler(handler http.Handler, opts ...Option) *HTTPServer {
 	return New(srv, opts...)
 }
 
-func (s *HTTPServer) Start(ctx context.Context) error {
+func (s *server) Start(ctx context.Context) error {
 	s.logger.InfoContext(ctx, "["+s.name+"] server listening on: "+s.server.Addr)
 	return s.server.ListenAndServe()
 }
 
-func (s *HTTPServer) Stop(ctx context.Context) error {
+func (s *server) Stop(ctx context.Context) error {
 	s.logger.InfoContext(ctx, "["+s.name+"] server stopping")
 	return s.server.Shutdown(ctx)
 }

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+
+	"github.com/go-fries/fries/contract/v4"
 )
 
 // Server wraps a standard library HTTP server with Start and Stop methods.
@@ -13,12 +15,7 @@ type Server struct {
 	logger *slog.Logger
 }
 
-type server interface {
-	Start(context.Context) error
-	Stop(context.Context) error
-}
-
-var _ server = (*Server)(nil)
+var _ contract.Server = (*Server)(nil)
 
 func New(srv *http.Server, opts ...Option) *Server {
 	cfg := newConfig(opts...)

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServerDoesNotExposeHTTPServer(t *testing.T) {
-	serverType := reflect.TypeFor[Server]()
+	serverType := reflect.TypeFor[HTTPServer]()
 	httpServerType := reflect.TypeFor[*http.Server]()
 
 	for i := range serverType.NumField() {

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServerDoesNotExposeHTTPServer(t *testing.T) {
-	serverType := reflect.TypeFor[server]()
+	serverType := reflect.TypeFor[Server]()
 	httpServerType := reflect.TypeFor[*http.Server]()
 
 	for i := range serverType.NumField() {
@@ -22,8 +22,8 @@ func TestServerDoesNotExposeHTTPServer(t *testing.T) {
 	}
 }
 
-func TestNewReturnsServerInterface(t *testing.T) {
-	requireServer(t, New(&http.Server{}))
+func TestNewReturnsServer(t *testing.T) {
+	require.IsType(t, &Server{}, New(&http.Server{}))
 }
 
 func TestNewUsesConfiguredHTTPServer(t *testing.T) {
@@ -50,18 +50,16 @@ func TestNewWithHandlerBuildsHTTPServer(t *testing.T) {
 	srv := NewWithHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("hello world"))
 	}), WithAddr(":8082"))
-	httpServer, ok := srv.(*server)
-	require.True(t, ok)
 
 	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
-	httpServer.server.Handler.ServeHTTP(recorder, req)
+	srv.server.Handler.ServeHTTP(recorder, req)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, "hello world", recorder.Body.String())
-	assert.Equal(t, ":8082", httpServer.server.Addr)
+	assert.Equal(t, ":8082", srv.server.Addr)
 }
 
 func TestNewDefaultsToSlogDefaultLogger(t *testing.T) {
@@ -115,18 +113,10 @@ func TestServerStopWritesToConfiguredLogger(t *testing.T) {
 	assert.Equal(t, "[HTTP] server stopping", handler.records[0].Message)
 }
 
-func newTestServer(t *testing.T, srv *http.Server, opts ...Option) *server {
+func newTestServer(t *testing.T, srv *http.Server, opts ...Option) *Server {
 	t.Helper()
 
-	httpServer, ok := New(srv, opts...).(*server)
-	require.True(t, ok)
-	return httpServer
-}
-
-func requireServer(t *testing.T, srv Server) {
-	t.Helper()
-
-	require.NotNil(t, srv)
+	return New(srv, opts...)
 }
 
 type recordingHandler struct {

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServerDoesNotExposeHTTPServer(t *testing.T) {
-	serverType := reflect.TypeFor[HTTPServer]()
+	serverType := reflect.TypeFor[server]()
 	httpServerType := reflect.TypeFor[*http.Server]()
 
 	for i := range serverType.NumField() {
@@ -22,8 +22,12 @@ func TestServerDoesNotExposeHTTPServer(t *testing.T) {
 	}
 }
 
+func TestNewReturnsServerInterface(t *testing.T) {
+	requireServer(t, New(&http.Server{}))
+}
+
 func TestNewUsesConfiguredHTTPServer(t *testing.T) {
-	srv := New(&http.Server{
+	srv := newTestServer(t, &http.Server{
 		Addr: ":8081",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "server", r.URL.Query().Get("name"))
@@ -46,16 +50,18 @@ func TestNewWithHandlerBuildsHTTPServer(t *testing.T) {
 	srv := NewWithHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("hello world"))
 	}), WithAddr(":8082"))
+	httpServer, ok := srv.(*server)
+	require.True(t, ok)
 
 	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	require.NoError(t, err)
 
 	recorder := httptest.NewRecorder()
-	srv.server.Handler.ServeHTTP(recorder, req)
+	httpServer.server.Handler.ServeHTTP(recorder, req)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, "hello world", recorder.Body.String())
-	assert.Equal(t, ":8082", srv.server.Addr)
+	assert.Equal(t, ":8082", httpServer.server.Addr)
 }
 
 func TestNewDefaultsToSlogDefaultLogger(t *testing.T) {
@@ -64,14 +70,14 @@ func TestNewDefaultsToSlogDefaultLogger(t *testing.T) {
 	slog.SetDefault(logger)
 	defer slog.SetDefault(previous)
 
-	srv := New(&http.Server{}, WithLogger(nil))
+	srv := newTestServer(t, &http.Server{}, WithLogger(nil))
 
 	assert.Same(t, logger, srv.logger)
 }
 
 func TestWithLoggerConfiguresServerLogger(t *testing.T) {
 	logger := slog.New(&recordingHandler{})
-	srv := New(&http.Server{}, WithLogger(logger))
+	srv := newTestServer(t, &http.Server{}, WithLogger(logger))
 
 	assert.Same(t, logger, srv.logger)
 }
@@ -89,7 +95,7 @@ func TestServerStartWritesToConfiguredLogger(t *testing.T) {
 }
 
 func TestServerStartReturnsServerClosed(t *testing.T) {
-	srv := New(&http.Server{Addr: "127.0.0.1:0"})
+	srv := newTestServer(t, &http.Server{Addr: "127.0.0.1:0"})
 	require.NoError(t, srv.server.Close())
 
 	err := srv.Start(t.Context())
@@ -107,6 +113,20 @@ func TestServerStopWritesToConfiguredLogger(t *testing.T) {
 	require.Len(t, handler.records, 1)
 	assert.Equal(t, slog.LevelInfo, handler.records[0].Level)
 	assert.Equal(t, "[HTTP] server stopping", handler.records[0].Message)
+}
+
+func newTestServer(t *testing.T, srv *http.Server, opts ...Option) *server {
+	t.Helper()
+
+	httpServer, ok := New(srv, opts...).(*server)
+	require.True(t, ok)
+	return httpServer
+}
+
+func requireServer(t *testing.T, srv Server) {
+	t.Helper()
+
+	require.NotNil(t, srv)
 }
 
 type recordingHandler struct {

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -88,6 +88,15 @@ func TestServerStartWritesToConfiguredLogger(t *testing.T) {
 	assert.Equal(t, "[HTTP] server listening on: invalid addr", handler.records[0].Message)
 }
 
+func TestServerStartReturnsServerClosed(t *testing.T) {
+	srv := New(&http.Server{Addr: "127.0.0.1:0"})
+	require.NoError(t, srv.server.Close())
+
+	err := srv.Start(t.Context())
+
+	require.ErrorIs(t, err, http.ErrServerClosed)
+}
+
 func TestServerStopWritesToConfiguredLogger(t *testing.T) {
 	handler := &recordingHandler{}
 	srv := New(&http.Server{}, WithLogger(slog.New(handler)))

--- a/signal/server_test.go
+++ b/signal/server_test.go
@@ -100,7 +100,7 @@ func TestServer_ServeDispatchesAsyncHandlers(t *testing.T) {
 		assert.NoError(t, err)
 	case <-time.After(time.Second):
 		close(release)
-		t.Fatal("server did not stop while async handler was running")
+		require.FailNow(t, "server did not stop while async handler was running")
 	}
 	close(release)
 }
@@ -267,7 +267,7 @@ func TestServer_StartStopsPromptly(t *testing.T) {
 	case err := <-done:
 		assert.NoError(t, err)
 	case <-time.After(time.Second):
-		t.Fatal("server did not stop")
+		require.FailNow(t, "server did not stop")
 	}
 }
 
@@ -278,7 +278,7 @@ func receive[T any](t *testing.T, ch <-chan T) T {
 	case value := <-ch:
 		return value
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for channel receive")
+		require.FailNow(t, "timed out waiting for channel receive")
 		var zero T
 		return zero
 	}


### PR DESCRIPTION
## Summary
Clarify server closed lifecycle behavior for HTTP transport wrappers while keeping raw net/http shutdown errors as the default.

## Changes
- Add `http/server.IgnoreServerClosed` for callers that want `http.ErrServerClosed` treated as a normal stop
- Keep `http/server`, `chi`, and `gin` `Start` behavior returning `http.ErrServerClosed` by default and cover that with tests
- Update the `http/server` Kratos example to wrap the server explicitly
- Replace remaining raw `t.Fatal` calls in `signal` server tests with testify assertions

## Motivation
- Support both direct use with raw `net/http` semantics and Kratos-compatible lifecycle usage without changing the default server behavior

## Testing
- `go test ./...` in `http/server`, `chi`, `gin`, `signal`, and `udp`
- `make lint/http/server`
- `make lint/chi`
- `make lint/gin`
- `make lint/signal`
- `make lint/udp`
- `git diff --check`
