### PR TITLE
fix(otel): align kratos v3 telemetry behavior

### DIFF
--- a/kratos/middleware/otel/README.md
+++ b/kratos/middleware/otel/README.md
@@ -35,7 +35,7 @@ func main() {
 				http.Address(":8001"),
 				http.Middleware(kratosotel.Server(
 					kratosotel.WithTracerProvider(tracerProvider),
-					kratosotel.WithSchemaURL("https://opentelemetry.io/schemas/1.37.0"),
+					kratosotel.WithSchemaURL("https://opentelemetry.io/schemas/1.41.0"),
 					kratosotel.WithAttributes(attribute.String("component", "kratos")),
 				)),
 			),
@@ -51,6 +51,12 @@ func main() {
 The instrumentation scope name is fixed to this package path. Use
 `WithVersion`, `WithSchemaURL`, and `WithAttributes` to configure the
 OpenTelemetry instrumentation scope metadata.
+
+The middleware emits traces only. It does not create metrics instruments, so
+histogram naming rules such as `_bucket` suffix handling are outside this
+package. For `log/slog` to OpenTelemetry log records, use the official
+`go.opentelemetry.io/contrib/bridges/otelslog` package instead of this
+middleware.
 
 ## License
 

--- a/kratos/middleware/otel/middleware_test.go
+++ b/kratos/middleware/otel/middleware_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/propagation"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	otelsemconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var _ transport.Transporter = (*mockTransport)(nil)
@@ -167,6 +170,32 @@ func TestServer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, childSpanID)
 	assert.Empty(t, childTraceID)
+}
+
+func TestServerAddsPeerServiceFromMetadataCarrier(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder))
+
+	tr := &mockTransport{
+		kind:      transport.KindHTTP,
+		operation: "/test.server/hello",
+		header: headerCarrier{
+			"X-Md-Service-Name": []string{"caller-service"},
+		},
+	}
+	next := func(_ context.Context, req any) (any, error) {
+		return req, nil
+	}
+
+	_, err := Server(WithTracerProvider(provider))(next)(
+		transport.NewServerContext(t.Context(), tr),
+		&emptypb.Empty{},
+	)
+
+	require.NoError(t, err)
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Contains(t, ended[0].Attributes(), otelsemconv.ServicePeerName("caller-service"))
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
## Summary
Align the Kratos OpenTelemetry middleware notes and tests with the Kratos v3 telemetry review items.

## Changes
- Add coverage that the default metadata propagator maps `x-md-service-name` into the server span `service.peer.name` attribute
- Update the README schema URL example to the semconv version used by the module
- Document that this middleware emits traces only and does not own metrics histogram or `log/slog` to OTel log bridging behavior

## Motivation
- Kratos v3 changed its logging and telemetry surface, so this module should clearly document which OTel behavior it owns and lock the metadata-to-semconv path with a focused test

## Testing
- `go test ./...` in `kratos/middleware/otel`
- `make lint/kratos/middleware/otel`
- `git diff --check`
