### PR TITLE
refactor(capability)!: rename contract module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v4` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `foundation/`, `event/`, `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, and `chi/`. Runnable samples and integration demos are under `examples/`. Protobuf contracts live in `contract/`, with root Buf configuration in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
+This is a multi-module Go repository. The root module is `github.com/go-fries/fries/v4` in `./go.mod`, and many component directories have their own `go.mod` files. Common packages live in top-level folders such as `foundation/`, `event/`, `cache/`, `codec/`, `env/`, `http/`, `redis/`, `mysql/`, `otel/`, `kratos/`, `gin/`, `chi/`, and `capability/`. Runnable samples and integration demos are under `examples/`. Root Buf configuration lives in `buf.yaml` and `buf.gen.yaml`. Developer tools are pinned in `internal/tools/`.
 
 Project working notes live under `.docs/`. Use `.docs/plans/` for task plans, phased checklists, and execution notes that coordinate longer work. The `.docs/plans/` directory is tracked, but individual plan files are local-only and should stay ignored. Use `.docs/memories/` for reusable project context that should survive across long-running tasks.
 

--- a/capability/asyncable.go
+++ b/capability/asyncable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Asyncable interface {
 	Async() bool

--- a/capability/countable.go
+++ b/capability/countable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Countable interface {
 	Count() int

--- a/capability/go.mod
+++ b/capability/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-fries/fries/capability/v4
+
+go 1.25.0

--- a/capability/htmlable.go
+++ b/capability/htmlable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Htmlable interface {
 	Html() string

--- a/capability/jsonable.go
+++ b/capability/jsonable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Jsonable interface {
 	Json() string

--- a/capability/nameable.go
+++ b/capability/nameable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Nameable interface {
 	Name() string

--- a/capability/renderable.go
+++ b/capability/renderable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Renderable interface {
 	Render() string

--- a/capability/retriable.go
+++ b/capability/retriable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Retriable interface {
 	Retries() int

--- a/capability/server.go
+++ b/capability/server.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 import "context"
 

--- a/capability/stringable.go
+++ b/capability/stringable.go
@@ -1,4 +1,4 @@
-package contract
+package capability
 
 type Stringable interface {
 	String() string

--- a/codecov.yml
+++ b/codecov.yml
@@ -35,7 +35,7 @@ fixes:
   - github.com/go-fries/fries/codec/yaml/v4::codec/yaml/
   - github.com/go-fries/fries/config/v4::config/
   - github.com/go-fries/fries/constraints/v4::constraints/
-  - github.com/go-fries/fries/contract/v4::contract/
+  - github.com/go-fries/fries/capability/v4::capability/
   - github.com/go-fries/fries/coroutines/v4::coroutines/
   - github.com/go-fries/fries/crontab/v4::crontab/
   - github.com/go-fries/fries/encrypter/v4::encrypter/

--- a/contract/go.mod
+++ b/contract/go.mod
@@ -1,3 +1,0 @@
-module github.com/go-fries/fries/contract/v4
-
-go 1.25.0

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -2,10 +2,10 @@ module github.com/go-fries/fries/http/server/v4
 
 go 1.25.0
 
-replace github.com/go-fries/fries/contract/v4 => ../../contract
+replace github.com/go-fries/fries/capability/v4 => ../../capability
 
 require (
-	github.com/go-fries/fries/contract/v4 v4.0.0
+	github.com/go-fries/fries/capability/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/http/server/ignore_closed.go
+++ b/http/server/ignore_closed.go
@@ -5,20 +5,20 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/go-fries/fries/contract/v4"
+	"github.com/go-fries/fries/capability/v4"
 )
 
 // IgnoreServerClosed returns a server that treats [http.ErrServerClosed] from Start as nil.
-func IgnoreServerClosed(srv contract.Server) *IgnoreClosedServer {
+func IgnoreServerClosed(srv capability.Server) *IgnoreClosedServer {
 	return &IgnoreClosedServer{srv: srv}
 }
 
 // IgnoreClosedServer wraps a server and ignores [http.ErrServerClosed] returned by Start.
 type IgnoreClosedServer struct {
-	srv contract.Server
+	srv capability.Server
 }
 
-var _ contract.Server = (*IgnoreClosedServer)(nil)
+var _ capability.Server = (*IgnoreClosedServer)(nil)
 
 // Start starts the wrapped server and returns nil for [http.ErrServerClosed].
 func (s *IgnoreClosedServer) Start(ctx context.Context) error {

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/go-fries/fries/contract/v4"
+	"github.com/go-fries/fries/capability/v4"
 )
 
 // Server wraps a standard library HTTP server with Start and Stop methods.
@@ -15,7 +15,7 @@ type Server struct {
 	logger *slog.Logger
 }
 
-var _ contract.Server = (*Server)(nil)
+var _ capability.Server = (*Server)(nil)
 
 func New(srv *http.Server, opts ...Option) *Server {
 	cfg := newConfig(opts...)

--- a/versions.yaml
+++ b/versions.yaml
@@ -6,7 +6,7 @@ module-sets:
       - github.com/go-fries/fries/errors/v4
       - github.com/go-fries/fries/coroutines/v4
       - github.com/go-fries/fries/constraints/v4
-      - github.com/go-fries/fries/contract/v4
+      - github.com/go-fries/fries/capability/v4
 
       # Cache
       - github.com/go-fries/fries/cache/v4


### PR DESCRIPTION
## Summary
Rename the shared interface module from `contract` to `capability` for 4.x, matching the intent that these are reusable capabilities rather than API contracts.

## Changes
- Move `contract` module contents to `capability` and update the package/module path
- Update `http/server` to depend on `capability.Server`
- Update release/module metadata in `versions.yaml`, `codecov.yml`, and repository guidance

## Breaking Changes
- `github.com/go-fries/fries/contract/v4` is replaced by `github.com/go-fries/fries/capability/v4`

## Motivation
- Keep common interface naming broader than server lifecycle contracts and leave room for other reusable capability-style interfaces

## Testing
- `go test ./...` in `capability`
- `go test ./...` in `http/server`
- `make lint/capability`
- `make lint/http/server`
- `git diff --check`