### PR TITLE
refactor(filesystem)!: redesign storage API

### DIFF
--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -1,12 +1,25 @@
 # Filesystem
 
-A unified filesystem abstraction layer for Go, supporting Local, S3, and OSS storage drivers.
+Filesystem provides a common logical-path storage contract for local files,
+Amazon S3, and Alibaba Cloud OSS.
+
+The base `Driver` API supports streaming reads and writes, deletion, metadata,
+and paginated listing. Backend-specific features such as hard links, symbolic
+links, and real directory management are exposed through optional capability
+interfaces.
 
 ## Installation
 
 ```bash
 go get github.com/go-fries/fries/filesystem/v4
+go get github.com/go-fries/fries/filesystem/local/v4
 ```
+
+## Logical paths
+
+Paths are relative and slash-separated. Use `.` for the logical root. Leading
+slashes, trailing slashes, empty path elements, `.`, `..`, and backslashes are
+rejected.
 
 ## Usage
 
@@ -25,32 +38,48 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// Initialize the Local driver
-	// You can also use s3.NewStorage(...) or oss.NewStorage(...)
-	store := local.NewStorage("./storage")
-
-	// Create the repository
-	fs := filesystem.NewRepository(store)
-
-	// Write a file
-	if err := fs.Put(ctx, "example.txt", []byte("Hello, Filesystem!")); err != nil {
-		log.Fatal(err)
-	}
-
-	// Read a file
-	content, err := fs.Get(ctx, "example.txt")
+	driver, err := local.New("./storage")
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("File Content: %s\n", content)
+	storage := filesystem.NewRepository(driver)
 
-	// Check if file exists
-	exists, _ := fs.Has(ctx, "example.txt")
+	if err := storage.WriteFile(
+		ctx,
+		"example.txt",
+		[]byte("Hello, Filesystem!"),
+		filesystem.PutOptions{},
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	content, err := storage.ReadFile(ctx, "example.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("File content: %s\n", content)
+
+	exists, err := storage.Exists(ctx, "example.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
 	fmt.Printf("Exists: %v\n", exists)
-
-	// Delete the file
-	// if err := fs.Destroy(ctx, "example.txt"); err != nil {
-	// 	log.Fatal(err)
-	// }
 }
 ```
+
+Amazon S3 and Alibaba Cloud OSS drivers are created with `s3.New(...)` and
+`oss.New(...)`. Both accept `WithRoot(...)` to place logical paths below a
+bucket prefix.
+
+## Optional capabilities
+
+Drivers may additionally implement:
+
+- `filesystem.Copier`
+- `filesystem.Mover`
+- `filesystem.Linker`
+- `filesystem.Symlinker`
+- `filesystem.DirectoryManager`
+
+`Repository.Copy` and `Repository.Move` prefer native driver capabilities and
+fall back to portable streaming operations when those capabilities are absent.

--- a/filesystem/README.md
+++ b/filesystem/README.md
@@ -1,25 +1,24 @@
 # Filesystem
 
-Filesystem provides a common logical-path storage contract for local files,
-Amazon S3, and Alibaba Cloud OSS.
+Filesystem provides a common storage API for local filesystems, Amazon S3, and
+Alibaba Cloud OSS. It uses logical paths relative to a configured root and
+supports streaming reads and writes, metadata, deletion, and paginated file
+listing.
 
-The base `Driver` API supports streaming reads and writes, deletion, metadata,
-and paginated listing. Backend-specific features such as hard links, symbolic
-links, and real directory management are exposed through optional capability
-interfaces.
+The component is split into a core module and backend modules:
+
+- [`filesystem/local`](./local) stores files below a local directory.
+- [`filesystem/s3`](./s3) stores objects in Amazon S3.
+- [`filesystem/oss`](./oss) stores objects in Alibaba Cloud OSS.
 
 ## Installation
+
+Install the core module and the backend you need:
 
 ```bash
 go get github.com/go-fries/fries/filesystem/v4
 go get github.com/go-fries/fries/filesystem/local/v4
 ```
-
-## Logical paths
-
-Paths are relative and slash-separated. Use `.` for the logical root. Leading
-slashes, trailing slashes, empty path elements, `.`, `..`, and backslashes are
-rejected.
 
 ## Usage
 
@@ -30,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/go-fries/fries/filesystem/local/v4"
 	"github.com/go-fries/fries/filesystem/v4"
@@ -38,18 +38,22 @@ import (
 func main() {
 	ctx := context.Background()
 
+	if err := os.MkdirAll("./storage", 0o755); err != nil {
+		log.Fatal(err)
+	}
 	driver, err := local.New("./storage")
 	if err != nil {
 		log.Fatal(err)
 	}
 	storage := filesystem.NewRepository(driver)
 
-	if err := storage.WriteFile(
+	err = storage.WriteFile(
 		ctx,
 		"example.txt",
 		[]byte("Hello, Filesystem!"),
 		filesystem.PutOptions{},
-	); err != nil {
+	)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -57,29 +61,35 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("File content: %s\n", content)
+	fmt.Println(string(content))
 
-	exists, err := storage.Exists(ctx, "example.txt")
+	page, err := storage.ListFiles(ctx, ".", filesystem.ListOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Exists: %v\n", exists)
+	for _, entry := range page.Entries {
+		fmt.Printf("%s (%d bytes)\n", entry.Path, entry.Size)
+	}
+
+	if err := storage.Delete(ctx, "example.txt"); err != nil {
+		log.Fatal(err)
+	}
 }
 ```
 
-Amazon S3 and Alibaba Cloud OSS drivers are created with `s3.New(...)` and
-`oss.New(...)`. Both accept `WithRoot(...)` to place logical paths below a
-bucket prefix.
+## Basic behavior
 
-## Optional capabilities
+- Paths are relative and slash-separated. Use `.` for the logical root.
+- `Open`, `Put`, and `Delete` operate on files or objects.
+- `Delete` is idempotent; deleting a missing path returns `nil`.
+- `ListFiles` returns files and objects only. Set `Recursive` to include nested
+  paths and follow `NextCursor` until it is empty when reading multiple pages.
+- `Put` accepts an `io.Reader`. Common readers and files expose enough
+  information to infer their length; other streams must set
+  `PutOptions.ContentLength`.
 
-Drivers may additionally implement:
+`Repository` adds whole-file helpers, existence checks, and portable copy and
+move fallbacks. Drivers may also expose optional capabilities such as native
+copying, moving, links, symbolic links, and directory management.
 
-- `filesystem.Copier`
-- `filesystem.Mover`
-- `filesystem.Linker`
-- `filesystem.Symlinker`
-- `filesystem.DirectoryManager`
-
-`Repository.Copy` and `Repository.Move` prefer native driver capabilities and
-fall back to portable streaming operations when those capabilities are absent.
+See the backend README for setup and backend-specific behavior.

--- a/filesystem/doc.go
+++ b/filesystem/doc.go
@@ -1,0 +1,3 @@
+// Package filesystem defines a logical-path storage contract shared by local
+// filesystems and object-storage backends.
+package filesystem

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -16,7 +16,9 @@ var (
 	// should use errors.Is to test for it. Delete does not return ErrNotFound,
 	// because deletion is idempotent.
 	ErrNotFound = errors.New("filesystem: entry not found")
-	// ErrUnsupported indicates that an optional operation is not supported.
+	// ErrUnsupported indicates that an optional capability or driver-specific
+	// extension cannot perform an operation. It is reserved for optional and
+	// future APIs; the core Driver contract does not currently return it.
 	ErrUnsupported = errors.New("filesystem: operation not supported")
 )
 
@@ -59,18 +61,36 @@ type PutOptions struct {
 	Metadata    map[string]string
 }
 
+const (
+	// DefaultListLimit is the page size used when ListOptions.Limit is not set.
+	DefaultListLimit = 1000
+	// MaxListLimit is the largest page size accepted by List.
+	MaxListLimit = 1000
+)
+
 // ListOptions configures a List operation.
 type ListOptions struct {
 	// Recursive includes entries below nested directories or prefixes.
 	Recursive bool
 	// Kind filters entries by kind. EntryKindAny includes every kind.
 	Kind EntryKind
-	// Limit caps the number of entries returned. Values less than one use the
-	// backend default.
+	// Limit caps the number of entries returned. Values less than one use
+	// DefaultListLimit; values greater than MaxListLimit use MaxListLimit.
 	Limit int
 	// Cursor continues a previous listing. Cursors are opaque and scoped to a
 	// driver, path, and option set.
 	Cursor string
+}
+
+// Normalize returns a copy of o with the shared page-size rules applied.
+func (o ListOptions) Normalize() ListOptions {
+	switch {
+	case o.Limit < 1:
+		o.Limit = DefaultListLimit
+	case o.Limit > MaxListLimit:
+		o.Limit = MaxListLimit
+	}
+	return o
 }
 
 // ListPage is one page of a directory or prefix listing.
@@ -101,7 +121,8 @@ type Driver interface {
 	// List returns one page of entries below a directory or object prefix. Use
 	// "." to list the logical root. If path has no matching descendants,
 	// including when it does not exist or names a file, List returns an empty
-	// page and a nil error.
+	// page and a nil error. Entries are sorted by logical path within each page;
+	// ordering across pages follows the backend cursor and is not guaranteed.
 	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
 }
 

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -35,7 +35,9 @@ const (
 )
 
 // Entry describes a file, object, or directory returned by Stat or List.
-// Fields unsupported by a backend use their zero values.
+// Fields unsupported by a backend use their zero values. For directories, only
+// Path and Kind are portable across drivers; other fields may be zero or contain
+// backend-specific information and must not be required for portable behavior.
 type Entry struct {
 	Path         string
 	Kind         EntryKind

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -94,7 +94,9 @@ type Driver interface {
 	Delete(ctx context.Context, path string) error
 	// Stat returns metadata for a file or object. Stat(".") returns a synthetic
 	// directory entry for the logical root. If path does not exist, Stat returns
-	// an error wrapping ErrNotFound.
+	// an error wrapping ErrNotFound. Object-storage drivers may perform an
+	// additional prefix listing to distinguish a missing object from a virtual
+	// directory.
 	Stat(ctx context.Context, path string) (Entry, error)
 	// List returns one page of entries below a directory or object prefix. Use
 	// "." to list the logical root. If path has no matching descendants,

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -75,7 +75,8 @@ type ListOptions struct {
 	// Kind filters entries by kind. List only enumerates files, so
 	// EntryKindDirectory produces an empty page.
 	Kind EntryKind
-	// Limit caps the number of entries returned. Values less than one use
+	// Limit caps the number of entries returned. A page may contain fewer entries,
+	// including none, even when more pages remain. Values less than one use
 	// DefaultListLimit; values greater than MaxListLimit use MaxListLimit.
 	Limit int
 	// Cursor continues a previous listing. Cursors are opaque and scoped to a
@@ -96,7 +97,9 @@ func (o ListOptions) Normalize() ListOptions {
 
 // ListPage is one page of a directory or prefix listing.
 type ListPage struct {
-	Entries    []Entry
+	Entries []Entry
+	// NextCursor continues the listing. Only an empty NextCursor indicates that
+	// the listing is complete; Entries may be empty while NextCursor is non-empty.
 	NextCursor string
 }
 
@@ -124,8 +127,9 @@ type Driver interface {
 	// are not returned. Use "." to list the logical root. If path has no matching
 	// files, including when it does not exist or names a file, List returns an
 	// empty page and a nil error. Entries are sorted by logical path within each
-	// page; ordering across pages follows the backend cursor and is not
-	// guaranteed.
+	// page. A page may be empty while NextCursor is non-empty; callers must
+	// continue until NextCursor is empty. Ordering across pages follows the
+	// backend cursor and is not guaranteed.
 	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
 }
 

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -26,7 +26,7 @@ var (
 type EntryKind uint8
 
 const (
-	// EntryKindAny matches files and directories when used as a list filter.
+	// EntryKindAny does not restrict the entry kind when used as a list filter.
 	EntryKindAny EntryKind = iota
 	// EntryKindFile identifies a file or object.
 	EntryKindFile
@@ -70,9 +70,10 @@ const (
 
 // ListOptions configures a List operation.
 type ListOptions struct {
-	// Recursive includes entries below nested directories or prefixes.
+	// Recursive includes files below nested directories or prefixes.
 	Recursive bool
-	// Kind filters entries by kind. EntryKindAny includes every kind.
+	// Kind filters entries by kind. List only enumerates files, so
+	// EntryKindDirectory produces an empty page.
 	Kind EntryKind
 	// Limit caps the number of entries returned. Values less than one use
 	// DefaultListLimit; values greater than MaxListLimit use MaxListLimit.
@@ -118,11 +119,13 @@ type Driver interface {
 	// additional prefix listing to distinguish a missing object from a virtual
 	// directory.
 	Stat(ctx context.Context, path string) (Entry, error)
-	// List returns one page of entries below a directory or object prefix. Use
-	// "." to list the logical root. If path has no matching descendants,
-	// including when it does not exist or names a file, List returns an empty
-	// page and a nil error. Entries are sorted by logical path within each page;
-	// ordering across pages follows the backend cursor and is not guaranteed.
+	// List returns one page of files or objects below a directory or object
+	// prefix. Directories, virtual prefixes, and object-storage directory markers
+	// are not returned. Use "." to list the logical root. If path has no matching
+	// files, including when it does not exist or names a file, List returns an
+	// empty page and a nil error. Entries are sorted by logical path within each
+	// page; ordering across pages follows the backend cursor and is not
+	// guaranteed.
 	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
 }
 

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -68,8 +68,8 @@ func (e Entry) IsDir() bool {
 type PutOptions struct {
 	// ContentLength is the number of bytes remaining in the source reader. A nil
 	// value lets the driver infer the length from readers that expose Len() int or
-	// implement io.Seeker. It must be set for other readers. Zero is valid;
-	// negative values are rejected.
+	// implement io.Seeker. An explicit value must equal an inferred length. It
+	// must be set for other readers. Zero is valid; negative values are rejected.
 	ContentLength *int64
 	ContentType   string
 	Metadata      map[string]string
@@ -82,29 +82,48 @@ func (o PutOptions) ResolveContentLength(src io.Reader) (int64, error) {
 		if *o.ContentLength < 0 {
 			return 0, ErrInvalidContentLength
 		}
+	}
+
+	inferred, known, err := inferContentLength(src)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", ErrInvalidContentLength, err)
+	}
+	if o.ContentLength != nil {
+		if known && *o.ContentLength != inferred {
+			return 0, fmt.Errorf(
+				"%w: explicit value %d does not match inferred value %d",
+				ErrInvalidContentLength,
+				*o.ContentLength,
+				inferred,
+			)
+		}
 		return *o.ContentLength, nil
 	}
+	if known {
+		return inferred, nil
+	}
+	return 0, ErrContentLengthRequired
+}
+
+func inferContentLength(src io.Reader) (int64, bool, error) {
 	if src == nil {
-		return 0, nil
+		return 0, true, nil
 	}
 	if source, ok := src.(interface{ Len() int }); ok {
 		length := int64(source.Len())
 		if length < 0 {
-			return 0, ErrInvalidContentLength
+			return 0, true, ErrInvalidContentLength
 		}
-		return length, nil
+		return length, true, nil
 	}
 	if source, ok := src.(io.Seeker); ok {
 		length, err := remainingLength(source)
 		if err != nil {
-			if errors.Is(err, ErrInvalidContentLength) {
-				return 0, err
-			}
-			return 0, fmt.Errorf("%w: %v", ErrContentLengthRequired, err)
+			return 0, true, err
 		}
-		return length, nil
+		return length, true, nil
 	}
-	return 0, ErrContentLengthRequired
+	return 0, false, nil
 }
 
 func remainingLength(source io.Seeker) (int64, error) {

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -83,7 +83,8 @@ type Driver interface {
 	Open(ctx context.Context, path string) (io.ReadCloser, error)
 	// Put writes src to path, replacing an existing entry.
 	Put(ctx context.Context, path string, src io.Reader, options PutOptions) error
-	// Delete removes a file or object.
+	// Delete removes a file or object. Delete is idempotent: deleting a path
+	// that does not exist returns nil.
 	Delete(ctx context.Context, path string) error
 	// Stat returns metadata for a file or object.
 	Stat(ctx context.Context, path string) (Entry, error)

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"time"
 )
@@ -20,6 +21,12 @@ var (
 	// extension cannot perform an operation. It is reserved for optional and
 	// future APIs; the core Driver contract does not currently return it.
 	ErrUnsupported = errors.New("filesystem: operation not supported")
+	// ErrContentLengthRequired indicates that Put cannot determine the number of
+	// bytes remaining in src and PutOptions.ContentLength was not provided.
+	ErrContentLengthRequired = errors.New("filesystem: content length required")
+	// ErrInvalidContentLength indicates that PutOptions.ContentLength is negative
+	// or an inferred reader length is invalid.
+	ErrInvalidContentLength = errors.New("filesystem: invalid content length")
 )
 
 // EntryKind identifies the logical kind of a filesystem entry.
@@ -59,8 +66,64 @@ func (e Entry) IsDir() bool {
 
 // PutOptions configures a Put operation.
 type PutOptions struct {
-	ContentType string
-	Metadata    map[string]string
+	// ContentLength is the number of bytes remaining in the source reader. A nil
+	// value lets the driver infer the length from readers that expose Len() int or
+	// implement io.Seeker. It must be set for other readers. Zero is valid;
+	// negative values are rejected.
+	ContentLength *int64
+	ContentType   string
+	Metadata      map[string]string
+}
+
+// ResolveContentLength returns the explicit or inferred number of bytes
+// remaining in src.
+func (o PutOptions) ResolveContentLength(src io.Reader) (int64, error) {
+	if o.ContentLength != nil {
+		if *o.ContentLength < 0 {
+			return 0, ErrInvalidContentLength
+		}
+		return *o.ContentLength, nil
+	}
+	if src == nil {
+		return 0, nil
+	}
+	if source, ok := src.(interface{ Len() int }); ok {
+		length := int64(source.Len())
+		if length < 0 {
+			return 0, ErrInvalidContentLength
+		}
+		return length, nil
+	}
+	if source, ok := src.(io.Seeker); ok {
+		length, err := remainingLength(source)
+		if err != nil {
+			if errors.Is(err, ErrInvalidContentLength) {
+				return 0, err
+			}
+			return 0, fmt.Errorf("%w: %v", ErrContentLengthRequired, err)
+		}
+		return length, nil
+	}
+	return 0, ErrContentLengthRequired
+}
+
+func remainingLength(source io.Seeker) (int64, error) {
+	current, err := source.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, err
+	}
+	end, endErr := source.Seek(0, io.SeekEnd)
+	_, restoreErr := source.Seek(current, io.SeekStart)
+	if endErr != nil {
+		return 0, endErr
+	}
+	if restoreErr != nil {
+		return 0, restoreErr
+	}
+	if end < current {
+		return 0, ErrInvalidContentLength
+	}
+	return end - current, nil
 }
 
 const (
@@ -109,8 +172,10 @@ type Driver interface {
 	// The logical root "." is not a valid file or object path.
 	// If path does not exist, Open returns an error wrapping ErrNotFound.
 	Open(ctx context.Context, path string) (io.ReadCloser, error)
-	// Put writes src to path, replacing an existing entry. The logical root "."
-	// is not a valid file or object path.
+	// Put writes src to path, replacing an existing entry. ContentLength must be
+	// provided when it cannot be inferred from src; otherwise Put returns an error
+	// wrapping ErrContentLengthRequired. The logical root "." is not a valid file
+	// or object path.
 	Put(ctx context.Context, path string, src io.Reader, options PutOptions) error
 	// Delete removes a file or object. Delete is idempotent: deleting a path
 	// that does not exist returns nil. The logical root "." cannot be deleted.

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -83,17 +83,21 @@ type ListPage struct {
 // object-storage backends.
 type Driver interface {
 	// Open opens path for streaming reads. The caller must close the result.
+	// The logical root "." is not a valid file or object path.
 	// If path does not exist, Open returns an error wrapping ErrNotFound.
 	Open(ctx context.Context, path string) (io.ReadCloser, error)
-	// Put writes src to path, replacing an existing entry.
+	// Put writes src to path, replacing an existing entry. The logical root "."
+	// is not a valid file or object path.
 	Put(ctx context.Context, path string, src io.Reader, options PutOptions) error
 	// Delete removes a file or object. Delete is idempotent: deleting a path
-	// that does not exist returns nil.
+	// that does not exist returns nil. The logical root "." cannot be deleted.
 	Delete(ctx context.Context, path string) error
-	// Stat returns metadata for a file or object. If path does not exist, Stat
-	// returns an error wrapping ErrNotFound.
+	// Stat returns metadata for a file or object. Stat(".") returns a synthetic
+	// directory entry for the logical root. If path does not exist, Stat returns
+	// an error wrapping ErrNotFound.
 	Stat(ctx context.Context, path string) (Entry, error)
-	// List returns one page of entries below a directory or object prefix.
+	// List returns one page of entries below a directory or object prefix. Use
+	// "." to list the logical root.
 	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
 }
 

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -42,9 +42,10 @@ const (
 )
 
 // Entry describes a file, object, or directory returned by Stat or ListFiles.
-// Fields unsupported by a backend use their zero values. For directories, only
-// Path and Kind are portable across drivers; other fields may be zero or contain
-// backend-specific information and must not be required for portable behavior.
+// Path and Kind are portable across drivers. Size is the exact byte length for
+// files and objects. For directories and unknown entry kinds, Size and all other
+// fields may be zero or contain backend-specific information and must not be
+// required for portable behavior.
 type Entry struct {
 	Path         string
 	Kind         EntryKind

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -97,7 +97,9 @@ type Driver interface {
 	// an error wrapping ErrNotFound.
 	Stat(ctx context.Context, path string) (Entry, error)
 	// List returns one page of entries below a directory or object prefix. Use
-	// "." to list the logical root.
+	// "." to list the logical root. If path has no matching descendants,
+	// including when it does not exist or names a file, List returns an empty
+	// page and a nil error.
 	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
 }
 

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -26,15 +26,15 @@ var (
 type EntryKind uint8
 
 const (
-	// EntryKindAny does not restrict the entry kind when used as a list filter.
-	EntryKindAny EntryKind = iota
+	// EntryKindUnknown indicates that an entry's kind is not known.
+	EntryKindUnknown EntryKind = iota
 	// EntryKindFile identifies a file or object.
 	EntryKindFile
 	// EntryKindDirectory identifies a real or virtual directory.
 	EntryKindDirectory
 )
 
-// Entry describes a file, object, or directory returned by Stat or List.
+// Entry describes a file, object, or directory returned by Stat or ListFiles.
 // Fields unsupported by a backend use their zero values. For directories, only
 // Path and Kind are portable across drivers; other fields may be zero or contain
 // backend-specific information and must not be required for portable behavior.
@@ -66,17 +66,14 @@ type PutOptions struct {
 const (
 	// DefaultListLimit is the page size used when ListOptions.Limit is not set.
 	DefaultListLimit = 1000
-	// MaxListLimit is the largest page size accepted by List.
+	// MaxListLimit is the largest page size accepted by ListFiles.
 	MaxListLimit = 1000
 )
 
-// ListOptions configures a List operation.
+// ListOptions configures a ListFiles operation.
 type ListOptions struct {
 	// Recursive includes files below nested directories or prefixes.
 	Recursive bool
-	// Kind filters entries by kind. List only enumerates files, so
-	// EntryKindDirectory produces an empty page.
-	Kind EntryKind
 	// Limit caps the number of entries returned. A page may contain fewer entries,
 	// including none, even when more pages remain. Values less than one use
 	// DefaultListLimit; values greater than MaxListLimit use MaxListLimit.
@@ -97,7 +94,7 @@ func (o ListOptions) Normalize() ListOptions {
 	return o
 }
 
-// ListPage is one page of a directory or prefix listing.
+// ListPage is one page of a file or object listing.
 type ListPage struct {
 	Entries []Entry
 	// NextCursor continues the listing. Only an empty NextCursor indicates that
@@ -124,15 +121,15 @@ type Driver interface {
 	// additional prefix listing to distinguish a missing object from a virtual
 	// directory.
 	Stat(ctx context.Context, path string) (Entry, error)
-	// List returns one page of files or objects below a directory or object
+	// ListFiles returns one page of files or objects below a directory or object
 	// prefix. Directories, virtual prefixes, and object-storage directory markers
 	// are not returned. Use "." to list the logical root. If path has no matching
-	// files, including when it does not exist or names a file, List returns an
+	// files, including when it does not exist or names a file, ListFiles returns an
 	// empty page and a nil error. Entries are sorted by logical path within each
 	// page. A page may be empty while NextCursor is non-empty; callers must
 	// continue until NextCursor is empty. Ordering across pages follows the
 	// backend cursor and is not guaranteed.
-	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
+	ListFiles(ctx context.Context, path string, options ListOptions) (ListPage, error)
 }
 
 // Copier is implemented by drivers with a native copy operation.

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -11,7 +11,10 @@ var (
 	// ErrInvalidPath indicates that a path does not follow the filesystem's
 	// logical path contract.
 	ErrInvalidPath = errors.New("filesystem: invalid path")
-	// ErrNotFound indicates that the requested entry does not exist.
+	// ErrNotFound indicates that the requested file or object does not exist.
+	// Drivers wrap ErrNotFound when Open or Stat cannot find a path. Callers
+	// should use errors.Is to test for it. Delete does not return ErrNotFound,
+	// because deletion is idempotent.
 	ErrNotFound = errors.New("filesystem: entry not found")
 	// ErrUnsupported indicates that an optional operation is not supported.
 	ErrUnsupported = errors.New("filesystem: operation not supported")
@@ -80,13 +83,15 @@ type ListPage struct {
 // object-storage backends.
 type Driver interface {
 	// Open opens path for streaming reads. The caller must close the result.
+	// If path does not exist, Open returns an error wrapping ErrNotFound.
 	Open(ctx context.Context, path string) (io.ReadCloser, error)
 	// Put writes src to path, replacing an existing entry.
 	Put(ctx context.Context, path string, src io.Reader, options PutOptions) error
 	// Delete removes a file or object. Delete is idempotent: deleting a path
 	// that does not exist returns nil.
 	Delete(ctx context.Context, path string) error
-	// Stat returns metadata for a file or object.
+	// Stat returns metadata for a file or object. If path does not exist, Stat
+	// returns an error wrapping ErrNotFound.
 	Stat(ctx context.Context, path string) (Entry, error)
 	// List returns one page of entries below a directory or object prefix.
 	List(ctx context.Context, path string, options ListOptions) (ListPage, error)

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -3,111 +3,117 @@ package filesystem
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 )
 
-var ErrNotSupported = errors.New("filesystem: the operation is not supported")
-
-type Filesystem interface {
-	// Read the value at the given path.
-	Read(ctx context.Context, path string) ([]byte, error)
-
-	// Write the value at the given path.
-	Write(ctx context.Context, path string, value []byte) error
-
-	// Delete the value at the given path.
-	Delete(ctx context.Context, path string) error
-
-	// Exists checks if the path exists.
-	Exists(ctx context.Context, path string) (bool, error)
-
-	// Rename renames the value from the old path to the new path.
-	Rename(ctx context.Context, oldPath, newPath string) error
-
-	// Link creates a hard link from the old path to the new path.
-	Link(ctx context.Context, oldPath, newPath string) error
-
-	// Symlink creates a symbolic link from the old path to the new path.
-	Symlink(ctx context.Context, oldPath, newPath string) error
-
-	// Files lists the files in the given path.
-	Files(ctx context.Context, path string) ([]string, error)
-
-	// AllFiles lists all the files in the given path.(including subdirectories)
-	AllFiles(ctx context.Context, path string) ([]string, error)
-
-	// Directories lists the directories in the given path.
-	Directories(ctx context.Context, path string) ([]string, error)
-
-	// AllDirectories lists all the directories in the given path.(including subdirectories)
-	AllDirectories(ctx context.Context, path string) ([]string, error)
-
-	// MakeDirectory creates a directory at the given path.
-	MakeDirectory(ctx context.Context, path string) error
-
-	// DeleteDirectory deletes the directory at the given path.
-	DeleteDirectory(ctx context.Context, path string) error
-
-	// IsFile checks if the path is a file.
-	IsFile(ctx context.Context, path string) (bool, error)
-
-	// IsDir checks if the path is a directory.
-	IsDir(ctx context.Context, path string) (bool, error)
-
-	// Size returns the size of the file in bytes.
-	Size(ctx context.Context, path string) (int64, error)
-
-	// LastModified returns the last modified time of the file.
-	LastModified(ctx context.Context, path string) (*time.Time, error)
-
-	// Path returns the full path for the given path.
-	Path(ctx context.Context, path string) string
-
-	// Name returns the name of the file, without the extension.
-	Name(ctx context.Context, path string) string
-
-	// Basename returns the base name of the file, with the extension.
-	Basename(ctx context.Context, path string) string
-
-	// Dirname returns the directory name of the file.
-	Dirname(ctx context.Context, path string) string
-
-	// Extension returns the extension of the file.
-	Extension(ctx context.Context, path string) string
-}
-
-type Copyable interface {
-	Copy(ctx context.Context, oldPath, newPath string) error
-}
-
-type NoopFilesystem struct{}
-
 var (
-	_ Filesystem = (*NoopFilesystem)(nil)
-	_ Copyable   = (*NoopFilesystem)(nil)
+	// ErrInvalidPath indicates that a path does not follow the filesystem's
+	// logical path contract.
+	ErrInvalidPath = errors.New("filesystem: invalid path")
+	// ErrNotFound indicates that the requested entry does not exist.
+	ErrNotFound = errors.New("filesystem: entry not found")
+	// ErrUnsupported indicates that an optional operation is not supported.
+	ErrUnsupported = errors.New("filesystem: operation not supported")
 )
 
-func (NoopFilesystem) Read(context.Context, string) ([]byte, error)             { return nil, nil }
-func (NoopFilesystem) Write(context.Context, string, []byte) error              { return nil }
-func (NoopFilesystem) Delete(context.Context, string) error                     { return nil }
-func (NoopFilesystem) Exists(context.Context, string) (bool, error)             { return true, nil }
-func (NoopFilesystem) Rename(context.Context, string, string) error             { return nil }
-func (NoopFilesystem) Link(context.Context, string, string) error               { return nil }
-func (NoopFilesystem) Symlink(context.Context, string, string) error            { return nil }
-func (NoopFilesystem) Files(context.Context, string) ([]string, error)          { return nil, nil }
-func (NoopFilesystem) AllFiles(context.Context, string) ([]string, error)       { return nil, nil }
-func (NoopFilesystem) Directories(context.Context, string) ([]string, error)    { return nil, nil }
-func (NoopFilesystem) AllDirectories(context.Context, string) ([]string, error) { return nil, nil }
-func (NoopFilesystem) MakeDirectory(context.Context, string) error              { return nil }
-func (NoopFilesystem) DeleteDirectory(context.Context, string) error            { return nil }
-func (NoopFilesystem) IsFile(context.Context, string) (bool, error)             { return false, nil }
+// EntryKind identifies the logical kind of a filesystem entry.
+type EntryKind uint8
 
-func (NoopFilesystem) IsDir(context.Context, string) (bool, error)              { return false, nil }
-func (NoopFilesystem) Size(context.Context, string) (int64, error)              { return 0, nil }
-func (NoopFilesystem) LastModified(context.Context, string) (*time.Time, error) { return nil, nil }
-func (NoopFilesystem) Path(context.Context, string) string                      { return "" }
-func (NoopFilesystem) Name(context.Context, string) string                      { return "" }
-func (NoopFilesystem) Basename(context.Context, string) string                  { return "" }
-func (NoopFilesystem) Dirname(context.Context, string) string                   { return "" }
-func (NoopFilesystem) Extension(context.Context, string) string                 { return "" }
-func (NoopFilesystem) Copy(context.Context, string, string) error               { return nil }
+const (
+	// EntryKindAny matches files and directories when used as a list filter.
+	EntryKindAny EntryKind = iota
+	// EntryKindFile identifies a file or object.
+	EntryKindFile
+	// EntryKindDirectory identifies a real or virtual directory.
+	EntryKindDirectory
+)
+
+// Entry describes a file, object, or directory returned by Stat or List.
+// Fields unsupported by a backend use their zero values.
+type Entry struct {
+	Path         string
+	Kind         EntryKind
+	Size         int64
+	LastModified time.Time
+	ContentType  string
+	Metadata     map[string]string
+}
+
+// IsFile reports whether e represents a file or object.
+func (e Entry) IsFile() bool {
+	return e.Kind == EntryKindFile
+}
+
+// IsDir reports whether e represents a real or virtual directory.
+func (e Entry) IsDir() bool {
+	return e.Kind == EntryKindDirectory
+}
+
+// PutOptions configures a Put operation.
+type PutOptions struct {
+	ContentType string
+	Metadata    map[string]string
+}
+
+// ListOptions configures a List operation.
+type ListOptions struct {
+	// Recursive includes entries below nested directories or prefixes.
+	Recursive bool
+	// Kind filters entries by kind. EntryKindAny includes every kind.
+	Kind EntryKind
+	// Limit caps the number of entries returned. Values less than one use the
+	// backend default.
+	Limit int
+	// Cursor continues a previous listing. Cursors are opaque and scoped to a
+	// driver, path, and option set.
+	Cursor string
+}
+
+// ListPage is one page of a directory or prefix listing.
+type ListPage struct {
+	Entries    []Entry
+	NextCursor string
+}
+
+// Driver is the minimal storage contract shared by local filesystems and
+// object-storage backends.
+type Driver interface {
+	// Open opens path for streaming reads. The caller must close the result.
+	Open(ctx context.Context, path string) (io.ReadCloser, error)
+	// Put writes src to path, replacing an existing entry.
+	Put(ctx context.Context, path string, src io.Reader, options PutOptions) error
+	// Delete removes a file or object.
+	Delete(ctx context.Context, path string) error
+	// Stat returns metadata for a file or object.
+	Stat(ctx context.Context, path string) (Entry, error)
+	// List returns one page of entries below a directory or object prefix.
+	List(ctx context.Context, path string, options ListOptions) (ListPage, error)
+}
+
+// Copier is implemented by drivers with a native copy operation.
+type Copier interface {
+	Copy(ctx context.Context, src, dst string) error
+}
+
+// Mover is implemented by drivers with a native move operation.
+// A move is not necessarily atomic on object-storage backends.
+type Mover interface {
+	Move(ctx context.Context, src, dst string) error
+}
+
+// Linker is implemented by drivers that support hard links.
+type Linker interface {
+	Link(ctx context.Context, src, dst string) error
+}
+
+// Symlinker is implemented by drivers that support symbolic links.
+type Symlinker interface {
+	Symlink(ctx context.Context, target, link string) error
+}
+
+// DirectoryManager is implemented by drivers with real directory semantics.
+type DirectoryManager interface {
+	MakeDirectory(ctx context.Context, path string) error
+	DeleteDirectory(ctx context.Context, path string) error
+}

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestEntryKind(t *testing.T) {
+	assert.False(t, Entry{Kind: EntryKindUnknown}.IsFile())
+	assert.False(t, Entry{Kind: EntryKindUnknown}.IsDir())
 	assert.True(t, Entry{Kind: EntryKindFile}.IsFile())
 	assert.False(t, Entry{Kind: EntryKindFile}.IsDir())
 	assert.True(t, Entry{Kind: EntryKindDirectory}.IsDir())

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -12,3 +12,9 @@ func TestEntryKind(t *testing.T) {
 	assert.True(t, Entry{Kind: EntryKindDirectory}.IsDir())
 	assert.False(t, Entry{Kind: EntryKindDirectory}.IsFile())
 }
+
+func TestListOptionsNormalize(t *testing.T) {
+	assert.Equal(t, DefaultListLimit, (ListOptions{}).Normalize().Limit)
+	assert.Equal(t, 10, (ListOptions{Limit: 10}).Normalize().Limit)
+	assert.Equal(t, MaxListLimit, (ListOptions{Limit: MaxListLimit + 1}).Normalize().Limit)
+}

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -41,6 +41,14 @@ func TestPutOptionsResolveContentLength(t *testing.T) {
 		assert.ErrorIs(t, err, ErrInvalidContentLength)
 	})
 
+	t.Run("explicit mismatch", func(t *testing.T) {
+		length := int64(3)
+		_, err := (PutOptions{ContentLength: &length}).ResolveContentLength(
+			strings.NewReader("content"),
+		)
+		assert.ErrorIs(t, err, ErrInvalidContentLength)
+	})
+
 	t.Run("len", func(t *testing.T) {
 		source := strings.NewReader("content")
 		_, err := source.Read(make([]byte, 3))

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -6,47 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStorage(t *testing.T) {
-	var (
-		noop = NoopFilesystem{}
-		ctx  = t.Context()
-	)
-
-	_, err := noop.Read(ctx, "test")
-	assert.NoError(t, err)
-
-	assert.NoError(t, noop.Write(ctx, "noop", []byte("noop")))
-	assert.NoError(t, noop.Delete(ctx, "noop"))
-
-	has, err := noop.Exists(ctx, "noop")
-	assert.NoError(t, err)
-	assert.True(t, has)
-
-	assert.NoError(t, noop.Rename(ctx, "noop", "noop"))
-	assert.NoError(t, noop.Link(ctx, "noop", "noop"))
-	assert.NoError(t, noop.Symlink(ctx, "noop", "noop"))
-
-	files, err := noop.Files(ctx, "noop")
-	assert.NoError(t, err)
-	assert.Len(t, files, 0)
-
-	allFiles, err := noop.AllFiles(ctx, "noop")
-	assert.NoError(t, err)
-	assert.Len(t, allFiles, 0)
-
-	directories, err := noop.Directories(ctx, "noop")
-	assert.NoError(t, err)
-	assert.Len(t, directories, 0)
-
-	allDirectories, err := noop.AllDirectories(ctx, "noop")
-	assert.NoError(t, err)
-	assert.Len(t, allDirectories, 0)
-
-	isFile, err := noop.IsFile(ctx, "noop")
-	assert.NoError(t, err)
-	assert.False(t, isFile)
-
-	isDir, err := noop.IsDir(ctx, "noop")
-	assert.NoError(t, err)
-	assert.False(t, isDir)
+func TestEntryKind(t *testing.T) {
+	assert.True(t, Entry{Kind: EntryKindFile}.IsFile())
+	assert.False(t, Entry{Kind: EntryKindFile}.IsDir())
+	assert.True(t, Entry{Kind: EntryKindDirectory}.IsDir())
+	assert.False(t, Entry{Kind: EntryKindDirectory}.IsFile())
 }

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -1,9 +1,13 @@
 package filesystem
 
 import (
+	"bytes"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEntryKind(t *testing.T) {
@@ -19,4 +23,65 @@ func TestListOptionsNormalize(t *testing.T) {
 	assert.Equal(t, DefaultListLimit, (ListOptions{}).Normalize().Limit)
 	assert.Equal(t, 10, (ListOptions{Limit: 10}).Normalize().Limit)
 	assert.Equal(t, MaxListLimit, (ListOptions{Limit: MaxListLimit + 1}).Normalize().Limit)
+}
+
+func TestPutOptionsResolveContentLength(t *testing.T) {
+	t.Run("explicit", func(t *testing.T) {
+		length := int64(7)
+		actual, err := (PutOptions{ContentLength: &length}).ResolveContentLength(
+			struct{ io.Reader }{Reader: strings.NewReader("content")},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, length, actual)
+	})
+
+	t.Run("invalid explicit", func(t *testing.T) {
+		length := int64(-1)
+		_, err := (PutOptions{ContentLength: &length}).ResolveContentLength(nil)
+		assert.ErrorIs(t, err, ErrInvalidContentLength)
+	})
+
+	t.Run("len", func(t *testing.T) {
+		source := strings.NewReader("content")
+		_, err := source.Read(make([]byte, 3))
+		require.NoError(t, err)
+
+		length, err := (PutOptions{}).ResolveContentLength(source)
+		require.NoError(t, err)
+		assert.Equal(t, int64(4), length)
+	})
+
+	t.Run("seeker", func(t *testing.T) {
+		source := &seekOnly{reader: bytes.NewReader([]byte("content"))}
+		_, err := source.Seek(3, io.SeekStart)
+		require.NoError(t, err)
+
+		length, err := (PutOptions{}).ResolveContentLength(source)
+		require.NoError(t, err)
+		assert.Equal(t, int64(4), length)
+
+		value := make([]byte, 1)
+		_, err = source.Read(value)
+		require.NoError(t, err)
+		assert.Equal(t, "t", string(value))
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		_, err := (PutOptions{}).ResolveContentLength(
+			struct{ io.Reader }{Reader: strings.NewReader("content")},
+		)
+		assert.ErrorIs(t, err, ErrContentLengthRequired)
+	})
+}
+
+type seekOnly struct {
+	reader *bytes.Reader
+}
+
+func (s *seekOnly) Read(buffer []byte) (int, error) {
+	return s.reader.Read(buffer)
+}
+
+func (s *seekOnly) Seek(offset int64, whence int) (int64, error) {
+	return s.reader.Seek(offset, whence)
 }

--- a/filesystem/local/README.md
+++ b/filesystem/local/README.md
@@ -1,0 +1,78 @@
+# Local Filesystem
+
+The Local Filesystem driver stores logical filesystem paths below a local root
+directory. It implements the core filesystem API and supports moves, hard
+links, symbolic links, and real directory management.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/filesystem/v4
+go get github.com/go-fries/fries/filesystem/local/v4
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/go-fries/fries/filesystem/local/v4"
+	"github.com/go-fries/fries/filesystem/v4"
+)
+
+func main() {
+	ctx := context.Background()
+
+	if err := os.MkdirAll("./storage", 0o755); err != nil {
+		log.Fatal(err)
+	}
+	driver, err := local.New("./storage")
+	if err != nil {
+		log.Fatal(err)
+	}
+	storage := filesystem.NewRepository(driver)
+
+	if err := driver.MakeDirectory(ctx, "documents"); err != nil {
+		log.Fatal(err)
+	}
+	if err := storage.WriteFile(
+		ctx,
+		"documents/example.txt",
+		[]byte("local content"),
+		filesystem.PutOptions{},
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	page, err := storage.ListFiles(ctx, "documents", filesystem.ListOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, entry := range page.Entries {
+		fmt.Println(entry.Path)
+	}
+
+	if err := driver.Symlink(
+		ctx,
+		"documents/example.txt",
+		"documents/example-link.txt",
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+## Behavior
+
+- All paths are resolved below the configured root.
+- Internal symbolic links are supported, but links cannot be followed outside
+  the root.
+- `ListFiles` includes regular files and internal symbolic links to regular
+  files. Directories and special filesystem nodes are excluded.
+- Directory creation and deletion are available directly on `*local.Filesystem`.

--- a/filesystem/local/doc.go
+++ b/filesystem/local/doc.go
@@ -1,0 +1,2 @@
+// Package local provides a filesystem driver backed by a local directory.
+package local

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/go-fries/fries/filesystem/v4"
 )
@@ -44,12 +44,13 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 	if err := filesystem.ValidateFilePath(path); err != nil {
 		return nil, err
 	}
-	resolved, err := s.resolve(path)
+	root, err := s.openRoot("open", path)
 	if err != nil {
 		return nil, err
 	}
+	defer closeRoot(root)
 
-	reader, err := os.Open(resolved)
+	reader, err := root.Open(nativePath(path))
 	if err != nil {
 		return nil, wrapPathError("open", path, err)
 	}
@@ -69,12 +70,13 @@ func (s *Filesystem) Put(
 	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
-	resolved, err := s.resolve(path)
+	root, err := s.openRoot("put", path)
 	if err != nil {
 		return err
 	}
+	defer closeRoot(root)
 
-	file, err := os.OpenFile(resolved, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	file, err := root.OpenFile(nativePath(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return wrapPathError("put", path, err)
 	}
@@ -97,11 +99,13 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
-	resolved, err := s.resolve(path)
+	root, err := s.openRoot("delete", path)
 	if err != nil {
 		return err
 	}
-	if err := os.Remove(resolved); err != nil {
+	defer closeRoot(root)
+
+	if err := root.Remove(nativePath(path)); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
@@ -118,19 +122,20 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 	if path == "." {
 		return filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, nil
 	}
-	resolved, err := s.resolve(path)
+	root, err := s.openRoot("stat", path)
 	if err != nil {
 		return filesystem.Entry{}, err
 	}
+	defer closeRoot(root)
 
-	info, err := os.Stat(resolved)
+	info, err := root.Stat(nativePath(path))
 	if err != nil {
 		return filesystem.Entry{}, wrapPathError("stat", path, err)
 	}
 	return entryFromInfo(path, info), nil
 }
 
-// List returns entries below path in lexical order.
+// List returns files below path in lexical order.
 func (s *Filesystem) List(
 	ctx context.Context,
 	path string,
@@ -140,12 +145,16 @@ func (s *Filesystem) List(
 	if err := ctx.Err(); err != nil {
 		return filesystem.ListPage{}, err
 	}
-	resolved, err := s.resolve(path)
+	if err := filesystem.ValidatePath(path); err != nil {
+		return filesystem.ListPage{}, err
+	}
+	root, err := s.openRoot("list", path)
 	if err != nil {
 		return filesystem.ListPage{}, err
 	}
+	defer closeRoot(root)
 
-	entries, err := s.listEntries(ctx, resolved, options.Recursive)
+	entries, err := listEntries(ctx, root.FS(), path, options.Recursive)
 	if err != nil {
 		return filesystem.ListPage{}, wrapPathError("list", path, err)
 	}
@@ -168,15 +177,13 @@ func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
 	if err := filesystem.ValidateFilePath(dst); err != nil {
 		return err
 	}
-	source, err := s.resolve(src)
+	root, err := s.openRoot("move", src)
 	if err != nil {
 		return err
 	}
-	destination, err := s.resolve(dst)
-	if err != nil {
-		return err
-	}
-	if err := os.Rename(source, destination); err != nil {
+	defer closeRoot(root)
+
+	if err := root.Rename(nativePath(src), nativePath(dst)); err != nil {
 		return wrapPathError("move", src, err)
 	}
 	return nil
@@ -193,22 +200,20 @@ func (s *Filesystem) Link(ctx context.Context, src, dst string) error {
 	if err := filesystem.ValidateFilePath(dst); err != nil {
 		return err
 	}
-	source, err := s.resolve(src)
+	root, err := s.openRoot("link", src)
 	if err != nil {
 		return err
 	}
-	destination, err := s.resolve(dst)
-	if err != nil {
-		return err
-	}
-	if err := os.Link(source, destination); err != nil {
+	defer closeRoot(root)
+
+	if err := root.Link(nativePath(src), nativePath(dst)); err != nil {
 		return wrapPathError("link", src, err)
 	}
 	return nil
 }
 
-// Symlink creates a symbolic link whose target remains inside the configured
-// root when both logical paths remain inside it.
+// Symlink creates a relative symbolic link. Access through this filesystem
+// rejects links whose resolution escapes the configured root.
 func (s *Filesystem) Symlink(ctx context.Context, target, link string) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -219,19 +224,19 @@ func (s *Filesystem) Symlink(ctx context.Context, target, link string) error {
 	if err := filesystem.ValidateFilePath(link); err != nil {
 		return err
 	}
-	targetPath, err := s.resolve(target)
+	root, err := s.openRoot("symlink", link)
 	if err != nil {
 		return err
 	}
-	linkPath, err := s.resolve(link)
-	if err != nil {
-		return err
-	}
+	defer closeRoot(root)
+
+	targetPath := nativePath(target)
+	linkPath := nativePath(link)
 	relativeTarget, err := filepath.Rel(filepath.Dir(linkPath), targetPath)
 	if err != nil {
 		return wrapPathError("symlink", target, err)
 	}
-	if err := os.Symlink(relativeTarget, linkPath); err != nil {
+	if err := root.Symlink(relativeTarget, linkPath); err != nil {
 		return wrapPathError("symlink", link, err)
 	}
 	return nil
@@ -242,11 +247,16 @@ func (s *Filesystem) MakeDirectory(ctx context.Context, path string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	resolved, err := s.resolve(path)
+	if err := filesystem.ValidatePath(path); err != nil {
+		return err
+	}
+	root, err := s.openRoot("mkdir", path)
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(resolved, 0o755); err != nil {
+	defer closeRoot(root)
+
+	if err := root.MkdirAll(nativePath(path), 0o755); err != nil {
 		return wrapPathError("mkdir", path, err)
 	}
 	return nil
@@ -260,41 +270,44 @@ func (s *Filesystem) DeleteDirectory(ctx context.Context, path string) error {
 	if path == "." {
 		return &fs.PathError{Op: "remove", Path: path, Err: filesystem.ErrInvalidPath}
 	}
-	resolved, err := s.resolve(path)
+	if err := filesystem.ValidatePath(path); err != nil {
+		return err
+	}
+	root, err := s.openRoot("remove", path)
 	if err != nil {
 		return err
 	}
-	if err := os.RemoveAll(resolved); err != nil {
+	defer closeRoot(root)
+
+	if err := root.RemoveAll(nativePath(path)); err != nil {
 		return wrapPathError("remove", path, err)
 	}
 	return nil
 }
 
-func (s *Filesystem) resolve(path string) (string, error) {
-	if err := filesystem.ValidatePath(path); err != nil {
-		return "", err
-	}
-	if path == "." {
-		return s.root, nil
-	}
-
-	resolved := filepath.Join(s.root, filepath.FromSlash(path))
-	relative, err := filepath.Rel(s.root, resolved)
+func (s *Filesystem) openRoot(op, path string) (*os.Root, error) {
+	root, err := os.OpenRoot(s.root)
 	if err != nil {
-		return "", &fs.PathError{Op: "resolve", Path: path, Err: err}
+		return nil, wrapPathError(op, path, err)
 	}
-	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return "", &fs.PathError{Op: "resolve", Path: path, Err: filesystem.ErrInvalidPath}
-	}
-	return resolved, nil
+	return root, nil
 }
 
-func (s *Filesystem) listEntries(
+func nativePath(path string) string {
+	return filepath.FromSlash(path)
+}
+
+func closeRoot(root *os.Root) {
+	_ = root.Close()
+}
+
+func listEntries(
 	ctx context.Context,
+	storage fs.FS,
 	root string,
 	recursive bool,
 ) ([]filesystem.Entry, error) {
-	info, err := os.Stat(root)
+	info, err := fs.Stat(storage, root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
@@ -306,7 +319,7 @@ func (s *Filesystem) listEntries(
 	}
 
 	if !recursive {
-		dirEntries, err := os.ReadDir(root)
+		dirEntries, err := fs.ReadDir(storage, root)
 		if err != nil {
 			return nil, err
 		}
@@ -316,9 +329,12 @@ func (s *Filesystem) listEntries(
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			entry, err := s.entryFromDirEntry(filepath.Join(root, dirEntry.Name()), dirEntry)
+			entry, err := entryFromDirEntry(logicalJoin(root, dirEntry.Name()), dirEntry)
 			if err != nil {
 				return nil, err
+			}
+			if entry.IsDir() {
+				continue
 			}
 			entries = append(entries, entry)
 		}
@@ -326,7 +342,7 @@ func (s *Filesystem) listEntries(
 	}
 
 	var entries []filesystem.Entry
-	err = filepath.WalkDir(root, func(path string, dirEntry fs.DirEntry, err error) error {
+	err = fs.WalkDir(storage, root, func(path string, dirEntry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -336,7 +352,10 @@ func (s *Filesystem) listEntries(
 		if path == root {
 			return nil
 		}
-		entry, err := s.entryFromDirEntry(path, dirEntry)
+		if dirEntry.IsDir() {
+			return nil
+		}
+		entry, err := entryFromDirEntry(path, dirEntry)
 		if err != nil {
 			return err
 		}
@@ -346,16 +365,19 @@ func (s *Filesystem) listEntries(
 	return entries, err
 }
 
-func (s *Filesystem) entryFromDirEntry(path string, dirEntry fs.DirEntry) (filesystem.Entry, error) {
+func logicalJoin(directory, name string) string {
+	if directory == "." {
+		return name
+	}
+	return pathpkg.Join(directory, name)
+}
+
+func entryFromDirEntry(path string, dirEntry fs.DirEntry) (filesystem.Entry, error) {
 	info, err := dirEntry.Info()
 	if err != nil {
 		return filesystem.Entry{}, err
 	}
-	relative, err := filepath.Rel(s.root, path)
-	if err != nil {
-		return filesystem.Entry{}, err
-	}
-	return entryFromInfo(filepath.ToSlash(relative), info), nil
+	return entryFromInfo(path, info), nil
 }
 
 func entryFromInfo(path string, info fs.FileInfo) filesystem.Entry {

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -135,8 +135,8 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 	return entryFromInfo(path, info), nil
 }
 
-// List returns files below path in lexical order.
-func (s *Filesystem) List(
+// ListFiles returns files below path in lexical order.
+func (s *Filesystem) ListFiles(
 	ctx context.Context,
 	path string,
 	options filesystem.ListOptions,
@@ -158,7 +158,6 @@ func (s *Filesystem) List(
 	if err != nil {
 		return filesystem.ListPage{}, wrapPathError("list", path, err)
 	}
-	entries = filterEntries(entries, options.Kind)
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Path < entries[j].Path
 	})
@@ -391,20 +390,6 @@ func entryFromInfo(path string, info fs.FileInfo) filesystem.Entry {
 		Size:         info.Size(),
 		LastModified: info.ModTime(),
 	}
-}
-
-func filterEntries(entries []filesystem.Entry, kind filesystem.EntryKind) []filesystem.Entry {
-	if kind == filesystem.EntryKindAny {
-		return entries
-	}
-
-	filtered := entries[:0]
-	for _, entry := range entries {
-		if entry.Kind == kind {
-			filtered = append(filtered, entry)
-		}
-	}
-	return filtered
 }
 
 func paginate(entries []filesystem.Entry, options filesystem.ListOptions) filesystem.ListPage {

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -57,18 +58,23 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 	return reader, nil
 }
 
-// Put writes src to path, replacing an existing file.
+// Put writes src to path, replacing an existing file. The content length must
+// be explicit or inferable as described by filesystem.PutOptions.
 func (s *Filesystem) Put(
 	ctx context.Context,
 	path string,
 	src io.Reader,
-	_ filesystem.PutOptions,
+	options filesystem.PutOptions,
 ) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
+	}
+	contentLength, err := options.ResolveContentLength(src)
+	if err != nil {
+		return wrapPathError("put", path, err)
 	}
 	root, err := s.openRoot("put", path)
 	if err != nil {
@@ -80,10 +86,19 @@ func (s *Filesystem) Put(
 	if err != nil {
 		return wrapPathError("put", path, err)
 	}
-	_, copyErr := io.Copy(file, contextReader{ctx: ctx, reader: src})
+	if src == nil {
+		src = bytes.NewReader(nil)
+	}
+	written, copyErr := io.Copy(
+		file,
+		io.LimitReader(contextReader{ctx: ctx, reader: src}, contentLength),
+	)
 	closeErr := file.Close()
 	if copyErr != nil {
 		return wrapPathError("put", path, copyErr)
+	}
+	if written != contentLength {
+		return wrapPathError("put", path, io.ErrUnexpectedEOF)
 	}
 	if closeErr != nil {
 		return wrapPathError("put", path, closeErr)

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -343,11 +343,18 @@ func listEntries(
 			if err := ctx.Err(); err != nil {
 				return nil, err
 			}
-			entry, err := entryFromDirEntry(logicalJoin(root, dirEntry.Name()), dirEntry)
+			if dirEntry.IsDir() {
+				continue
+			}
+			entry, include, err := fileEntryFromDirEntry(
+				storage,
+				logicalJoin(root, dirEntry.Name()),
+				dirEntry,
+			)
 			if err != nil {
 				return nil, err
 			}
-			if entry.IsDir() {
+			if !include {
 				continue
 			}
 			entries = append(entries, entry)
@@ -369,9 +376,12 @@ func listEntries(
 		if dirEntry.IsDir() {
 			return nil
 		}
-		entry, err := entryFromDirEntry(path, dirEntry)
+		entry, include, err := fileEntryFromDirEntry(storage, path, dirEntry)
 		if err != nil {
 			return err
+		}
+		if !include {
+			return nil
 		}
 		entries = append(entries, entry)
 		return nil
@@ -386,18 +396,31 @@ func logicalJoin(directory, name string) string {
 	return pathpkg.Join(directory, name)
 }
 
-func entryFromDirEntry(path string, dirEntry fs.DirEntry) (filesystem.Entry, error) {
-	info, err := dirEntry.Info()
+func fileEntryFromDirEntry(
+	storage fs.FS,
+	path string,
+	dirEntry fs.DirEntry,
+) (filesystem.Entry, bool, error) {
+	info, err := fs.Stat(storage, path)
 	if err != nil {
-		return filesystem.Entry{}, err
+		if dirEntry.Type()&fs.ModeSymlink != 0 {
+			return filesystem.Entry{}, false, nil
+		}
+		return filesystem.Entry{}, false, err
 	}
-	return entryFromInfo(path, info), nil
+	if !info.Mode().IsRegular() {
+		return filesystem.Entry{}, false, nil
+	}
+	return entryFromInfo(path, info), true, nil
 }
 
 func entryFromInfo(path string, info fs.FileInfo) filesystem.Entry {
-	kind := filesystem.EntryKindFile
-	if info.IsDir() {
+	kind := filesystem.EntryKindUnknown
+	switch {
+	case info.IsDir():
 		kind = filesystem.EntryKindDirectory
+	case info.Mode().IsRegular():
+		kind = filesystem.EntryKindFile
 	}
 	return filesystem.Entry{
 		Path:         path,

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -93,6 +93,9 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 		return err
 	}
 	if err := os.Remove(resolved); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		return wrapPathError("delete", path, err)
 	}
 	return nil

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -2,211 +2,375 @@ package local
 
 import (
 	"context"
+	"errors"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
-	"time"
 
 	"github.com/go-fries/fries/filesystem/v4"
 )
 
+// Filesystem stores logical filesystem paths below a local root directory.
 type Filesystem struct {
-	root     string
-	prefixer *filesystem.PathPrefixer
+	root string
 }
 
-var _ filesystem.Filesystem = (*Filesystem)(nil)
+var (
+	_ filesystem.Driver           = (*Filesystem)(nil)
+	_ filesystem.Mover            = (*Filesystem)(nil)
+	_ filesystem.Linker           = (*Filesystem)(nil)
+	_ filesystem.Symlinker        = (*Filesystem)(nil)
+	_ filesystem.DirectoryManager = (*Filesystem)(nil)
+)
 
-func NewStorage(root string) *Filesystem {
-	return &Filesystem{
-		root:     root,
-		prefixer: filesystem.NewPathPrefixer(root),
-	}
-}
-
-func (s *Filesystem) Read(_ context.Context, path string) ([]byte, error) {
-	return os.ReadFile(s.prefixer.Prefix(path))
-}
-
-func (s *Filesystem) Write(_ context.Context, path string, value []byte) error {
-	return os.WriteFile(s.prefixer.Prefix(path), value, 0o644) //nolint:mnd
-}
-
-func (s *Filesystem) Delete(_ context.Context, path string) error {
-	return os.Remove(s.prefixer.Prefix(path))
-}
-
-func (s *Filesystem) Exists(_ context.Context, path string) (bool, error) {
-	_, err := os.Stat(s.prefixer.Prefix(path))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
-}
-
-func (s *Filesystem) Rename(_ context.Context, oldPath, newPath string) error {
-	return os.Rename(s.prefixer.Prefix(oldPath), s.prefixer.Prefix(newPath))
-}
-
-func (s *Filesystem) Link(_ context.Context, oldPath, newPath string) error {
-	return os.Link(s.prefixer.Prefix(oldPath), s.prefixer.Prefix(newPath))
-}
-
-func (s *Filesystem) Symlink(_ context.Context, oldPath, newPath string) error {
-	_, _ = oldPath, newPath
-	panic("not implemented") // TODO: Implement
-	// return os.Symlink(s.prefixer.Prefix(oldPath), s.prefixer.Prefix(newPath))
-}
-
-func (s *Filesystem) Files(_ context.Context, path string) ([]string, error) {
-	f, err := os.ReadDir(s.prefixer.Prefix(path))
+// New creates a local filesystem rooted at root.
+func New(root string) (*Filesystem, error) {
+	absolute, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
 	}
 
-	var files []string
-	for _, file := range f {
-		if !file.IsDir() {
-			files = append(files, file.Name())
-		}
-	}
-	return files, nil
+	return &Filesystem{root: filepath.Clean(absolute)}, nil
 }
 
-func (s *Filesystem) AllFiles(ctx context.Context, path string) ([]string, error) {
-	f, err := os.ReadDir(s.prefixer.Prefix(path))
+// Open opens path for streaming reads.
+func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	resolved, err := s.resolve(path)
 	if err != nil {
 		return nil, err
 	}
 
-	var files []string //molint:prealloc
-	for _, file := range f {
-		if !file.IsDir() {
-			files = append(files, file.Name())
-		} else {
-			subFiles, err := s.AllFiles(ctx, file.Name())
-			if err != nil {
-				return nil, err
-			}
-			files = append(files, subFiles...)
-		}
+	reader, err := os.Open(resolved)
+	if err != nil {
+		return nil, wrapPathError("open", path, err)
 	}
-
-	return files, nil
+	return reader, nil
 }
 
-func (s *Filesystem) Directories(_ context.Context, path string) ([]string, error) {
-	f, err := os.ReadDir(s.prefixer.Prefix(path))
+// Put writes src to path, replacing an existing file.
+func (s *Filesystem) Put(
+	ctx context.Context,
+	path string,
+	src io.Reader,
+	_ filesystem.PutOptions,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	resolved, err := s.resolve(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var dirs []string
-	for _, file := range f {
-		if !file.IsDir() {
-			continue
-		}
-		dirs = append(dirs, file.Name())
+	file, err := os.OpenFile(resolved, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return wrapPathError("put", path, err)
 	}
-	return dirs, nil
+	_, copyErr := io.Copy(file, contextReader{ctx: ctx, reader: src})
+	closeErr := file.Close()
+	if copyErr != nil {
+		return wrapPathError("put", path, copyErr)
+	}
+	if closeErr != nil {
+		return wrapPathError("put", path, closeErr)
+	}
+	return nil
 }
 
-func (s *Filesystem) AllDirectories(ctx context.Context, path string) ([]string, error) {
-	f, err := os.ReadDir(s.prefixer.Prefix(path))
+// Delete removes a file.
+func (s *Filesystem) Delete(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	resolved, err := s.resolve(path)
 	if err != nil {
-		return nil, err
+		return err
+	}
+	if err := os.Remove(resolved); err != nil {
+		return wrapPathError("delete", path, err)
+	}
+	return nil
+}
+
+// Stat returns metadata for path.
+func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
+	if err := ctx.Err(); err != nil {
+		return filesystem.Entry{}, err
+	}
+	resolved, err := s.resolve(path)
+	if err != nil {
+		return filesystem.Entry{}, err
 	}
 
-	var dirs []string
-	for _, file := range f {
-		if !file.IsDir() {
-			continue
-		}
-		subDirs, err := s.AllDirectories(ctx, file.Name())
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return filesystem.Entry{}, wrapPathError("stat", path, err)
+	}
+	return entryFromInfo(path, info), nil
+}
+
+// List returns entries below path in lexical order.
+func (s *Filesystem) List(
+	ctx context.Context,
+	path string,
+	options filesystem.ListOptions,
+) (filesystem.ListPage, error) {
+	if err := ctx.Err(); err != nil {
+		return filesystem.ListPage{}, err
+	}
+	resolved, err := s.resolve(path)
+	if err != nil {
+		return filesystem.ListPage{}, err
+	}
+
+	entries, err := s.listEntries(ctx, resolved, options.Recursive)
+	if err != nil {
+		return filesystem.ListPage{}, wrapPathError("list", path, err)
+	}
+	entries = filterEntries(entries, options.Kind)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+
+	return paginate(entries, options), nil
+}
+
+// Move moves src to dst atomically when the local operating system permits it.
+func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	source, err := s.resolve(src)
+	if err != nil {
+		return err
+	}
+	destination, err := s.resolve(dst)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(source, destination); err != nil {
+		return wrapPathError("move", src, err)
+	}
+	return nil
+}
+
+// Link creates a hard link from src to dst.
+func (s *Filesystem) Link(ctx context.Context, src, dst string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	source, err := s.resolve(src)
+	if err != nil {
+		return err
+	}
+	destination, err := s.resolve(dst)
+	if err != nil {
+		return err
+	}
+	if err := os.Link(source, destination); err != nil {
+		return wrapPathError("link", src, err)
+	}
+	return nil
+}
+
+// Symlink creates a symbolic link whose target remains inside the configured
+// root when both logical paths remain inside it.
+func (s *Filesystem) Symlink(ctx context.Context, target, link string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	targetPath, err := s.resolve(target)
+	if err != nil {
+		return err
+	}
+	linkPath, err := s.resolve(link)
+	if err != nil {
+		return err
+	}
+	relativeTarget, err := filepath.Rel(filepath.Dir(linkPath), targetPath)
+	if err != nil {
+		return wrapPathError("symlink", target, err)
+	}
+	if err := os.Symlink(relativeTarget, linkPath); err != nil {
+		return wrapPathError("symlink", link, err)
+	}
+	return nil
+}
+
+// MakeDirectory creates path and any missing parent directories.
+func (s *Filesystem) MakeDirectory(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	resolved, err := s.resolve(path)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(resolved, 0o755); err != nil {
+		return wrapPathError("mkdir", path, err)
+	}
+	return nil
+}
+
+// DeleteDirectory recursively removes path. The logical root cannot be removed.
+func (s *Filesystem) DeleteDirectory(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if path == "." {
+		return &fs.PathError{Op: "remove", Path: path, Err: filesystem.ErrInvalidPath}
+	}
+	resolved, err := s.resolve(path)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(resolved); err != nil {
+		return wrapPathError("remove", path, err)
+	}
+	return nil
+}
+
+func (s *Filesystem) resolve(path string) (string, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return "", err
+	}
+	if path == "." {
+		return s.root, nil
+	}
+
+	resolved := filepath.Join(s.root, filepath.FromSlash(path))
+	relative, err := filepath.Rel(s.root, resolved)
+	if err != nil {
+		return "", &fs.PathError{Op: "resolve", Path: path, Err: err}
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", &fs.PathError{Op: "resolve", Path: path, Err: filesystem.ErrInvalidPath}
+	}
+	return resolved, nil
+}
+
+func (s *Filesystem) listEntries(
+	ctx context.Context,
+	root string,
+	recursive bool,
+) ([]filesystem.Entry, error) {
+	if !recursive {
+		dirEntries, err := os.ReadDir(root)
 		if err != nil {
 			return nil, err
 		}
-		dirs = append(dirs, subDirs...)
-	}
-	return dirs, nil
-}
 
-func (s *Filesystem) MakeDirectory(_ context.Context, path string) error {
-	return os.MkdirAll(s.prefixer.Prefix(path), 0o755) //nolint:mnd
-}
-
-func (s *Filesystem) DeleteDirectory(_ context.Context, path string) error {
-	return os.RemoveAll(s.prefixer.Prefix(path))
-}
-
-func (s *Filesystem) IsFile(_ context.Context, path string) (bool, error) {
-	info, err := os.Stat(s.prefixer.Prefix(path))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
+		entries := make([]filesystem.Entry, 0, len(dirEntries))
+		for _, dirEntry := range dirEntries {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			entry, err := s.entryFromDirEntry(filepath.Join(root, dirEntry.Name()), dirEntry)
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, entry)
 		}
-		return false, err
+		return entries, nil
 	}
 
-	return !info.IsDir(), nil
-}
-
-func (s *Filesystem) IsDir(_ context.Context, path string) (bool, error) {
-	info, err := os.Stat(s.prefixer.Prefix(path))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
+	var entries []filesystem.Entry
+	err := filepath.WalkDir(root, func(path string, dirEntry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		return false, err
-	}
-
-	return info.IsDir(), nil
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+		entry, err := s.entryFromDirEntry(path, dirEntry)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, entry)
+		return nil
+	})
+	return entries, err
 }
 
-func (s *Filesystem) Size(_ context.Context, path string) (int64, error) {
-	info, err := os.Stat(s.prefixer.Prefix(path))
+func (s *Filesystem) entryFromDirEntry(path string, dirEntry fs.DirEntry) (filesystem.Entry, error) {
+	info, err := dirEntry.Info()
 	if err != nil {
+		return filesystem.Entry{}, err
+	}
+	relative, err := filepath.Rel(s.root, path)
+	if err != nil {
+		return filesystem.Entry{}, err
+	}
+	return entryFromInfo(filepath.ToSlash(relative), info), nil
+}
+
+func entryFromInfo(path string, info fs.FileInfo) filesystem.Entry {
+	kind := filesystem.EntryKindFile
+	if info.IsDir() {
+		kind = filesystem.EntryKindDirectory
+	}
+	return filesystem.Entry{
+		Path:         path,
+		Kind:         kind,
+		Size:         info.Size(),
+		LastModified: info.ModTime(),
+	}
+}
+
+func filterEntries(entries []filesystem.Entry, kind filesystem.EntryKind) []filesystem.Entry {
+	if kind == filesystem.EntryKindAny {
+		return entries
+	}
+
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if entry.Kind == kind {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+func paginate(entries []filesystem.Entry, options filesystem.ListOptions) filesystem.ListPage {
+	start := sort.Search(len(entries), func(i int) bool {
+		return entries[i].Path > options.Cursor
+	})
+	end := len(entries)
+	if options.Limit > 0 && start+options.Limit < end {
+		end = start + options.Limit
+	}
+
+	page := filesystem.ListPage{Entries: entries[start:end]}
+	if end < len(entries) && end > start {
+		page.NextCursor = entries[end-1].Path
+	}
+	return page
+}
+
+func wrapPathError(op, path string, err error) error {
+	if errors.Is(err, os.ErrNotExist) {
+		err = filesystem.ErrNotFound
+	}
+	return &fs.PathError{Op: op, Path: path, Err: err}
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r contextReader) Read(buffer []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
 		return 0, err
 	}
-
-	return info.Size(), nil
-}
-
-func (s *Filesystem) LastModified(_ context.Context, path string) (*time.Time, error) {
-	info, err := os.Stat(s.prefixer.Prefix(path))
-	if err != nil {
-		return nil, err
-	}
-
-	return ptr(info.ModTime()), nil
-}
-
-func (s *Filesystem) Path(_ context.Context, path string) string {
-	return s.prefixer.Prefix(path)
-}
-
-func (s *Filesystem) Name(_ context.Context, path string) string {
-	path = s.prefixer.Prefix(path)
-	base := filepath.Base(path)
-	return strings.TrimSuffix(base, filepath.Ext(base))
-}
-
-func (s *Filesystem) Basename(_ context.Context, path string) string {
-	return filepath.Base(s.prefixer.Prefix(path))
-}
-
-func (s *Filesystem) Dirname(_ context.Context, path string) string {
-	return filepath.Dir(s.prefixer.Prefix(path))
-}
-
-func (s *Filesystem) Extension(_ context.Context, path string) string {
-	return filepath.Ext(s.prefixer.Prefix(path))
-}
-
-func ptr[T any](v T) *T {
-	return &v
+	return r.reader.Read(buffer)
 }

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -293,6 +293,17 @@ func (s *Filesystem) listEntries(
 	root string,
 	recursive bool,
 ) ([]filesystem.Entry, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, nil
+	}
+
 	if !recursive {
 		dirEntries, err := os.ReadDir(root)
 		if err != nil {
@@ -314,7 +325,7 @@ func (s *Filesystem) listEntries(
 	}
 
 	var entries []filesystem.Entry
-	err := filepath.WalkDir(root, func(path string, dirEntry fs.DirEntry, err error) error {
+	err = filepath.WalkDir(root, func(path string, dirEntry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -41,6 +41,9 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if err := filesystem.ValidateFilePath(path); err != nil {
+		return nil, err
+	}
 	resolved, err := s.resolve(path)
 	if err != nil {
 		return nil, err
@@ -61,6 +64,9 @@ func (s *Filesystem) Put(
 	_ filesystem.PutOptions,
 ) error {
 	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
 	resolved, err := s.resolve(path)
@@ -88,6 +94,9 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := filesystem.ValidateFilePath(path); err != nil {
+		return err
+	}
 	resolved, err := s.resolve(path)
 	if err != nil {
 		return err
@@ -105,6 +114,9 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
 	if err := ctx.Err(); err != nil {
 		return filesystem.Entry{}, err
+	}
+	if path == "." {
+		return filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, nil
 	}
 	resolved, err := s.resolve(path)
 	if err != nil {
@@ -149,6 +161,12 @@ func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := filesystem.ValidateFilePath(src); err != nil {
+		return err
+	}
+	if err := filesystem.ValidateFilePath(dst); err != nil {
+		return err
+	}
 	source, err := s.resolve(src)
 	if err != nil {
 		return err
@@ -166,6 +184,12 @@ func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
 // Link creates a hard link from src to dst.
 func (s *Filesystem) Link(ctx context.Context, src, dst string) error {
 	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := filesystem.ValidateFilePath(src); err != nil {
+		return err
+	}
+	if err := filesystem.ValidateFilePath(dst); err != nil {
 		return err
 	}
 	source, err := s.resolve(src)
@@ -186,6 +210,12 @@ func (s *Filesystem) Link(ctx context.Context, src, dst string) error {
 // root when both logical paths remain inside it.
 func (s *Filesystem) Symlink(ctx context.Context, target, link string) error {
 	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := filesystem.ValidateFilePath(target); err != nil {
+		return err
+	}
+	if err := filesystem.ValidateFilePath(link); err != nil {
 		return err
 	}
 	targetPath, err := s.resolve(target)

--- a/filesystem/local/filesystem.go
+++ b/filesystem/local/filesystem.go
@@ -136,6 +136,7 @@ func (s *Filesystem) List(
 	path string,
 	options filesystem.ListOptions,
 ) (filesystem.ListPage, error) {
+	options = options.Normalize()
 	if err := ctx.Err(); err != nil {
 		return filesystem.ListPage{}, err
 	}

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -97,6 +97,28 @@ func TestFilesystemListPagination(t *testing.T) {
 	assert.Empty(t, second.NextCursor)
 }
 
+func TestFilesystemPutContentLength(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
+	source := struct{ io.Reader }{Reader: strings.NewReader("content")}
+
+	err = storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{})
+	assert.ErrorIs(t, err, filesystem.ErrContentLengthRequired)
+
+	length := int64(len("content"))
+	err = storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{
+		ContentLength: &length,
+	})
+	require.NoError(t, err)
+
+	reader, err := storage.Open(t.Context(), "file.txt")
+	require.NoError(t, err)
+	value, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, "content", string(value))
+}
+
 func TestFilesystemListWithoutMatches(t *testing.T) {
 	storage, err := New(t.TempDir())
 	require.NoError(t, err)

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -99,6 +99,23 @@ func TestFilesystemListPagination(t *testing.T) {
 	assert.Empty(t, second.NextCursor)
 }
 
+func TestFilesystemListWithoutMatches(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	missing, err := storage.List(ctx, "missing", filesystem.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, missing.Entries)
+	assert.Empty(t, missing.NextCursor)
+
+	require.NoError(t, storage.Put(ctx, "file.txt", strings.NewReader("content"), filesystem.PutOptions{}))
+	file, err := storage.List(ctx, "file.txt", filesystem.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, file.Entries)
+	assert.Empty(t, file.NextCursor)
+}
+
 func TestFilesystemRejectsEscapingPaths(t *testing.T) {
 	storage, err := New(t.TempDir())
 	require.NoError(t, err)

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -2,6 +2,8 @@ package local
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -46,12 +48,11 @@ func TestFilesystem(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []filesystem.Entry{
 		{Path: "dir/file.txt", Kind: filesystem.EntryKindFile, Size: 7, LastModified: page.Entries[0].LastModified},
-		{Path: "dir/nested", Kind: filesystem.EntryKindDirectory, Size: page.Entries[1].Size, LastModified: page.Entries[1].LastModified},
 	}, page.Entries)
 
 	recursive, err := storage.List(ctx, "dir", filesystem.ListOptions{Recursive: true})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"dir/file.txt", "dir/nested", "dir/nested/child.txt"}, entryPaths(recursive.Entries))
+	assert.Equal(t, []string{"dir/file.txt", "dir/nested/child.txt"}, entryPaths(recursive.Entries))
 
 	files, err := storage.List(ctx, ".", filesystem.ListOptions{
 		Recursive: true,
@@ -59,6 +60,13 @@ func TestFilesystem(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"dir/file.txt", "dir/nested/child.txt"}, entryPaths(files.Entries))
+
+	directories, err := storage.List(ctx, ".", filesystem.ListOptions{
+		Recursive: true,
+		Kind:      filesystem.EntryKindDirectory,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, directories.Entries)
 
 	require.NoError(t, storage.Move(ctx, "dir/file.txt", "dir/moved.txt"))
 	require.NoError(t, storage.Link(ctx, "dir/moved.txt", "dir/link.txt"))
@@ -128,6 +136,53 @@ func TestFilesystemRejectsEscapingPaths(t *testing.T) {
 	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
 	assert.ErrorIs(t, storage.Delete(t.Context(), "."), filesystem.ErrInvalidPath)
 	assert.ErrorIs(t, storage.DeleteDirectory(t.Context(), "."), filesystem.ErrInvalidPath)
+}
+
+func TestFilesystemRejectsEscapingSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link creation may require additional privileges")
+	}
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "outside.txt"), []byte("outside"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(outside, "directory"), 0o755))
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "escape")))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "inside.txt"), []byte("inside"), 0o644))
+
+	storage, err := New(root)
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	_, err = storage.Open(ctx, "escape/outside.txt")
+	assert.Error(t, err)
+	assert.Error(t, storage.Put(
+		ctx,
+		"escape/created.txt",
+		strings.NewReader("created"),
+		filesystem.PutOptions{},
+	))
+	_, err = os.Stat(filepath.Join(outside, "created.txt"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	_, err = storage.Stat(ctx, "escape/outside.txt")
+	assert.Error(t, err)
+	_, err = storage.List(ctx, "escape", filesystem.ListOptions{})
+	assert.Error(t, err)
+
+	assert.Error(t, storage.Delete(ctx, "escape/outside.txt"))
+	_, err = os.Stat(filepath.Join(outside, "outside.txt"))
+	assert.NoError(t, err)
+
+	assert.Error(t, storage.Move(ctx, "inside.txt", "escape/moved.txt"))
+	_, err = os.Stat(filepath.Join(root, "inside.txt"))
+	assert.NoError(t, err)
+	assert.Error(t, storage.Link(ctx, "inside.txt", "escape/linked.txt"))
+	assert.Error(t, storage.Symlink(ctx, "inside.txt", "escape/symlink.txt"))
+	assert.Error(t, storage.MakeDirectory(ctx, "escape/created-directory"))
+	assert.Error(t, storage.DeleteDirectory(ctx, "escape/directory"))
+	_, err = os.Stat(filepath.Join(outside, "directory"))
+	assert.NoError(t, err)
 }
 
 func TestFilesystemStatRoot(t *testing.T) {

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -116,6 +116,7 @@ func TestFilesystemMissingEntry(t *testing.T) {
 	assert.ErrorIs(t, err, filesystem.ErrNotFound)
 	_, err = storage.Stat(t.Context(), "missing.txt")
 	assert.ErrorIs(t, err, filesystem.ErrNotFound)
+	assert.NoError(t, storage.Delete(t.Context(), "missing.txt"))
 }
 
 func entryPaths(entries []filesystem.Entry) []string {

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -1,201 +1,127 @@
 package local
 
 import (
-	"context"
-	"os"
+	"io"
+	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/go-fries/fries/filesystem/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var ctx = context.Background()
+func TestFilesystem(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
+	ctx := t.Context()
 
-func TestFilesystem_basic(t *testing.T) {
-	// init
-	require.NoError(t, os.Mkdir("./testfile/basic", os.ModePerm))
-	defer t.Cleanup(func() {
-		assert.NoError(t, os.RemoveAll("./testfile/basic"))
+	require.NoError(t, storage.MakeDirectory(ctx, "dir/nested"))
+	require.NoError(t, storage.Put(
+		ctx,
+		"dir/file.txt",
+		strings.NewReader("content"),
+		filesystem.PutOptions{},
+	))
+	require.NoError(t, storage.Put(
+		ctx,
+		"dir/nested/child.txt",
+		strings.NewReader("child"),
+		filesystem.PutOptions{},
+	))
+
+	reader, err := storage.Open(ctx, "dir/file.txt")
+	require.NoError(t, err)
+	value, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+	assert.Equal(t, "content", string(value))
+
+	entry, err := storage.Stat(ctx, "dir/file.txt")
+	require.NoError(t, err)
+	assert.True(t, entry.IsFile())
+	assert.EqualValues(t, len("content"), entry.Size)
+
+	page, err := storage.List(ctx, "dir", filesystem.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []filesystem.Entry{
+		{Path: "dir/file.txt", Kind: filesystem.EntryKindFile, Size: 7, LastModified: page.Entries[0].LastModified},
+		{Path: "dir/nested", Kind: filesystem.EntryKindDirectory, Size: page.Entries[1].Size, LastModified: page.Entries[1].LastModified},
+	}, page.Entries)
+
+	recursive, err := storage.List(ctx, "dir", filesystem.ListOptions{Recursive: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dir/file.txt", "dir/nested", "dir/nested/child.txt"}, entryPaths(recursive.Entries))
+
+	files, err := storage.List(ctx, ".", filesystem.ListOptions{
+		Recursive: true,
+		Kind:      filesystem.EntryKindFile,
 	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dir/file.txt", "dir/nested/child.txt"}, entryPaths(files.Entries))
 
-	// local
-	local := NewStorage("./testfile/basic")
-	filename := "test.txt"
+	require.NoError(t, storage.Move(ctx, "dir/file.txt", "dir/moved.txt"))
+	require.NoError(t, storage.Link(ctx, "dir/moved.txt", "dir/link.txt"))
 
-	// write
-	assert.NoError(t, local.Write(ctx, filename, []byte("test")))
+	if runtime.GOOS != "windows" {
+		require.NoError(t, storage.Symlink(ctx, "dir/moved.txt", "dir/symlink.txt"))
+		symlink, err := storage.Open(ctx, "dir/symlink.txt")
+		require.NoError(t, err)
+		value, err := io.ReadAll(symlink)
+		require.NoError(t, err)
+		require.NoError(t, symlink.Close())
+		assert.Equal(t, "content", string(value))
+	}
 
-	// read
-	data, err := local.Read(ctx, filename)
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("test"), data)
-
-	data, err = local.Read(ctx, "missing")
-	assert.Error(t, err)
-	assert.Nil(t, data)
-
-	// has
-	has, err := local.Exists(ctx, filename)
-	assert.NoError(t, err)
-	assert.True(t, has)
-
-	missing, err := local.Exists(ctx, "missing")
-	assert.NoError(t, err)
-	assert.False(t, missing)
-
-	// move
-	assert.NoError(t, local.Rename(ctx, filename, "test2.txt"))
-	has, err = local.Exists(ctx, filename)
-	assert.NoError(t, err)
-	assert.False(t, has)
-	has, err = local.Exists(ctx, "test2.txt")
-	assert.NoError(t, err)
-	assert.True(t, has)
-
-	// link
-	assert.NoError(t, local.Link(ctx, "test2.txt", "test4.txt"))
-	has, err = local.Exists(ctx, "test4.txt")
-	assert.NoError(t, err)
-	assert.True(t, has)
-	data, err = local.Read(ctx, "test4.txt")
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("test"), data)
-
-	// symlink
-	// assert.NoError(t, local.Symlink(ctx, "test2.txt", "test5.txt"))
-	// data, err = local.Read(ctx, "test5.txt")
-	// assert.NoError(t, err)
-	// assert.Equal(t, []byte("test"), data)
-
-	// path
-	path := local.Path(ctx, "1.jpg")
-	assert.Equal(t, "./testfile/basic/1.jpg", path)
-
-	// delete
-	assert.NoError(t, local.Delete(ctx, "test4.txt"))
-	has, err = local.Exists(ctx, "test4.txt")
-	assert.NoError(t, err)
-	assert.False(t, has)
+	require.NoError(t, storage.Delete(ctx, "dir/link.txt"))
+	require.NoError(t, storage.DeleteDirectory(ctx, "dir"))
+	_, err = storage.Stat(ctx, "dir")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
 }
 
-func TestFilesystem_Path(t *testing.T) {
-	local := NewStorage("./testfile/path")
+func TestFilesystemListPagination(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
+	ctx := t.Context()
 
-	tests := []struct {
-		name string
-		path string
-		want string
-	}{
-		{"", ".jpg", "./testfile/path/.jpg"},
-		{"", "", "./testfile/path/"},
-		{"", "1.jpg", "./testfile/path/1.jpg"},
-		{"", "2.jpg", "./testfile/path/2.jpg"},
-		{"", "2", "./testfile/path/2"},
-		{"", "2/3", "./testfile/path/2/3"},
-		{"", "/4/3.jpg", "./testfile/path/4/3.jpg"},
+	for _, path := range []string{"a.txt", "b.txt", "c.txt"} {
+		require.NoError(t, storage.Put(ctx, path, strings.NewReader(path), filesystem.PutOptions{}))
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, local.Path(ctx, tt.path))
-		})
-	}
+	first, err := storage.List(ctx, ".", filesystem.ListOptions{Limit: 2})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.txt", "b.txt"}, entryPaths(first.Entries))
+	assert.Equal(t, "b.txt", first.NextCursor)
+
+	second, err := storage.List(ctx, ".", filesystem.ListOptions{Limit: 2, Cursor: first.NextCursor})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c.txt"}, entryPaths(second.Entries))
+	assert.Empty(t, second.NextCursor)
 }
 
-func TestFilesystem_Name(t *testing.T) {
-	local := NewStorage("./testfile/path")
+func TestFilesystemRejectsEscapingPaths(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
 
-	tests := []struct {
-		name string
-		path string
-		want string
-	}{
-		{"", ".jpg", ""},
-		{"", "", "path"},
-		{"", "/1/", "1"},
-		{"", "1.jpg", "1"},
-		{"", "2.jpg", "2"},
-		{"", "2", "2"},
-		{"", "2/3", "3"},
-		{"", "/4/3.jpg", "3"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, local.Name(ctx, tt.path))
-		})
-	}
+	err = storage.Put(t.Context(), "../escape.txt", strings.NewReader("escape"), filesystem.PutOptions{})
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
+	assert.ErrorIs(t, storage.DeleteDirectory(t.Context(), "."), filesystem.ErrInvalidPath)
 }
 
-func TestFilesystem_Basename(t *testing.T) {
-	local := NewStorage("./testfile/path")
+func TestFilesystemMissingEntry(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
 
-	tests := []struct {
-		name string
-		path string
-		want string
-	}{
-		{"", ".jpg", ".jpg"},
-		{"", "/1/", "1"},
-		{"", "", "path"},
-		{"", "1.jpg", "1.jpg"},
-		{"", "2.jpg", "2.jpg"},
-		{"", "2", "2"},
-		{"", "2/3", "3"},
-		{"", "/4/3.jpg", "3.jpg"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, local.Basename(ctx, tt.path))
-		})
-	}
+	_, err = storage.Open(t.Context(), "missing.txt")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
+	_, err = storage.Stat(t.Context(), "missing.txt")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
 }
 
-func TestFilesystem_Dirname(t *testing.T) {
-	local := NewStorage("./testfile/path")
-
-	tests := []struct {
-		name string
-		path string
-		want string
-	}{
-		{"", ".jpg", "testfile/path"},
-		{"", "", "testfile/path"},
-		{"", "1.jpg", "testfile/path"},
-		{"", "2.jpg", "testfile/path"},
-		{"", "2", "testfile/path"},
-		{"", "3/4", "testfile/path/3"},
-		{"", "/5/6.jpg", "testfile/path/5"},
+func entryPaths(entries []filesystem.Entry) []string {
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, local.Dirname(ctx, tt.path))
-		})
-	}
-}
-
-func TestFilesystem_Extension(t *testing.T) {
-	local := NewStorage("./testfile/path")
-
-	tests := []struct {
-		name string
-		path string
-		want string
-	}{
-		{"", ".jpg", ".jpg"},
-		{"", "", ""},
-		{"", "1.jpg", ".jpg"},
-		{"", "2.jpg", ".jpg"},
-		{"", "2", ""},
-		{"", "2/3", ""},
-		{"", "/4/3.jpg", ".jpg"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, local.Extension(ctx, tt.path))
-		})
-	}
+	return paths
 }

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -2,11 +2,13 @@ package local
 
 import (
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/go-fries/fries/filesystem/v4"
 	"github.com/stretchr/testify/assert"
@@ -207,6 +209,51 @@ func TestFilesystemRejectsEscapingSymlinks(t *testing.T) {
 	assert.Error(t, storage.DeleteDirectory(ctx, "escape/directory"))
 	_, err = os.Stat(filepath.Join(outside, "directory"))
 	assert.NoError(t, err)
+}
+
+func TestFilesystemListFilesClassifiesSymlinkTargets(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic-link creation may require additional privileges")
+	}
+
+	root := t.TempDir()
+	outside := t.TempDir()
+	storage, err := New(root)
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	require.NoError(t, storage.Put(
+		ctx,
+		"file.txt",
+		strings.NewReader("content"),
+		filesystem.PutOptions{},
+	))
+	require.NoError(t, storage.MakeDirectory(ctx, "directory"))
+	require.NoError(t, storage.Symlink(ctx, "file.txt", "file-link"))
+	require.NoError(t, storage.Symlink(ctx, "directory", "directory-link"))
+	require.NoError(t, os.Symlink("missing", filepath.Join(root, "broken-link")))
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "external-link")))
+
+	page, err := storage.ListFiles(ctx, ".", filesystem.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"file-link", "file.txt"}, entryPaths(page.Entries))
+
+	fileLink, err := storage.Stat(ctx, "file-link")
+	require.NoError(t, err)
+	assert.True(t, fileLink.IsFile())
+	directoryLink, err := storage.Stat(ctx, "directory-link")
+	require.NoError(t, err)
+	assert.True(t, directoryLink.IsDir())
+}
+
+func TestEntryFromInfoUnknownKind(t *testing.T) {
+	info, err := fs.Stat(fstest.MapFS{
+		"pipe": &fstest.MapFile{Mode: fs.ModeNamedPipe},
+	}, "pipe")
+	require.NoError(t, err)
+
+	entry := entryFromInfo("pipe", info)
+	assert.Equal(t, filesystem.EntryKindUnknown, entry.Kind)
 }
 
 func TestFilesystemStatRoot(t *testing.T) {

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -44,29 +44,19 @@ func TestFilesystem(t *testing.T) {
 	assert.True(t, entry.IsFile())
 	assert.EqualValues(t, len("content"), entry.Size)
 
-	page, err := storage.List(ctx, "dir", filesystem.ListOptions{})
+	page, err := storage.ListFiles(ctx, "dir", filesystem.ListOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, []filesystem.Entry{
 		{Path: "dir/file.txt", Kind: filesystem.EntryKindFile, Size: 7, LastModified: page.Entries[0].LastModified},
 	}, page.Entries)
 
-	recursive, err := storage.List(ctx, "dir", filesystem.ListOptions{Recursive: true})
+	recursive, err := storage.ListFiles(ctx, "dir", filesystem.ListOptions{Recursive: true})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"dir/file.txt", "dir/nested/child.txt"}, entryPaths(recursive.Entries))
 
-	files, err := storage.List(ctx, ".", filesystem.ListOptions{
-		Recursive: true,
-		Kind:      filesystem.EntryKindFile,
-	})
+	files, err := storage.ListFiles(ctx, ".", filesystem.ListOptions{Recursive: true})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"dir/file.txt", "dir/nested/child.txt"}, entryPaths(files.Entries))
-
-	directories, err := storage.List(ctx, ".", filesystem.ListOptions{
-		Recursive: true,
-		Kind:      filesystem.EntryKindDirectory,
-	})
-	require.NoError(t, err)
-	assert.Empty(t, directories.Entries)
 
 	require.NoError(t, storage.Move(ctx, "dir/file.txt", "dir/moved.txt"))
 	require.NoError(t, storage.Link(ctx, "dir/moved.txt", "dir/link.txt"))
@@ -96,12 +86,12 @@ func TestFilesystemListPagination(t *testing.T) {
 		require.NoError(t, storage.Put(ctx, path, strings.NewReader(path), filesystem.PutOptions{}))
 	}
 
-	first, err := storage.List(ctx, ".", filesystem.ListOptions{Limit: 2})
+	first, err := storage.ListFiles(ctx, ".", filesystem.ListOptions{Limit: 2})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a.txt", "b.txt"}, entryPaths(first.Entries))
 	assert.Equal(t, "b.txt", first.NextCursor)
 
-	second, err := storage.List(ctx, ".", filesystem.ListOptions{Limit: 2, Cursor: first.NextCursor})
+	second, err := storage.ListFiles(ctx, ".", filesystem.ListOptions{Limit: 2, Cursor: first.NextCursor})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"c.txt"}, entryPaths(second.Entries))
 	assert.Empty(t, second.NextCursor)
@@ -112,13 +102,13 @@ func TestFilesystemListWithoutMatches(t *testing.T) {
 	require.NoError(t, err)
 	ctx := t.Context()
 
-	missing, err := storage.List(ctx, "missing", filesystem.ListOptions{})
+	missing, err := storage.ListFiles(ctx, "missing", filesystem.ListOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, missing.Entries)
 	assert.Empty(t, missing.NextCursor)
 
 	require.NoError(t, storage.Put(ctx, "file.txt", strings.NewReader("content"), filesystem.PutOptions{}))
-	file, err := storage.List(ctx, "file.txt", filesystem.ListOptions{})
+	file, err := storage.ListFiles(ctx, "file.txt", filesystem.ListOptions{})
 	require.NoError(t, err)
 	assert.Empty(t, file.Entries)
 	assert.Empty(t, file.NextCursor)
@@ -167,7 +157,7 @@ func TestFilesystemRejectsEscapingSymlinks(t *testing.T) {
 
 	_, err = storage.Stat(ctx, "escape/outside.txt")
 	assert.Error(t, err)
-	_, err = storage.List(ctx, "escape", filesystem.ListOptions{})
+	_, err = storage.ListFiles(ctx, "escape", filesystem.ListOptions{})
 	assert.Error(t, err)
 
 	assert.Error(t, storage.Delete(ctx, "escape/outside.txt"))

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -98,12 +98,24 @@ func TestFilesystemListPagination(t *testing.T) {
 }
 
 func TestFilesystemPutContentLength(t *testing.T) {
-	storage, err := New(t.TempDir())
+	root := t.TempDir()
+	storage, err := New(root)
 	require.NoError(t, err)
 	source := struct{ io.Reader }{Reader: strings.NewReader("content")}
 
 	err = storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{})
 	assert.ErrorIs(t, err, filesystem.ErrContentLengthRequired)
+
+	mismatch := int64(3)
+	err = storage.Put(
+		t.Context(),
+		"file.txt",
+		strings.NewReader("content"),
+		filesystem.PutOptions{ContentLength: &mismatch},
+	)
+	assert.ErrorIs(t, err, filesystem.ErrInvalidContentLength)
+	_, err = os.Stat(filepath.Join(root, "file.txt"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	length := int64(len("content"))
 	err = storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{

--- a/filesystem/local/filesystem_test.go
+++ b/filesystem/local/filesystem_test.go
@@ -105,7 +105,21 @@ func TestFilesystemRejectsEscapingPaths(t *testing.T) {
 
 	err = storage.Put(t.Context(), "../escape.txt", strings.NewReader("escape"), filesystem.PutOptions{})
 	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
+	_, err = storage.Open(t.Context(), ".")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
+	err = storage.Put(t.Context(), ".", strings.NewReader("root"), filesystem.PutOptions{})
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
+	assert.ErrorIs(t, storage.Delete(t.Context(), "."), filesystem.ErrInvalidPath)
 	assert.ErrorIs(t, storage.DeleteDirectory(t.Context(), "."), filesystem.ErrInvalidPath)
+}
+
+func TestFilesystemStatRoot(t *testing.T) {
+	storage, err := New(t.TempDir())
+	require.NoError(t, err)
+
+	entry, err := storage.Stat(t.Context(), ".")
+	require.NoError(t, err)
+	assert.Equal(t, filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, entry)
 }
 
 func TestFilesystemMissingEntry(t *testing.T) {

--- a/filesystem/oss/README.md
+++ b/filesystem/oss/README.md
@@ -1,0 +1,83 @@
+# Alibaba Cloud OSS Filesystem
+
+The Alibaba Cloud OSS Filesystem driver stores logical filesystem paths as
+objects in an OSS bucket. It implements the core filesystem API and provides
+native copy and move capabilities.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/filesystem/v4
+go get github.com/go-fries/fries/filesystem/oss/v4
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	aliyunoss "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/credentials"
+	"github.com/go-fries/fries/filesystem/v4"
+	filesystemOSS "github.com/go-fries/fries/filesystem/oss/v4"
+)
+
+func main() {
+	ctx := context.Background()
+
+	cfg := aliyunoss.LoadDefaultConfig().
+		WithCredentialsProvider(credentials.NewEnvironmentVariableCredentialsProvider()).
+		WithRegion("cn-hangzhou")
+	client := aliyunoss.NewClient(cfg)
+	driver := filesystemOSS.New(
+		client,
+		"my-bucket",
+		filesystemOSS.WithRoot("application"),
+	)
+	storage := filesystem.NewRepository(driver)
+
+	if err := storage.WriteFile(
+		ctx,
+		"documents/example.txt",
+		[]byte("oss content"),
+		filesystem.PutOptions{ContentType: "text/plain"},
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	page, err := storage.ListFiles(
+		ctx,
+		"documents",
+		filesystem.ListOptions{Recursive: true},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, entry := range page.Entries {
+		fmt.Printf("%s (%d bytes)\n", entry.Path, entry.Size)
+	}
+
+	if err := storage.Copy(
+		ctx,
+		"documents/example.txt",
+		"documents/example-copy.txt",
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+## Behavior
+
+- `WithRoot` places every logical path below an object-key prefix. In the
+  example, `documents/example.txt` maps to
+  `application/documents/example.txt`.
+- Directories are virtual prefixes. `ListFiles` returns objects only and omits
+  directory markers.
+- `Repository.Copy` uses OSS's native server-side copy operation.
+- Move is implemented as copy followed by delete and is not atomic.

--- a/filesystem/oss/config.go
+++ b/filesystem/oss/config.go
@@ -1,0 +1,31 @@
+package oss
+
+type config struct {
+	root string
+}
+
+// Option configures an OSS filesystem.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(cfg *config) {
+	f(cfg)
+}
+
+// WithRoot stores logical paths below root in the bucket.
+func WithRoot(root string) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.root = root
+	})
+}
+
+func newConfig(opts ...Option) *config {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+	return cfg
+}

--- a/filesystem/oss/doc.go
+++ b/filesystem/oss/doc.go
@@ -1,0 +1,2 @@
+// Package oss provides a filesystem driver backed by Alibaba Cloud OSS.
+package oss

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -189,6 +189,7 @@ func (s *Filesystem) List(
 	path string,
 	options filesystem.ListOptions,
 ) (filesystem.ListPage, error) {
+	options = options.Normalize()
 	if err := filesystem.ValidatePath(path); err != nil {
 		return filesystem.ListPage{}, err
 	}
@@ -202,9 +203,7 @@ func (s *Filesystem) List(
 	if options.Cursor != "" {
 		request.ContinuationToken = aliyunoss.Ptr(options.Cursor)
 	}
-	if options.Limit > 0 {
-		request.MaxKeys = int32(min(options.Limit, 1000))
-	}
+	request.MaxKeys = int32(options.Limit)
 
 	result, err := s.client.ListObjectsV2(ctx, request)
 	if err != nil {

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -183,8 +183,8 @@ func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error)
 	return len(result.Contents) > 0 || len(result.CommonPrefixes) > 0, nil
 }
 
-// List returns one page of objects below path.
-func (s *Filesystem) List(
+// ListFiles returns one page of objects below path.
+func (s *Filesystem) ListFiles(
 	ctx context.Context,
 	path string,
 	options filesystem.ListOptions,
@@ -209,7 +209,7 @@ func (s *Filesystem) List(
 	if err != nil {
 		return filesystem.ListPage{}, wrapPathError("list", path, err)
 	}
-	page := filesystem.ListPage{Entries: s.entries(result, options.Kind)}
+	page := filesystem.ListPage{Entries: s.entries(result)}
 	if result.NextContinuationToken != nil {
 		page.NextCursor = *result.NextContinuationToken
 	}
@@ -244,10 +244,7 @@ func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
 	return s.Delete(ctx, src)
 }
 
-func (s *Filesystem) entries(
-	result *aliyunoss.ListObjectsV2Result,
-	kind filesystem.EntryKind,
-) []filesystem.Entry {
+func (s *Filesystem) entries(result *aliyunoss.ListObjectsV2Result) []filesystem.Entry {
 	byPath := make(map[string]filesystem.Entry, len(result.Contents))
 	for _, object := range result.Contents {
 		key := dereference(object.Key)
@@ -255,8 +252,7 @@ func (s *Filesystem) entries(
 			continue
 		}
 		path, ok := s.prefixer.Strip(key)
-		if !ok || path == "." || !filesystem.ValidPath(path) ||
-			!matchesKind(filesystem.EntryKindFile, kind) {
+		if !ok || path == "." || !filesystem.ValidPath(path) {
 			continue
 		}
 		entry := filesystem.Entry{
@@ -284,10 +280,6 @@ func directoryPrefix(prefix string) string {
 		return ""
 	}
 	return strings.TrimSuffix(prefix, "/") + "/"
-}
-
-func matchesKind(entryKind, filter filesystem.EntryKind) bool {
-	return filter == filesystem.EntryKindAny || entryKind == filter
 }
 
 func wrapPathError(op, path string, err error) error {

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -183,7 +183,7 @@ func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error)
 	return len(result.Contents) > 0 || len(result.CommonPrefixes) > 0, nil
 }
 
-// List returns one page of objects and virtual directories below path.
+// List returns one page of objects below path.
 func (s *Filesystem) List(
 	ctx context.Context,
 	path string,
@@ -248,34 +248,27 @@ func (s *Filesystem) entries(
 	result *aliyunoss.ListObjectsV2Result,
 	kind filesystem.EntryKind,
 ) []filesystem.Entry {
-	byPath := make(map[string]filesystem.Entry, len(result.Contents)+len(result.CommonPrefixes))
+	byPath := make(map[string]filesystem.Entry, len(result.Contents))
 	for _, object := range result.Contents {
 		key := dereference(object.Key)
-		entryKind := filesystem.EntryKindFile
 		if strings.HasSuffix(key, "/") {
-			entryKind = filesystem.EntryKindDirectory
-			key = strings.TrimSuffix(key, "/")
-		}
-		path, ok := s.prefixer.Strip(key)
-		if !ok || path == "." || !filesystem.ValidPath(path) || !matchesKind(entryKind, kind) {
 			continue
 		}
-		entry := filesystem.Entry{Path: path, Kind: entryKind, Size: object.Size}
+		path, ok := s.prefixer.Strip(key)
+		if !ok || path == "." || !filesystem.ValidPath(path) ||
+			!matchesKind(filesystem.EntryKindFile, kind) {
+			continue
+		}
+		entry := filesystem.Entry{
+			Path: path,
+			Kind: filesystem.EntryKindFile,
+			Size: object.Size,
+		}
 		if object.LastModified != nil {
 			entry.LastModified = *object.LastModified
 		}
 		byPath[path] = entry
 	}
-	for _, commonPrefix := range result.CommonPrefixes {
-		key := strings.TrimSuffix(dereference(commonPrefix.Prefix), "/")
-		path, ok := s.prefixer.Strip(key)
-		if !ok || path == "." || !filesystem.ValidPath(path) ||
-			!matchesKind(filesystem.EntryKindDirectory, kind) {
-			continue
-		}
-		byPath[path] = filesystem.Entry{Path: path, Kind: filesystem.EntryKindDirectory}
-	}
-
 	entries := make([]filesystem.Entry, 0, len(byPath))
 	for _, entry := range byPath {
 		entries = append(entries, entry)

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -50,7 +50,6 @@ type ossClient interface {
 type Filesystem struct {
 	client   ossClient
 	bucket   string
-	root     string
 	prefixer *filesystem.PathPrefixer
 }
 
@@ -60,28 +59,18 @@ var (
 	_ filesystem.Mover  = (*Filesystem)(nil)
 )
 
-// Option configures an OSS filesystem.
-type Option func(*Filesystem)
-
-// WithRoot stores logical paths below root in the bucket.
-func WithRoot(root string) Option {
-	return func(storage *Filesystem) {
-		storage.root = root
-	}
-}
-
 // New creates an OSS-backed filesystem.
-func New(client *aliyunoss.Client, bucket string, options ...Option) *Filesystem {
-	return newFilesystem(client, bucket, options...)
+func New(client *aliyunoss.Client, bucket string, opts ...Option) *Filesystem {
+	return newFilesystem(client, bucket, opts...)
 }
 
-func newFilesystem(client ossClient, bucket string, options ...Option) *Filesystem {
-	storage := &Filesystem{client: client, bucket: bucket}
-	for _, option := range options {
-		option(storage)
+func newFilesystem(client ossClient, bucket string, opts ...Option) *Filesystem {
+	cfg := newConfig(opts...)
+	return &Filesystem{
+		client:   client,
+		bucket:   bucket,
+		prefixer: filesystem.NewPathPrefixer(cfg.root),
 	}
-	storage.prefixer = filesystem.NewPathPrefixer(storage.root)
-	return storage
 }
 
 // Open opens path for streaming reads.

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -88,7 +88,8 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 	return result.Body, nil
 }
 
-// Put writes src to path, replacing an existing object.
+// Put writes src to path, replacing an existing object. The content length must
+// be explicit or inferable as described by filesystem.PutOptions.
 func (s *Filesystem) Put(
 	ctx context.Context,
 	path string,
@@ -98,16 +99,21 @@ func (s *Filesystem) Put(
 	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
+	contentLength, err := options.ResolveContentLength(src)
+	if err != nil {
+		return wrapPathError("put", path, err)
+	}
 	request := &aliyunoss.PutObjectRequest{
-		Bucket:   aliyunoss.Ptr(s.bucket),
-		Key:      aliyunoss.Ptr(s.prefixer.Prefix(path)),
-		Body:     src,
-		Metadata: cloneMetadata(options.Metadata),
+		Bucket:        aliyunoss.Ptr(s.bucket),
+		Key:           aliyunoss.Ptr(s.prefixer.Prefix(path)),
+		Body:          src,
+		ContentLength: aliyunoss.Ptr(contentLength),
+		Metadata:      cloneMetadata(options.Metadata),
 	}
 	if options.ContentType != "" {
 		request.ContentType = aliyunoss.Ptr(options.ContentType)
 	}
-	_, err := s.client.PutObject(ctx, request)
+	_, err = s.client.PutObject(ctx, request)
 	if err != nil {
 		return wrapPathError("put", path, err)
 	}

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -129,7 +129,8 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 	return nil
 }
 
-// Stat returns object metadata.
+// Stat returns object metadata. If an exact object does not exist, Stat issues
+// one additional ListObjectsV2 request to detect a virtual directory prefix.
 func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
 	if err := filesystem.ValidatePath(path); err != nil {
 		return filesystem.Entry{}, err
@@ -145,6 +146,15 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
+		if isNotFound(err) {
+			directory, listErr := s.hasChildren(ctx, path)
+			if listErr != nil {
+				return filesystem.Entry{}, wrapPathError("stat", path, listErr)
+			}
+			if directory {
+				return filesystem.Entry{Path: path, Kind: filesystem.EntryKindDirectory}, nil
+			}
+		}
 		return filesystem.Entry{}, wrapPathError("stat", path, err)
 	}
 
@@ -159,6 +169,18 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 		entry.LastModified = *result.LastModified
 	}
 	return entry, nil
+}
+
+func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error) {
+	result, err := s.client.ListObjectsV2(ctx, &aliyunoss.ListObjectsV2Request{
+		Bucket:  aliyunoss.Ptr(s.bucket),
+		Prefix:  aliyunoss.Ptr(directoryPrefix(s.prefixer.Prefix(path))),
+		MaxKeys: 1,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(result.Contents) > 0 || len(result.CommonPrefixes) > 0, nil
 }
 
 // List returns one page of objects and virtual directories below path.

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -1,171 +1,316 @@
 package oss
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"io"
-	"net/http"
-	"time"
+	"io/fs"
+	"maps"
+	"sort"
+	"strings"
 
-	"github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	aliyunoss "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
 	"github.com/go-fries/fries/filesystem/v4"
 )
 
+type ossClient interface {
+	GetObject(
+		context.Context,
+		*aliyunoss.GetObjectRequest,
+		...func(*aliyunoss.Options),
+	) (*aliyunoss.GetObjectResult, error)
+	PutObject(
+		context.Context,
+		*aliyunoss.PutObjectRequest,
+		...func(*aliyunoss.Options),
+	) (*aliyunoss.PutObjectResult, error)
+	DeleteObject(
+		context.Context,
+		*aliyunoss.DeleteObjectRequest,
+		...func(*aliyunoss.Options),
+	) (*aliyunoss.DeleteObjectResult, error)
+	HeadObject(
+		context.Context,
+		*aliyunoss.HeadObjectRequest,
+		...func(*aliyunoss.Options),
+	) (*aliyunoss.HeadObjectResult, error)
+	ListObjectsV2(
+		context.Context,
+		*aliyunoss.ListObjectsV2Request,
+		...func(*aliyunoss.Options),
+	) (*aliyunoss.ListObjectsV2Result, error)
+	CopyObject(
+		context.Context,
+		*aliyunoss.CopyObjectRequest,
+		...func(*aliyunoss.Options),
+	) (*aliyunoss.CopyObjectResult, error)
+}
+
+// Filesystem stores logical filesystem paths in an Alibaba Cloud OSS bucket.
 type Filesystem struct {
-	client   *oss.Client
+	client   ossClient
 	bucket   string
 	root     string
 	prefixer *filesystem.PathPrefixer
 }
 
+var (
+	_ filesystem.Driver = (*Filesystem)(nil)
+	_ filesystem.Copier = (*Filesystem)(nil)
+	_ filesystem.Mover  = (*Filesystem)(nil)
+)
+
+// Option configures an OSS filesystem.
 type Option func(*Filesystem)
 
+// WithRoot stores logical paths below root in the bucket.
 func WithRoot(root string) Option {
-	return func(f *Filesystem) {
-		f.root = root
+	return func(storage *Filesystem) {
+		storage.root = root
 	}
 }
 
-func New(client *oss.Client, bucket string, opts ...Option) *Filesystem {
-	fs := &Filesystem{
-		client: client,
-		bucket: bucket,
-	}
-	for _, opt := range opts {
-		opt(fs)
-	}
-	fs.prefixer = filesystem.NewPathPrefixer(fs.root)
-	return fs
+// New creates an OSS-backed filesystem.
+func New(client *aliyunoss.Client, bucket string, options ...Option) *Filesystem {
+	return newFilesystem(client, bucket, options...)
 }
 
-func (fs *Filesystem) Read(ctx context.Context, path string) ([]byte, error) {
-	result, err := fs.client.GetObject(ctx, &oss.GetObjectRequest{
-		Bucket: oss.Ptr(fs.bucket),
-		Key:    oss.Ptr(fs.prefixer.Prefix(path)),
-	})
-	if err != nil {
+func newFilesystem(client ossClient, bucket string, options ...Option) *Filesystem {
+	storage := &Filesystem{client: client, bucket: bucket}
+	for _, option := range options {
+		option(storage)
+	}
+	storage.prefixer = filesystem.NewPathPrefixer(storage.root)
+	return storage
+}
+
+// Open opens path for streaming reads.
+func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
 		return nil, err
 	}
-	defer result.Body.Close() //nolint:errcheck
-	return io.ReadAll(result.Body)
-}
-
-func (fs *Filesystem) Write(ctx context.Context, path string, value []byte) error {
-	_, err := fs.client.PutObject(ctx, &oss.PutObjectRequest{
-		Bucket:        oss.Ptr(fs.bucket),
-		Key:           oss.Ptr(fs.prefixer.Prefix(path)),
-		Body:          bytes.NewBuffer(value),
-		ContentType:   oss.Ptr(http.DetectContentType(value)),
-		ContentLength: oss.Ptr(int64(len(value))),
+	result, err := s.client.GetObject(ctx, &aliyunoss.GetObjectRequest{
+		Bucket: aliyunoss.Ptr(s.bucket),
+		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
 	})
-	return err
+	if err != nil {
+		return nil, wrapPathError("open", path, err)
+	}
+	return result.Body, nil
 }
 
-func (fs *Filesystem) Delete(ctx context.Context, path string) error {
-	_, err := fs.client.DeleteObject(ctx, &oss.DeleteObjectRequest{
-		Bucket: oss.Ptr(fs.bucket),
-		Key:    oss.Ptr(fs.prefixer.Prefix(path)),
+// Put writes src to path, replacing an existing object.
+func (s *Filesystem) Put(
+	ctx context.Context,
+	path string,
+	src io.Reader,
+	options filesystem.PutOptions,
+) error {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return err
+	}
+	request := &aliyunoss.PutObjectRequest{
+		Bucket:   aliyunoss.Ptr(s.bucket),
+		Key:      aliyunoss.Ptr(s.prefixer.Prefix(path)),
+		Body:     src,
+		Metadata: cloneMetadata(options.Metadata),
+	}
+	if options.ContentType != "" {
+		request.ContentType = aliyunoss.Ptr(options.ContentType)
+	}
+	_, err := s.client.PutObject(ctx, request)
+	if err != nil {
+		return wrapPathError("put", path, err)
+	}
+	return nil
+}
+
+// Delete removes an object.
+func (s *Filesystem) Delete(ctx context.Context, path string) error {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return err
+	}
+	_, err := s.client.DeleteObject(ctx, &aliyunoss.DeleteObjectRequest{
+		Bucket: aliyunoss.Ptr(s.bucket),
+		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
 	})
-	return err
+	if err != nil {
+		return wrapPathError("delete", path, err)
+	}
+	return nil
 }
 
-func (fs *Filesystem) Exists(ctx context.Context, path string) (bool, error) {
-	return fs.client.IsObjectExist(ctx, fs.bucket, fs.prefixer.Prefix(path))
-}
-
-func (fs *Filesystem) Rename(ctx context.Context, oldPath, newPath string) error {
-	_, err := fs.client.CopyObject(ctx, &oss.CopyObjectRequest{
-		Bucket:       oss.Ptr(fs.bucket),
-		Key:          oss.Ptr(fs.prefixer.Prefix(newPath)),
-		SourceBucket: oss.Ptr(fs.bucket),
-		SourceKey:    oss.Ptr(fs.prefixer.Prefix(oldPath)),
+// Stat returns object metadata.
+func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return filesystem.Entry{}, err
+	}
+	result, err := s.client.HeadObject(ctx, &aliyunoss.HeadObjectRequest{
+		Bucket: aliyunoss.Ptr(s.bucket),
+		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
 	})
-	return err
+	if err != nil {
+		return filesystem.Entry{}, wrapPathError("stat", path, err)
+	}
+
+	entry := filesystem.Entry{
+		Path:        path,
+		Kind:        filesystem.EntryKindFile,
+		Size:        result.ContentLength,
+		ContentType: dereference(result.ContentType),
+		Metadata:    cloneMetadata(result.Metadata),
+	}
+	if result.LastModified != nil {
+		entry.LastModified = *result.LastModified
+	}
+	return entry, nil
 }
 
-func (fs *Filesystem) Link(ctx context.Context, oldPath, newPath string) error {
-	// TODO implement me
-	panic("implement me")
+// List returns one page of objects and virtual directories below path.
+func (s *Filesystem) List(
+	ctx context.Context,
+	path string,
+	options filesystem.ListOptions,
+) (filesystem.ListPage, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return filesystem.ListPage{}, err
+	}
+	request := &aliyunoss.ListObjectsV2Request{
+		Bucket: aliyunoss.Ptr(s.bucket),
+		Prefix: aliyunoss.Ptr(directoryPrefix(s.prefixer.Prefix(path))),
+	}
+	if !options.Recursive {
+		request.Delimiter = aliyunoss.Ptr("/")
+	}
+	if options.Cursor != "" {
+		request.ContinuationToken = aliyunoss.Ptr(options.Cursor)
+	}
+	if options.Limit > 0 {
+		request.MaxKeys = int32(min(options.Limit, 1000))
+	}
+
+	result, err := s.client.ListObjectsV2(ctx, request)
+	if err != nil {
+		return filesystem.ListPage{}, wrapPathError("list", path, err)
+	}
+	page := filesystem.ListPage{Entries: s.entries(result, options.Kind)}
+	if result.NextContinuationToken != nil {
+		page.NextCursor = *result.NextContinuationToken
+	}
+	return page, nil
 }
 
-func (fs *Filesystem) Symlink(ctx context.Context, oldPath, newPath string) error {
-	// TODO implement me
-	panic("implement me")
+// Copy copies src to dst using OSS's native server-side copy operation.
+func (s *Filesystem) Copy(ctx context.Context, src, dst string) error {
+	if err := filesystem.ValidatePath(src); err != nil {
+		return err
+	}
+	if err := filesystem.ValidatePath(dst); err != nil {
+		return err
+	}
+	_, err := s.client.CopyObject(ctx, &aliyunoss.CopyObjectRequest{
+		Bucket:       aliyunoss.Ptr(s.bucket),
+		Key:          aliyunoss.Ptr(s.prefixer.Prefix(dst)),
+		SourceBucket: aliyunoss.Ptr(s.bucket),
+		SourceKey:    aliyunoss.Ptr(s.prefixer.Prefix(src)),
+	})
+	if err != nil {
+		return wrapPathError("copy", src, err)
+	}
+	return nil
 }
 
-func (fs *Filesystem) Files(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+// Move copies src to dst and then deletes src. The operation is not atomic.
+func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
+	if err := s.Copy(ctx, src, dst); err != nil {
+		return err
+	}
+	return s.Delete(ctx, src)
 }
 
-func (fs *Filesystem) AllFiles(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+func (s *Filesystem) entries(
+	result *aliyunoss.ListObjectsV2Result,
+	kind filesystem.EntryKind,
+) []filesystem.Entry {
+	byPath := make(map[string]filesystem.Entry, len(result.Contents)+len(result.CommonPrefixes))
+	for _, object := range result.Contents {
+		key := dereference(object.Key)
+		entryKind := filesystem.EntryKindFile
+		if strings.HasSuffix(key, "/") {
+			entryKind = filesystem.EntryKindDirectory
+			key = strings.TrimSuffix(key, "/")
+		}
+		path, ok := s.prefixer.Strip(key)
+		if !ok || path == "." || !filesystem.ValidPath(path) || !matchesKind(entryKind, kind) {
+			continue
+		}
+		entry := filesystem.Entry{Path: path, Kind: entryKind, Size: object.Size}
+		if object.LastModified != nil {
+			entry.LastModified = *object.LastModified
+		}
+		byPath[path] = entry
+	}
+	for _, commonPrefix := range result.CommonPrefixes {
+		key := strings.TrimSuffix(dereference(commonPrefix.Prefix), "/")
+		path, ok := s.prefixer.Strip(key)
+		if !ok || path == "." || !filesystem.ValidPath(path) ||
+			!matchesKind(filesystem.EntryKindDirectory, kind) {
+			continue
+		}
+		byPath[path] = filesystem.Entry{Path: path, Kind: filesystem.EntryKindDirectory}
+	}
+
+	entries := make([]filesystem.Entry, 0, len(byPath))
+	for _, entry := range byPath {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries
 }
 
-func (fs *Filesystem) Directories(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+func directoryPrefix(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	return strings.TrimSuffix(prefix, "/") + "/"
 }
 
-func (fs *Filesystem) AllDirectories(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+func matchesKind(entryKind, filter filesystem.EntryKind) bool {
+	return filter == filesystem.EntryKindAny || entryKind == filter
 }
 
-func (fs *Filesystem) MakeDirectory(ctx context.Context, path string) error {
-	// TODO implement me
-	panic("implement me")
+func wrapPathError(op, path string, err error) error {
+	if isNotFound(err) {
+		err = filesystem.ErrNotFound
+	}
+	return &fs.PathError{Op: op, Path: path, Err: err}
 }
 
-func (fs *Filesystem) DeleteDirectory(ctx context.Context, path string) error {
-	// TODO implement me
-	panic("implement me")
+func isNotFound(err error) bool {
+	var serviceError *aliyunoss.ServiceError
+	if !errors.As(err, &serviceError) {
+		return false
+	}
+	if serviceError.StatusCode == 404 {
+		return true
+	}
+	switch serviceError.Code {
+	case "NoSuchKey", "NoSuchObject", "NotFound":
+		return true
+	default:
+		return false
+	}
 }
 
-func (fs *Filesystem) IsFile(ctx context.Context, path string) (bool, error) {
-	// TODO implement me
-	panic("implement me")
+func cloneMetadata(metadata map[string]string) map[string]string {
+	return maps.Clone(metadata)
 }
 
-func (fs *Filesystem) IsDir(ctx context.Context, path string) (bool, error) {
-	// TODO implement me
-	panic("implement me")
+func dereference(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
 }
-
-func (fs *Filesystem) Size(ctx context.Context, path string) (int64, error) {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (fs *Filesystem) LastModified(ctx context.Context, path string) (*time.Time, error) {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (fs *Filesystem) Path(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (fs *Filesystem) Name(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (fs *Filesystem) Basename(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (fs *Filesystem) Dirname(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (fs *Filesystem) Extension(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-var _ filesystem.Filesystem = (*Filesystem)(nil)

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -75,7 +75,7 @@ func newFilesystem(client ossClient, bucket string, opts ...Option) *Filesystem 
 
 // Open opens path for streaming reads.
 func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, error) {
-	if err := filesystem.ValidatePath(path); err != nil {
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return nil, err
 	}
 	result, err := s.client.GetObject(ctx, &aliyunoss.GetObjectRequest{
@@ -95,7 +95,7 @@ func (s *Filesystem) Put(
 	src io.Reader,
 	options filesystem.PutOptions,
 ) error {
-	if err := filesystem.ValidatePath(path); err != nil {
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
 	request := &aliyunoss.PutObjectRequest{
@@ -116,7 +116,7 @@ func (s *Filesystem) Put(
 
 // Delete removes an object.
 func (s *Filesystem) Delete(ctx context.Context, path string) error {
-	if err := filesystem.ValidatePath(path); err != nil {
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
 	_, err := s.client.DeleteObject(ctx, &aliyunoss.DeleteObjectRequest{
@@ -133,6 +133,12 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
 	if err := filesystem.ValidatePath(path); err != nil {
 		return filesystem.Entry{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return filesystem.Entry{}, err
+	}
+	if path == "." {
+		return filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, nil
 	}
 	result, err := s.client.HeadObject(ctx, &aliyunoss.HeadObjectRequest{
 		Bucket: aliyunoss.Ptr(s.bucket),
@@ -191,10 +197,10 @@ func (s *Filesystem) List(
 
 // Copy copies src to dst using OSS's native server-side copy operation.
 func (s *Filesystem) Copy(ctx context.Context, src, dst string) error {
-	if err := filesystem.ValidatePath(src); err != nil {
+	if err := filesystem.ValidateFilePath(src); err != nil {
 		return err
 	}
-	if err := filesystem.ValidatePath(dst); err != nil {
+	if err := filesystem.ValidateFilePath(dst); err != nil {
 		return err
 	}
 	_, err := s.client.CopyObject(ctx, &aliyunoss.CopyObjectRequest{

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -58,6 +58,19 @@ func TestFilesystemNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, filesystem.ErrNotFound)
 }
 
+func TestFilesystemRoot(t *testing.T) {
+	storage := newFilesystem(&fakeClient{}, "bucket", WithRoot("root"))
+
+	entry, err := storage.Stat(t.Context(), ".")
+	require.NoError(t, err)
+	assert.Equal(t, filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, entry)
+
+	_, err = storage.Open(t.Context(), ".")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
+	assert.ErrorIs(t, storage.Delete(t.Context(), "."), filesystem.ErrInvalidPath)
+	assert.ErrorIs(t, storage.Copy(t.Context(), ".", "target.txt"), filesystem.ErrInvalidPath)
+}
+
 type fakeClient struct {
 	getErr        error
 	listRequest   *aliyunoss.ListObjectsV2Request

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -1,11 +1,126 @@
 package oss
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	aliyunoss "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	"github.com/go-fries/fries/filesystem/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFilesystem(t *testing.T) {
-	assert.NotNil(t, New(nil, "bucket"))
+func TestFilesystemList(t *testing.T) {
+	modified := time.Now()
+	client := &fakeClient{
+		listResult: &aliyunoss.ListObjectsV2Result{
+			Contents: []aliyunoss.ObjectProperties{{
+				Key:          aliyunoss.Ptr("root/dir/file.txt"),
+				Size:         7,
+				LastModified: &modified,
+			}},
+			CommonPrefixes:        []aliyunoss.CommonPrefix{{Prefix: aliyunoss.Ptr("root/dir/nested/")}},
+			NextContinuationToken: aliyunoss.Ptr("next"),
+		},
+	}
+	storage := newFilesystem(client, "bucket", WithRoot("root"))
+
+	page, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
+		Limit:  2,
+		Cursor: "cursor",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "root/dir/", dereference(client.listRequest.Prefix))
+	assert.Equal(t, "/", dereference(client.listRequest.Delimiter))
+	assert.Equal(t, "cursor", dereference(client.listRequest.ContinuationToken))
+	assert.Equal(t, []string{"dir/file.txt", "dir/nested"}, entryPaths(page.Entries))
+	assert.Equal(t, "next", page.NextCursor)
+}
+
+func TestFilesystemMove(t *testing.T) {
+	client := &fakeClient{}
+	storage := newFilesystem(client, "bucket", WithRoot("root"))
+
+	require.NoError(t, storage.Move(t.Context(), "source.txt", "target.txt"))
+	require.NotNil(t, client.copyRequest)
+	require.NotNil(t, client.deleteRequest)
+	assert.Equal(t, "root/source.txt", dereference(client.copyRequest.SourceKey))
+	assert.Equal(t, "root/target.txt", dereference(client.copyRequest.Key))
+	assert.Equal(t, "root/source.txt", dereference(client.deleteRequest.Key))
+}
+
+func TestFilesystemNotFound(t *testing.T) {
+	client := &fakeClient{getErr: &aliyunoss.ServiceError{StatusCode: 404, Code: "NoSuchKey"}}
+	storage := newFilesystem(client, "bucket")
+
+	_, err := storage.Open(t.Context(), "missing.txt")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
+}
+
+type fakeClient struct {
+	getErr        error
+	listRequest   *aliyunoss.ListObjectsV2Request
+	listResult    *aliyunoss.ListObjectsV2Result
+	copyRequest   *aliyunoss.CopyObjectRequest
+	deleteRequest *aliyunoss.DeleteObjectRequest
+}
+
+func (c *fakeClient) GetObject(
+	context.Context,
+	*aliyunoss.GetObjectRequest,
+	...func(*aliyunoss.Options),
+) (*aliyunoss.GetObjectResult, error) {
+	return nil, c.getErr
+}
+
+func (*fakeClient) PutObject(
+	context.Context,
+	*aliyunoss.PutObjectRequest,
+	...func(*aliyunoss.Options),
+) (*aliyunoss.PutObjectResult, error) {
+	return &aliyunoss.PutObjectResult{}, nil
+}
+
+func (c *fakeClient) DeleteObject(
+	_ context.Context,
+	request *aliyunoss.DeleteObjectRequest,
+	_ ...func(*aliyunoss.Options),
+) (*aliyunoss.DeleteObjectResult, error) {
+	c.deleteRequest = request
+	return &aliyunoss.DeleteObjectResult{}, nil
+}
+
+func (*fakeClient) HeadObject(
+	context.Context,
+	*aliyunoss.HeadObjectRequest,
+	...func(*aliyunoss.Options),
+) (*aliyunoss.HeadObjectResult, error) {
+	return &aliyunoss.HeadObjectResult{}, nil
+}
+
+func (c *fakeClient) ListObjectsV2(
+	_ context.Context,
+	request *aliyunoss.ListObjectsV2Request,
+	_ ...func(*aliyunoss.Options),
+) (*aliyunoss.ListObjectsV2Result, error) {
+	c.listRequest = request
+	return c.listResult, nil
+}
+
+func (c *fakeClient) CopyObject(
+	_ context.Context,
+	request *aliyunoss.CopyObjectRequest,
+	_ ...func(*aliyunoss.Options),
+) (*aliyunoss.CopyObjectResult, error) {
+	c.copyRequest = request
+	return &aliyunoss.CopyObjectResult{}, nil
+}
+
+func entryPaths(entries []filesystem.Entry) []string {
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
+	}
+	return paths
 }

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -71,8 +71,37 @@ func TestFilesystemRoot(t *testing.T) {
 	assert.ErrorIs(t, storage.Copy(t.Context(), ".", "target.txt"), filesystem.ErrInvalidPath)
 }
 
+func TestFilesystemStatVirtualDirectory(t *testing.T) {
+	client := &fakeClient{
+		headErr: &aliyunoss.ServiceError{StatusCode: 404, Code: "NoSuchKey"},
+		listResult: &aliyunoss.ListObjectsV2Result{
+			Contents: []aliyunoss.ObjectProperties{{Key: aliyunoss.Ptr("root/images/file.jpg")}},
+		},
+	}
+	storage := newFilesystem(client, "bucket", WithRoot("root"))
+
+	entry, err := storage.Stat(t.Context(), "images")
+	require.NoError(t, err)
+	assert.Equal(t, filesystem.Entry{Path: "images", Kind: filesystem.EntryKindDirectory}, entry)
+	assert.Equal(t, "root/images/", dereference(client.listRequest.Prefix))
+	assert.Equal(t, int32(1), client.listRequest.MaxKeys)
+}
+
+func TestFilesystemStatMissing(t *testing.T) {
+	client := &fakeClient{
+		headErr:    &aliyunoss.ServiceError{StatusCode: 404, Code: "NoSuchKey"},
+		listResult: &aliyunoss.ListObjectsV2Result{},
+	}
+	storage := newFilesystem(client, "bucket")
+
+	_, err := storage.Stat(t.Context(), "missing")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
+}
+
 type fakeClient struct {
 	getErr        error
+	headErr       error
+	headResult    *aliyunoss.HeadObjectResult
 	listRequest   *aliyunoss.ListObjectsV2Request
 	listResult    *aliyunoss.ListObjectsV2Result
 	copyRequest   *aliyunoss.CopyObjectRequest
@@ -104,12 +133,15 @@ func (c *fakeClient) DeleteObject(
 	return &aliyunoss.DeleteObjectResult{}, nil
 }
 
-func (*fakeClient) HeadObject(
-	context.Context,
-	*aliyunoss.HeadObjectRequest,
-	...func(*aliyunoss.Options),
+func (c *fakeClient) HeadObject(
+	_ context.Context,
+	_ *aliyunoss.HeadObjectRequest,
+	_ ...func(*aliyunoss.Options),
 ) (*aliyunoss.HeadObjectResult, error) {
-	return &aliyunoss.HeadObjectResult{}, nil
+	if c.headResult == nil {
+		c.headResult = &aliyunoss.HeadObjectResult{}
+	}
+	return c.headResult, c.headErr
 }
 
 func (c *fakeClient) ListObjectsV2(

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -2,6 +2,8 @@ package oss
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +53,23 @@ func TestFilesystemMove(t *testing.T) {
 	assert.Equal(t, "root/source.txt", dereference(client.copyRequest.SourceKey))
 	assert.Equal(t, "root/target.txt", dereference(client.copyRequest.Key))
 	assert.Equal(t, "root/source.txt", dereference(client.deleteRequest.Key))
+}
+
+func TestFilesystemPutContentLength(t *testing.T) {
+	client := &fakeClient{}
+	storage := newFilesystem(client, "bucket")
+	source := struct{ io.Reader }{Reader: strings.NewReader("content")}
+
+	err := storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{})
+	assert.ErrorIs(t, err, filesystem.ErrContentLengthRequired)
+
+	length := int64(len("content"))
+	err = storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{
+		ContentLength: &length,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client.putRequest)
+	assert.Equal(t, length, *client.putRequest.ContentLength)
 }
 
 func TestFilesystemNotFound(t *testing.T) {
@@ -107,6 +126,7 @@ type fakeClient struct {
 	headResult    *aliyunoss.HeadObjectResult
 	listRequest   *aliyunoss.ListObjectsV2Request
 	listResult    *aliyunoss.ListObjectsV2Result
+	putRequest    *aliyunoss.PutObjectRequest
 	copyRequest   *aliyunoss.CopyObjectRequest
 	deleteRequest *aliyunoss.DeleteObjectRequest
 }
@@ -119,11 +139,12 @@ func (c *fakeClient) GetObject(
 	return nil, c.getErr
 }
 
-func (*fakeClient) PutObject(
-	context.Context,
-	*aliyunoss.PutObjectRequest,
-	...func(*aliyunoss.Options),
+func (c *fakeClient) PutObject(
+	_ context.Context,
+	request *aliyunoss.PutObjectRequest,
+	_ ...func(*aliyunoss.Options),
 ) (*aliyunoss.PutObjectResult, error) {
+	c.putRequest = request
 	return &aliyunoss.PutObjectResult{}, nil
 }
 

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -29,7 +29,7 @@ func TestFilesystemList(t *testing.T) {
 	}
 	storage := newFilesystem(client, "bucket", WithRoot("root"))
 
-	page, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
+	page, err := storage.ListFiles(t.Context(), "dir", filesystem.ListOptions{
 		Limit:  2,
 		Cursor: "cursor",
 	})
@@ -39,12 +39,6 @@ func TestFilesystemList(t *testing.T) {
 	assert.Equal(t, "cursor", dereference(client.listRequest.ContinuationToken))
 	assert.Equal(t, []string{"dir/file.txt"}, entryPaths(page.Entries))
 	assert.Equal(t, "next", page.NextCursor)
-
-	directories, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
-		Kind: filesystem.EntryKindDirectory,
-	})
-	require.NoError(t, err)
-	assert.Empty(t, directories.Entries)
 }
 
 func TestFilesystemMove(t *testing.T) {

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -15,11 +15,14 @@ func TestFilesystemList(t *testing.T) {
 	modified := time.Now()
 	client := &fakeClient{
 		listResult: &aliyunoss.ListObjectsV2Result{
-			Contents: []aliyunoss.ObjectProperties{{
-				Key:          aliyunoss.Ptr("root/dir/file.txt"),
-				Size:         7,
-				LastModified: &modified,
-			}},
+			Contents: []aliyunoss.ObjectProperties{
+				{
+					Key:          aliyunoss.Ptr("root/dir/file.txt"),
+					Size:         7,
+					LastModified: &modified,
+				},
+				{Key: aliyunoss.Ptr("root/dir/marker/")},
+			},
 			CommonPrefixes:        []aliyunoss.CommonPrefix{{Prefix: aliyunoss.Ptr("root/dir/nested/")}},
 			NextContinuationToken: aliyunoss.Ptr("next"),
 		},
@@ -34,8 +37,14 @@ func TestFilesystemList(t *testing.T) {
 	assert.Equal(t, "root/dir/", dereference(client.listRequest.Prefix))
 	assert.Equal(t, "/", dereference(client.listRequest.Delimiter))
 	assert.Equal(t, "cursor", dereference(client.listRequest.ContinuationToken))
-	assert.Equal(t, []string{"dir/file.txt", "dir/nested"}, entryPaths(page.Entries))
+	assert.Equal(t, []string{"dir/file.txt"}, entryPaths(page.Entries))
 	assert.Equal(t, "next", page.NextCursor)
+
+	directories, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
+		Kind: filesystem.EntryKindDirectory,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, directories.Entries)
 }
 
 func TestFilesystemMove(t *testing.T) {

--- a/filesystem/paths.go
+++ b/filesystem/paths.go
@@ -20,6 +20,18 @@ func ValidatePath(path string) error {
 	return &fs.PathError{Op: "validate", Path: path, Err: ErrInvalidPath}
 }
 
+// ValidateFilePath validates a logical file or object path. Unlike
+// ValidatePath, it rejects ".", which represents the logical root.
+func ValidateFilePath(path string) error {
+	if err := ValidatePath(path); err != nil {
+		return err
+	}
+	if path == "." {
+		return &fs.PathError{Op: "validate", Path: path, Err: ErrInvalidPath}
+	}
+	return nil
+}
+
 // PathPrefixer maps logical paths to object-storage keys below a root prefix.
 type PathPrefixer struct {
 	prefix string

--- a/filesystem/paths.go
+++ b/filesystem/paths.go
@@ -1,36 +1,59 @@
 package filesystem
 
-import "strings"
+import (
+	"io/fs"
+	"strings"
+)
 
+// ValidPath reports whether path is a valid logical filesystem path.
+// Paths are unrooted, slash-separated, and may use "." for the logical root.
+func ValidPath(path string) bool {
+	return fs.ValidPath(path) && !strings.Contains(path, `\`)
+}
+
+// ValidatePath returns a path error when path is not a valid logical path.
+func ValidatePath(path string) error {
+	if ValidPath(path) {
+		return nil
+	}
+
+	return &fs.PathError{Op: "validate", Path: path, Err: ErrInvalidPath}
+}
+
+// PathPrefixer maps logical paths to object-storage keys below a root prefix.
 type PathPrefixer struct {
-	prefix    string
-	separator string
+	prefix string
 }
 
-type PathPrefixerOption func(*PathPrefixer)
-
-func WithPathPrefixerSeparator(separator string) PathPrefixerOption {
-	return func(p *PathPrefixer) {
-		p.separator = separator
-	}
+// NewPathPrefixer creates a logical object-key prefixer.
+func NewPathPrefixer(prefix string) *PathPrefixer {
+	return &PathPrefixer{prefix: strings.Trim(prefix, "/")}
 }
 
-func NewPathPrefixer(prefix string, opts ...PathPrefixerOption) *PathPrefixer {
-	prefixer := &PathPrefixer{
-		prefix:    strings.TrimRight(prefix, "\\/"),
-		separator: "/",
-	}
-	for _, opt := range opts {
-		opt(prefixer)
-	}
-
-	if prefixer.prefix != "" || prefix == prefixer.separator {
-		prefixer.prefix += prefixer.separator
-	}
-
-	return prefixer
-}
-
+// Prefix maps a logical path to its backend key.
 func (p *PathPrefixer) Prefix(path string) string {
-	return p.prefix + strings.TrimLeft(path, "\\/")
+	if path == "." {
+		return p.prefix
+	}
+	if p.prefix == "" {
+		return path
+	}
+	return p.prefix + "/" + path
+}
+
+// Strip maps a backend key below the configured prefix to a logical path.
+func (p *PathPrefixer) Strip(key string) (string, bool) {
+	key = strings.TrimPrefix(key, "/")
+	if p.prefix == "" {
+		if key == "" {
+			return ".", true
+		}
+		return key, true
+	}
+	if key == p.prefix {
+		return ".", true
+	}
+
+	path, ok := strings.CutPrefix(key, p.prefix+"/")
+	return path, ok
 }

--- a/filesystem/paths_test.go
+++ b/filesystem/paths_test.go
@@ -1,87 +1,59 @@
 package filesystem
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPathPrefixer_Prefix(t *testing.T) {
-	prefixer := NewPathPrefixer("prefix")
-
+func TestValidPath(t *testing.T) {
 	tests := []struct {
-		path     string
-		expected string
+		path string
+		want bool
 	}{
-		{"path", "prefix/path"},
-		{"/path", "prefix/path"},
-		{"//path", "prefix/path"},
-		{"path/", "prefix/path/"},
+		{path: ".", want: true},
+		{path: "file.txt", want: true},
+		{path: "dir/file.txt", want: true},
+		{path: "", want: false},
+		{path: "/file.txt", want: false},
+		{path: "dir/", want: false},
+		{path: "dir//file.txt", want: false},
+		{path: "../file.txt", want: false},
+		{path: `dir\file.txt`, want: false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, prefixer.Prefix(test.path))
+			assert.Equal(t, test.want, ValidPath(test.path))
 		})
 	}
 }
 
-func TestPathPrefixer_PrefixEmptyPrefix(t *testing.T) {
-	prefixer := NewPathPrefixer("")
-
-	tests := []struct {
-		path     string
-		expected string
-	}{
-		{"path", "path"},
-		{"/path", "path"},
-		{"//path", "path"},
-		{"path/", "path/"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, prefixer.Prefix(test.path))
-		})
-	}
+func TestValidatePath(t *testing.T) {
+	assert.NoError(t, ValidatePath("dir/file.txt"))
+	assert.ErrorIs(t, ValidatePath("../file.txt"), ErrInvalidPath)
 }
 
-func TestPathPrefixer_PrefixWithSeparator(t *testing.T) {
-	prefixer := NewPathPrefixer("prefix", WithPathPrefixerSeparator("::"))
+func TestPathPrefixer(t *testing.T) {
+	prefixer := NewPathPrefixer("/tenant/root/")
 
-	tests := []struct {
-		path     string
-		expected string
-	}{
-		{"path", "prefix::path"},
-		{"/path", "prefix::path"},
-		{"//path", "prefix::path"},
-		{"path/", "prefix::path/"},
-	}
+	assert.Equal(t, "tenant/root", prefixer.Prefix("."))
+	assert.Equal(t, "tenant/root/dir/file.txt", prefixer.Prefix("dir/file.txt"))
 
-	for _, test := range tests {
-		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, prefixer.Prefix(test.path))
-		})
-	}
+	path, ok := prefixer.Strip("tenant/root/dir/file.txt")
+	assert.True(t, ok)
+	assert.Equal(t, "dir/file.txt", path)
+
+	path, ok = prefixer.Strip("tenant/root")
+	assert.True(t, ok)
+	assert.Equal(t, ".", path)
+
+	_, ok = prefixer.Strip("other/file.txt")
+	assert.False(t, ok)
 }
 
-func TestPathPrefixer_PrefixWithSamePrefixAndSeparator(t *testing.T) {
-	prefixer := NewPathPrefixer("", WithPathPrefixerSeparator(""))
-
-	tests := []struct {
-		path     string
-		expected string
-	}{
-		{"path", "path"},
-		{"/path", "path"},
-		{"//path", "path"},
-		{"path/", "path/"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, prefixer.Prefix(test.path))
-		})
-	}
+func TestValidatePathError(t *testing.T) {
+	err := ValidatePath("../file.txt")
+	assert.True(t, errors.Is(err, ErrInvalidPath))
 }

--- a/filesystem/paths_test.go
+++ b/filesystem/paths_test.go
@@ -35,6 +35,12 @@ func TestValidatePath(t *testing.T) {
 	assert.ErrorIs(t, ValidatePath("../file.txt"), ErrInvalidPath)
 }
 
+func TestValidateFilePath(t *testing.T) {
+	assert.NoError(t, ValidateFilePath("dir/file.txt"))
+	assert.ErrorIs(t, ValidateFilePath("."), ErrInvalidPath)
+	assert.ErrorIs(t, ValidateFilePath("../file.txt"), ErrInvalidPath)
+}
+
 func TestPathPrefixer(t *testing.T) {
 	prefixer := NewPathPrefixer("/tenant/root/")
 

--- a/filesystem/repository.go
+++ b/filesystem/repository.go
@@ -1,106 +1,132 @@
 package filesystem
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"maps"
+	"net/http"
+)
 
-type Repository interface {
-	Filesystem
-	Copyable
-
-	// Get retrieves the value for the given path.
-	Get(ctx context.Context, path string) ([]byte, error)
-
-	// Set sets the value for the given path.
-	Set(ctx context.Context, path string, value []byte) error
-
-	// Put sets the value for the given path.
-	Put(ctx context.Context, path string, value []byte) error
-
-	// Destroy deletes the value for the given path.
-	Destroy(ctx context.Context, path string) error
-
-	// Has checks if the path exists.
-	Has(ctx context.Context, path string) (bool, error)
-
-	// Missing checks if the path does not exist.
-	Missing(ctx context.Context, path string) (bool, error)
-
-	// Move moves the value from the old path to the new path.
-	Move(ctx context.Context, oldPath, newPath string) error
-
-	// Prepend prepends the value to the existing value for the given path.
-	Prepend(ctx context.Context, path string, value []byte) error
-
-	// Append appends the value to the existing value for the given path.
-	Append(ctx context.Context, path string, value []byte) error
+// Repository adds whole-file helpers and portable copy and move fallbacks to a
+// Driver.
+type Repository struct {
+	driver Driver
 }
 
-type repository struct {
-	Filesystem
+var _ Driver = (*Repository)(nil)
+
+// NewRepository wraps driver with portable convenience operations.
+func NewRepository(driver Driver) *Repository {
+	return &Repository{driver: driver}
 }
 
-func NewRepository(store Filesystem) Repository {
-	return &repository{
-		Filesystem: store,
-	}
+// Driver returns the wrapped storage driver.
+func (r *Repository) Driver() Driver {
+	return r.driver
 }
 
-func (r *repository) Get(ctx context.Context, path string) ([]byte, error) {
-	return r.Read(ctx, path)
+// Open delegates to the wrapped driver.
+func (r *Repository) Open(ctx context.Context, path string) (io.ReadCloser, error) {
+	return r.driver.Open(ctx, path)
 }
 
-func (r *repository) Set(ctx context.Context, path string, value []byte) error {
-	return r.Write(ctx, path, value)
+// Put delegates to the wrapped driver.
+func (r *Repository) Put(
+	ctx context.Context,
+	path string,
+	src io.Reader,
+	options PutOptions,
+) error {
+	return r.driver.Put(ctx, path, src, options)
 }
 
-func (r *repository) Put(ctx context.Context, path string, value []byte) error {
-	return r.Write(ctx, path, value)
+// Delete delegates to the wrapped driver.
+func (r *Repository) Delete(ctx context.Context, path string) error {
+	return r.driver.Delete(ctx, path)
 }
 
-func (r *repository) Destroy(ctx context.Context, path string) error {
-	return r.Delete(ctx, path)
+// Stat delegates to the wrapped driver.
+func (r *Repository) Stat(ctx context.Context, path string) (Entry, error) {
+	return r.driver.Stat(ctx, path)
 }
 
-func (r *repository) Has(ctx context.Context, path string) (bool, error) {
-	return r.Exists(ctx, path)
+// List delegates to the wrapped driver.
+func (r *Repository) List(ctx context.Context, path string, options ListOptions) (ListPage, error) {
+	return r.driver.List(ctx, path, options)
 }
 
-func (r *repository) Missing(ctx context.Context, path string) (bool, error) {
-	had, err := r.Exists(ctx, path)
+// ReadFile reads the complete contents of path into memory.
+func (r *Repository) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	reader, err := r.Open(ctx, path)
 	if err != nil {
-		return false, err
+		return nil, err
+	}
+	defer reader.Close() //nolint:errcheck
+
+	return io.ReadAll(reader)
+}
+
+// WriteFile writes value to path.
+func (r *Repository) WriteFile(
+	ctx context.Context,
+	path string,
+	value []byte,
+	options PutOptions,
+) error {
+	if options.ContentType == "" {
+		options.ContentType = http.DetectContentType(value)
 	}
 
-	return !had, nil
+	return r.Put(ctx, path, bytes.NewReader(value), options)
 }
 
-func (r *repository) Move(ctx context.Context, oldPath, newPath string) error {
-	return r.Rename(ctx, oldPath, newPath)
+// Exists reports whether path exists.
+func (r *Repository) Exists(ctx context.Context, path string) (bool, error) {
+	_, err := r.Stat(ctx, path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	return false, err
 }
 
-func (r *repository) Prepend(ctx context.Context, path string, value []byte) error {
-	old, err := r.Read(ctx, path)
+// Copy copies src to dst, preferring a driver's native copy operation.
+func (r *Repository) Copy(ctx context.Context, src, dst string) error {
+	if copier, ok := r.driver.(Copier); ok {
+		return copier.Copy(ctx, src, dst)
+	}
+
+	entry, err := r.Stat(ctx, src)
 	if err != nil {
 		return err
 	}
-	return r.Write(ctx, path, append(value, old...))
-}
-
-func (r *repository) Append(ctx context.Context, path string, value []byte) error {
-	old, err := r.Read(ctx, path)
+	reader, err := r.Open(ctx, src)
 	if err != nil {
 		return err
 	}
-	return r.Write(ctx, path, append(old, value...))
+	defer reader.Close() //nolint:errcheck
+
+	return r.Put(ctx, dst, reader, PutOptions{
+		ContentType: entry.ContentType,
+		Metadata:    cloneMetadata(entry.Metadata),
+	})
 }
 
-func (r *repository) Copy(ctx context.Context, oldPath, newPath string) error {
-	if copier, ok := r.Filesystem.(Copyable); ok {
-		return copier.Copy(ctx, oldPath, newPath)
+// Move moves src to dst, preferring a driver's native move operation.
+func (r *Repository) Move(ctx context.Context, src, dst string) error {
+	if mover, ok := r.driver.(Mover); ok {
+		return mover.Move(ctx, src, dst)
 	}
-
-	old, err := r.Read(ctx, oldPath)
-	if err != nil {
+	if err := r.Copy(ctx, src, dst); err != nil {
 		return err
 	}
-	return r.Write(ctx, newPath, old)
+	return r.Delete(ctx, src)
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	return maps.Clone(metadata)
 }

--- a/filesystem/repository.go
+++ b/filesystem/repository.go
@@ -121,9 +121,11 @@ func (r *Repository) Copy(ctx context.Context, src, dst string) error {
 	}
 	defer reader.Close() //nolint:errcheck
 
+	contentLength := entry.Size
 	return r.Put(ctx, dst, reader, PutOptions{
-		ContentType: entry.ContentType,
-		Metadata:    cloneMetadata(entry.Metadata),
+		ContentLength: &contentLength,
+		ContentType:   entry.ContentType,
+		Metadata:      cloneMetadata(entry.Metadata),
 	})
 }
 

--- a/filesystem/repository.go
+++ b/filesystem/repository.go
@@ -59,9 +59,13 @@ func (r *Repository) Stat(ctx context.Context, path string) (Entry, error) {
 	return r.driver.Stat(ctx, path)
 }
 
-// List delegates to the wrapped driver.
-func (r *Repository) List(ctx context.Context, path string, options ListOptions) (ListPage, error) {
-	return r.driver.List(ctx, path, options)
+// ListFiles delegates to the wrapped driver.
+func (r *Repository) ListFiles(
+	ctx context.Context,
+	path string,
+	options ListOptions,
+) (ListPage, error) {
+	return r.driver.ListFiles(ctx, path, options)
 }
 
 // ReadFile reads the complete contents of path into memory.

--- a/filesystem/repository.go
+++ b/filesystem/repository.go
@@ -15,14 +15,21 @@ type Repository struct {
 	driver Driver
 }
 
-var _ Driver = (*Repository)(nil)
+var (
+	_ Driver = (*Repository)(nil)
+	_ Copier = (*Repository)(nil)
+	_ Mover  = (*Repository)(nil)
+)
 
 // NewRepository wraps driver with portable convenience operations.
 func NewRepository(driver Driver) *Repository {
 	return &Repository{driver: driver}
 }
 
-// Driver returns the wrapped storage driver.
+// Driver returns the wrapped storage driver. Use it to access optional
+// backend capabilities that Repository does not guarantee, such as Linker,
+// Symlinker, or DirectoryManager, by using a type assertion. It can also be
+// asserted to a concrete driver type when backend-specific APIs are required.
 func (r *Repository) Driver() Driver {
 	return r.driver
 }

--- a/filesystem/repository_test.go
+++ b/filesystem/repository_test.go
@@ -114,6 +114,6 @@ func (d *memoryDriver) Stat(_ context.Context, path string) (Entry, error) {
 	}, nil
 }
 
-func (d *memoryDriver) List(context.Context, string, ListOptions) (ListPage, error) {
+func (d *memoryDriver) ListFiles(context.Context, string, ListOptions) (ListPage, error) {
 	return ListPage{}, nil
 }

--- a/filesystem/repository_test.go
+++ b/filesystem/repository_test.go
@@ -1,29 +1,119 @@
 package filesystem
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestNoopRepository(t *testing.T) {
-	repo := NewRepository(NoopFilesystem{})
+func TestRepository(t *testing.T) {
+	driver := newMemoryDriver()
+	repository := NewRepository(driver)
 	ctx := t.Context()
 
-	assert.NoError(t, repo.Put(ctx, "noop", []byte("noop")))
-	assert.NoError(t, repo.Destroy(ctx, "noop"))
+	require.NoError(t, repository.WriteFile(ctx, "source.txt", []byte("content"), PutOptions{
+		Metadata: map[string]string{"owner": "test"},
+	}))
 
-	exists, err := repo.Exists(ctx, "noop")
-	assert.NoError(t, err)
+	value, err := repository.ReadFile(ctx, "source.txt")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("content"), value)
+
+	exists, err := repository.Exists(ctx, "source.txt")
+	require.NoError(t, err)
 	assert.True(t, exists)
 
-	missing, err := repo.Missing(ctx, "noop")
-	assert.NoError(t, err)
-	assert.False(t, missing)
+	require.NoError(t, repository.Copy(ctx, "source.txt", "copy.txt"))
+	copyEntry, err := repository.Stat(ctx, "copy.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "test", copyEntry.Metadata["owner"])
 
-	assert.NoError(t, repo.Rename(ctx, "noop", "noop2"))
+	require.NoError(t, repository.Move(ctx, "copy.txt", "moved.txt"))
+	exists, err = repository.Exists(ctx, "copy.txt")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	exists, err = repository.Exists(ctx, "moved.txt")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
 
-	assert.NoError(t, repo.Prepend(ctx, "noop", []byte("noop")))
-	assert.NoError(t, repo.Append(ctx, "noop", []byte("noop")))
-	assert.NoError(t, repo.Copy(ctx, "noop", "noop2"))
+func TestRepositoryMissingEntry(t *testing.T) {
+	repository := NewRepository(newMemoryDriver())
+
+	exists, err := repository.Exists(t.Context(), "missing.txt")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	_, err = repository.ReadFile(t.Context(), "missing.txt")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+type memoryObject struct {
+	value       []byte
+	contentType string
+	metadata    map[string]string
+}
+
+type memoryDriver struct {
+	objects map[string]memoryObject
+}
+
+func newMemoryDriver() *memoryDriver {
+	return &memoryDriver{objects: make(map[string]memoryObject)}
+}
+
+func (d *memoryDriver) Open(_ context.Context, path string) (io.ReadCloser, error) {
+	object, ok := d.objects[path]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(object.value)), nil
+}
+
+func (d *memoryDriver) Put(
+	_ context.Context,
+	path string,
+	src io.Reader,
+	options PutOptions,
+) error {
+	value, err := io.ReadAll(src)
+	if err != nil {
+		return err
+	}
+	d.objects[path] = memoryObject{
+		value:       value,
+		contentType: options.ContentType,
+		metadata:    cloneMetadata(options.Metadata),
+	}
+	return nil
+}
+
+func (d *memoryDriver) Delete(_ context.Context, path string) error {
+	if _, ok := d.objects[path]; !ok {
+		return ErrNotFound
+	}
+	delete(d.objects, path)
+	return nil
+}
+
+func (d *memoryDriver) Stat(_ context.Context, path string) (Entry, error) {
+	object, ok := d.objects[path]
+	if !ok {
+		return Entry{}, ErrNotFound
+	}
+	return Entry{
+		Path:        path,
+		Kind:        EntryKindFile,
+		Size:        int64(len(object.value)),
+		ContentType: object.contentType,
+		Metadata:    cloneMetadata(object.metadata),
+	}, nil
+}
+
+func (d *memoryDriver) List(context.Context, string, ListOptions) (ListPage, error) {
+	return ListPage{}, nil
 }

--- a/filesystem/repository_test.go
+++ b/filesystem/repository_test.go
@@ -80,9 +80,16 @@ func (d *memoryDriver) Put(
 	src io.Reader,
 	options PutOptions,
 ) error {
-	value, err := io.ReadAll(src)
+	contentLength, err := options.ResolveContentLength(src)
 	if err != nil {
 		return err
+	}
+	value, err := io.ReadAll(io.LimitReader(src, contentLength))
+	if err != nil {
+		return err
+	}
+	if int64(len(value)) != contentLength {
+		return io.ErrUnexpectedEOF
 	}
 	d.objects[path] = memoryObject{
 		value:       value,

--- a/filesystem/s3/README.md
+++ b/filesystem/s3/README.md
@@ -1,0 +1,85 @@
+# Amazon S3 Filesystem
+
+The Amazon S3 Filesystem driver stores logical filesystem paths as objects in
+an S3 bucket. It implements the core filesystem API and provides native copy
+and move capabilities.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/filesystem/v4
+go get github.com/go-fries/fries/filesystem/s3/v4
+go get github.com/aws/aws-sdk-go-v2/config
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/go-fries/fries/filesystem/v4"
+	filesystemS3 "github.com/go-fries/fries/filesystem/s3/v4"
+)
+
+func main() {
+	ctx := context.Background()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := awss3.NewFromConfig(cfg)
+	driver := filesystemS3.New(
+		client,
+		"my-bucket",
+		filesystemS3.WithRoot("application"),
+	)
+	storage := filesystem.NewRepository(driver)
+
+	if err := storage.WriteFile(
+		ctx,
+		"documents/example.txt",
+		[]byte("s3 content"),
+		filesystem.PutOptions{ContentType: "text/plain"},
+	); err != nil {
+		log.Fatal(err)
+	}
+
+	page, err := storage.ListFiles(
+		ctx,
+		"documents",
+		filesystem.ListOptions{Recursive: true},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, entry := range page.Entries {
+		fmt.Printf("%s (%d bytes)\n", entry.Path, entry.Size)
+	}
+
+	if err := storage.Copy(
+		ctx,
+		"documents/example.txt",
+		"documents/example-copy.txt",
+	); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+## Behavior
+
+- `WithRoot` places every logical path below an object-key prefix. In the
+  example, `documents/example.txt` maps to
+  `application/documents/example.txt`.
+- Directories are virtual prefixes. `ListFiles` returns objects only and omits
+  directory markers.
+- `Repository.Copy` uses S3's native server-side copy operation.
+- Move is implemented as copy followed by delete and is not atomic.

--- a/filesystem/s3/config.go
+++ b/filesystem/s3/config.go
@@ -1,0 +1,31 @@
+package s3
+
+type config struct {
+	root string
+}
+
+// Option configures an S3 filesystem.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(cfg *config) {
+	f(cfg)
+}
+
+// WithRoot stores logical paths below root in the bucket.
+func WithRoot(root string) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.root = root
+	})
+}
+
+func newConfig(opts ...Option) *config {
+	cfg := &config{}
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+	return cfg
+}

--- a/filesystem/s3/doc.go
+++ b/filesystem/s3/doc.go
@@ -1,0 +1,2 @@
+// Package s3 provides a filesystem driver backed by Amazon S3.
+package s3

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -91,7 +91,8 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 	return output.Body, nil
 }
 
-// Put writes src to path, replacing an existing object.
+// Put writes src to path, replacing an existing object. The content length must
+// be explicit or inferable as described by filesystem.PutOptions.
 func (s *Filesystem) Put(
 	ctx context.Context,
 	path string,
@@ -101,16 +102,21 @@ func (s *Filesystem) Put(
 	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
+	contentLength, err := options.ResolveContentLength(src)
+	if err != nil {
+		return wrapPathError("put", path, err)
+	}
 	input := &awss3.PutObjectInput{
-		Bucket:   ptr(s.bucket),
-		Key:      ptr(s.prefixer.Prefix(path)),
-		Body:     src,
-		Metadata: cloneMetadata(options.Metadata),
+		Bucket:        ptr(s.bucket),
+		Key:           ptr(s.prefixer.Prefix(path)),
+		Body:          src,
+		ContentLength: ptr(contentLength),
+		Metadata:      cloneMetadata(options.Metadata),
 	}
 	if options.ContentType != "" {
 		input.ContentType = ptr(options.ContentType)
 	}
-	_, err := s.client.PutObject(ctx, input)
+	_, err = s.client.PutObject(ctx, input)
 	if err != nil {
 		return wrapPathError("put", path, err)
 	}

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -194,6 +194,7 @@ func (s *Filesystem) List(
 	path string,
 	options filesystem.ListOptions,
 ) (filesystem.ListPage, error) {
+	options = options.Normalize()
 	if err := filesystem.ValidatePath(path); err != nil {
 		return filesystem.ListPage{}, err
 	}
@@ -207,10 +208,7 @@ func (s *Filesystem) List(
 	if options.Cursor != "" {
 		input.ContinuationToken = ptr(options.Cursor)
 	}
-	if options.Limit > 0 {
-		limit := min(options.Limit, 1000)
-		input.MaxKeys = ptr(int32(limit))
-	}
+	input.MaxKeys = ptr(int32(options.Limit))
 
 	output, err := s.client.ListObjectsV2(ctx, input)
 	if err != nil {

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -78,7 +78,7 @@ func newFilesystem(client s3Client, bucket string, opts ...Option) *Filesystem {
 
 // Open opens path for streaming reads.
 func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, error) {
-	if err := filesystem.ValidatePath(path); err != nil {
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return nil, err
 	}
 	output, err := s.client.GetObject(ctx, &awss3.GetObjectInput{
@@ -98,7 +98,7 @@ func (s *Filesystem) Put(
 	src io.Reader,
 	options filesystem.PutOptions,
 ) error {
-	if err := filesystem.ValidatePath(path); err != nil {
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
 	input := &awss3.PutObjectInput{
@@ -119,7 +119,7 @@ func (s *Filesystem) Put(
 
 // Delete removes an object.
 func (s *Filesystem) Delete(ctx context.Context, path string) error {
-	if err := filesystem.ValidatePath(path); err != nil {
+	if err := filesystem.ValidateFilePath(path); err != nil {
 		return err
 	}
 	_, err := s.client.DeleteObject(ctx, &awss3.DeleteObjectInput{
@@ -136,6 +136,12 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
 	if err := filesystem.ValidatePath(path); err != nil {
 		return filesystem.Entry{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return filesystem.Entry{}, err
+	}
+	if path == "." {
+		return filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, nil
 	}
 	output, err := s.client.HeadObject(ctx, &awss3.HeadObjectInput{
 		Bucket: ptr(s.bucket),
@@ -198,10 +204,10 @@ func (s *Filesystem) List(
 
 // Copy copies src to dst using S3's native server-side copy operation.
 func (s *Filesystem) Copy(ctx context.Context, src, dst string) error {
-	if err := filesystem.ValidatePath(src); err != nil {
+	if err := filesystem.ValidateFilePath(src); err != nil {
 		return err
 	}
-	if err := filesystem.ValidatePath(dst); err != nil {
+	if err := filesystem.ValidateFilePath(dst); err != nil {
 		return err
 	}
 	copySource := url.PathEscape(s.bucket + "/" + s.prefixer.Prefix(src))

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -188,7 +188,7 @@ func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error)
 	return len(output.Contents) > 0 || len(output.CommonPrefixes) > 0, nil
 }
 
-// List returns one page of objects and virtual directories below path.
+// List returns one page of objects below path.
 func (s *Filesystem) List(
 	ctx context.Context,
 	path string,
@@ -254,19 +254,18 @@ func (s *Filesystem) entries(
 	output *awss3.ListObjectsV2Output,
 	kind filesystem.EntryKind,
 ) []filesystem.Entry {
-	byPath := make(map[string]filesystem.Entry, len(output.Contents)+len(output.CommonPrefixes))
+	byPath := make(map[string]filesystem.Entry, len(output.Contents))
 	for _, object := range output.Contents {
 		key := dereference(object.Key)
-		entryKind := filesystem.EntryKindFile
 		if strings.HasSuffix(key, "/") {
-			entryKind = filesystem.EntryKindDirectory
-			key = strings.TrimSuffix(key, "/")
-		}
-		path, ok := s.prefixer.Strip(key)
-		if !ok || path == "." || !filesystem.ValidPath(path) || !matchesKind(entryKind, kind) {
 			continue
 		}
-		entry := filesystem.Entry{Path: path, Kind: entryKind}
+		path, ok := s.prefixer.Strip(key)
+		if !ok || path == "." || !filesystem.ValidPath(path) ||
+			!matchesKind(filesystem.EntryKindFile, kind) {
+			continue
+		}
+		entry := filesystem.Entry{Path: path, Kind: filesystem.EntryKindFile}
 		if object.Size != nil {
 			entry.Size = *object.Size
 		}
@@ -275,16 +274,6 @@ func (s *Filesystem) entries(
 		}
 		byPath[path] = entry
 	}
-	for _, commonPrefix := range output.CommonPrefixes {
-		key := strings.TrimSuffix(dereference(commonPrefix.Prefix), "/")
-		path, ok := s.prefixer.Strip(key)
-		if !ok || path == "." || !filesystem.ValidPath(path) ||
-			!matchesKind(filesystem.EntryKindDirectory, kind) {
-			continue
-		}
-		byPath[path] = filesystem.Entry{Path: path, Kind: filesystem.EntryKindDirectory}
-	}
-
 	entries := make([]filesystem.Entry, 0, len(byPath))
 	for _, entry := range byPath {
 		entries = append(entries, entry)

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -188,8 +188,8 @@ func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error)
 	return len(output.Contents) > 0 || len(output.CommonPrefixes) > 0, nil
 }
 
-// List returns one page of objects below path.
-func (s *Filesystem) List(
+// ListFiles returns one page of objects below path.
+func (s *Filesystem) ListFiles(
 	ctx context.Context,
 	path string,
 	options filesystem.ListOptions,
@@ -215,7 +215,7 @@ func (s *Filesystem) List(
 		return filesystem.ListPage{}, wrapPathError("list", path, err)
 	}
 
-	page := filesystem.ListPage{Entries: s.entries(output, options.Kind)}
+	page := filesystem.ListPage{Entries: s.entries(output)}
 	if output.NextContinuationToken != nil {
 		page.NextCursor = *output.NextContinuationToken
 	}
@@ -250,10 +250,7 @@ func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
 	return s.Delete(ctx, src)
 }
 
-func (s *Filesystem) entries(
-	output *awss3.ListObjectsV2Output,
-	kind filesystem.EntryKind,
-) []filesystem.Entry {
+func (s *Filesystem) entries(output *awss3.ListObjectsV2Output) []filesystem.Entry {
 	byPath := make(map[string]filesystem.Entry, len(output.Contents))
 	for _, object := range output.Contents {
 		key := dereference(object.Key)
@@ -261,8 +258,7 @@ func (s *Filesystem) entries(
 			continue
 		}
 		path, ok := s.prefixer.Strip(key)
-		if !ok || path == "." || !filesystem.ValidPath(path) ||
-			!matchesKind(filesystem.EntryKindFile, kind) {
+		if !ok || path == "." || !filesystem.ValidPath(path) {
 			continue
 		}
 		entry := filesystem.Entry{Path: path, Kind: filesystem.EntryKindFile}
@@ -289,10 +285,6 @@ func directoryPrefix(prefix string) string {
 		return ""
 	}
 	return strings.TrimSuffix(prefix, "/") + "/"
-}
-
-func matchesKind(entryKind, filter filesystem.EntryKind) bool {
-	return filter == filesystem.EntryKindAny || entryKind == filter
 }
 
 func wrapPathError(op, path string, err error) error {

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -132,7 +132,8 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 	return nil
 }
 
-// Stat returns object metadata.
+// Stat returns object metadata. If an exact object does not exist, Stat issues
+// one additional ListObjectsV2 request to detect a virtual directory prefix.
 func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
 	if err := filesystem.ValidatePath(path); err != nil {
 		return filesystem.Entry{}, err
@@ -148,6 +149,15 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 		Key:    ptr(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
+		if isNotFound(err) {
+			directory, listErr := s.hasChildren(ctx, path)
+			if listErr != nil {
+				return filesystem.Entry{}, wrapPathError("stat", path, listErr)
+			}
+			if directory {
+				return filesystem.Entry{Path: path, Kind: filesystem.EntryKindDirectory}, nil
+			}
+		}
 		return filesystem.Entry{}, wrapPathError("stat", path, err)
 	}
 
@@ -164,6 +174,18 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 		entry.LastModified = *output.LastModified
 	}
 	return entry, nil
+}
+
+func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error) {
+	output, err := s.client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+		Bucket:  ptr(s.bucket),
+		Prefix:  ptr(directoryPrefix(s.prefixer.Prefix(path))),
+		MaxKeys: ptr(int32(1)),
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(output.Contents) > 0 || len(output.CommonPrefixes) > 0, nil
 }
 
 // List returns one page of objects and virtual directories below path.

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -1,239 +1,333 @@
 package s3
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
-	"net/http"
-	"time"
+	"io/fs"
+	"maps"
+	"net/url"
+	"sort"
+	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/go-fries/fries/filesystem/v4"
 )
 
-type Filesystem struct {
-	s3       *s3.Client
-	prefixer *filesystem.PathPrefixer
+type s3Client interface {
+	GetObject(
+		context.Context,
+		*awss3.GetObjectInput,
+		...func(*awss3.Options),
+	) (*awss3.GetObjectOutput, error)
+	PutObject(
+		context.Context,
+		*awss3.PutObjectInput,
+		...func(*awss3.Options),
+	) (*awss3.PutObjectOutput, error)
+	DeleteObject(
+		context.Context,
+		*awss3.DeleteObjectInput,
+		...func(*awss3.Options),
+	) (*awss3.DeleteObjectOutput, error)
+	HeadObject(
+		context.Context,
+		*awss3.HeadObjectInput,
+		...func(*awss3.Options),
+	) (*awss3.HeadObjectOutput, error)
+	ListObjectsV2(
+		context.Context,
+		*awss3.ListObjectsV2Input,
+		...func(*awss3.Options),
+	) (*awss3.ListObjectsV2Output, error)
+	CopyObject(
+		context.Context,
+		*awss3.CopyObjectInput,
+		...func(*awss3.Options),
+	) (*awss3.CopyObjectOutput, error)
+}
 
-	root   string
-	bucket string
+// Filesystem stores logical filesystem paths in an Amazon S3 bucket.
+type Filesystem struct {
+	client   s3Client
+	prefixer *filesystem.PathPrefixer
+	root     string
+	bucket   string
 }
 
 var (
-	_ filesystem.Filesystem = (*Filesystem)(nil)
-	_ filesystem.Copyable   = (*Filesystem)(nil)
+	_ filesystem.Driver = (*Filesystem)(nil)
+	_ filesystem.Copier = (*Filesystem)(nil)
+	_ filesystem.Mover  = (*Filesystem)(nil)
 )
 
+// Option configures an S3 filesystem.
 type Option func(*Filesystem)
 
+// WithRoot stores logical paths below root in the bucket.
 func WithRoot(root string) Option {
 	return func(s *Filesystem) {
 		s.root = root
 	}
 }
 
-func New(s3 *s3.Client, bucket string, opts ...Option) *Filesystem {
-	s := &Filesystem{
-		s3:     s3,
-		bucket: bucket,
-		root:   "",
-	}
-	for _, opt := range opts {
-		opt(s)
-	}
-
-	s.prefixer = filesystem.NewPathPrefixer(s.root)
-
-	return s
+// New creates an S3-backed filesystem.
+func New(client *awss3.Client, bucket string, options ...Option) *Filesystem {
+	return newFilesystem(client, bucket, options...)
 }
 
-func (s *Filesystem) Read(ctx context.Context, path string) ([]byte, error) {
-	output, err := s.s3.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path)),
-	})
-	if err != nil {
+func newFilesystem(client s3Client, bucket string, options ...Option) *Filesystem {
+	storage := &Filesystem{client: client, bucket: bucket}
+	for _, option := range options {
+		option(storage)
+	}
+	storage.prefixer = filesystem.NewPathPrefixer(storage.root)
+	return storage
+}
+
+// Open opens path for streaming reads.
+func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
 		return nil, err
 	}
-	defer output.Body.Close() //nolint:errcheck
-
-	return io.ReadAll(output.Body)
-}
-
-func (s *Filesystem) Write(ctx context.Context, path string, value []byte) error {
-	_, err := s.s3.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:        ptr(s.bucket),
-		Key:           ptr(s.prefixer.Prefix(path)),
-		Body:          io.NopCloser(bytes.NewBuffer(value)),
-		ContentType:   ptr(http.DetectContentType(value)),
-		ContentLength: ptr(int64(len(value))),
-	})
-	return err
-}
-
-func (s *Filesystem) Exists(ctx context.Context, path string) (bool, error) {
-	_, err := s.s3.HeadObject(ctx, &s3.HeadObjectInput{
+	output, err := s.client.GetObject(ctx, &awss3.GetObjectInput{
 		Bucket: ptr(s.bucket),
 		Key:    ptr(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
-		var nf *types.NotFound
-		if errors.As(err, &nf) {
-			return false, nil
-		}
-		// Alternative approach using response error
-		var responseError smithy.APIError
-		if errors.As(err, &responseError) {
-			if responseError.ErrorCode() == "NotFound" {
-				return false, nil
-			}
-		}
-		return false, err
+		return nil, wrapPathError("open", path, err)
 	}
-
-	return true, nil
+	return output.Body, nil
 }
 
-func (s *Filesystem) Rename(ctx context.Context, oldPath, newPath string) error {
-	_, err := s.s3.CopyObject(ctx, &s3.CopyObjectInput{
-		Bucket:     ptr(s.bucket),
-		CopySource: ptr(s.bucket + "/" + s.prefixer.Prefix(oldPath)),
-		Key:        ptr(s.prefixer.Prefix(newPath)),
-	})
-	if err != nil {
+// Put writes src to path, replacing an existing object.
+func (s *Filesystem) Put(
+	ctx context.Context,
+	path string,
+	src io.Reader,
+	options filesystem.PutOptions,
+) error {
+	if err := filesystem.ValidatePath(path); err != nil {
 		return err
 	}
-
-	return s.Delete(ctx, oldPath)
-}
-
-func (s *Filesystem) MakeDirectory(ctx context.Context, path string) error {
-	_, err := s.s3.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path) + "/"),
-		Body:   io.NopCloser(bytes.NewBuffer([]byte{})),
-	})
-	return err
-}
-
-func (s *Filesystem) DeleteDirectory(ctx context.Context, path string) error {
-	_, err := s.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path) + "/"),
-	})
-	return err
-}
-
-func (s *Filesystem) Size(ctx context.Context, path string) (int64, error) {
-	output, err := s.s3.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path)),
-	})
+	input := &awss3.PutObjectInput{
+		Bucket:   ptr(s.bucket),
+		Key:      ptr(s.prefixer.Prefix(path)),
+		Body:     src,
+		Metadata: cloneMetadata(options.Metadata),
+	}
+	if options.ContentType != "" {
+		input.ContentType = ptr(options.ContentType)
+	}
+	_, err := s.client.PutObject(ctx, input)
 	if err != nil {
-		return 0, err
+		return wrapPathError("put", path, err)
 	}
-
-	if output.ContentLength == nil {
-		return 0, errors.New("storage: content length is nil")
-	}
-
-	return *output.ContentLength, nil
+	return nil
 }
 
-func (s *Filesystem) LastModified(ctx context.Context, path string) (*time.Time, error) {
-	output, err := s.s3.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path)),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if output.LastModified == nil {
-		return nil, errors.New("storage: last modified is nil")
-	}
-
-	return output.LastModified, nil
-}
-
-func (s *Filesystem) Path(_ context.Context, path string) string {
-	return s.prefixer.Prefix(path)
-}
-
-func (s *Filesystem) Name(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (s *Filesystem) Basename(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (s *Filesystem) Dirname(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
-func (s *Filesystem) Extension(ctx context.Context, path string) string {
-	// TODO implement me
-	panic("implement me")
-}
-
+// Delete removes an object.
 func (s *Filesystem) Delete(ctx context.Context, path string) error {
-	_, err := s.s3.DeleteObject(ctx, &s3.DeleteObjectInput{
+	if err := filesystem.ValidatePath(path); err != nil {
+		return err
+	}
+	_, err := s.client.DeleteObject(ctx, &awss3.DeleteObjectInput{
 		Bucket: ptr(s.bucket),
 		Key:    ptr(s.prefixer.Prefix(path)),
 	})
-	return err
+	if err != nil {
+		return wrapPathError("delete", path, err)
+	}
+	return nil
 }
 
-func (s *Filesystem) Link(context.Context, string, string) error {
-	return filesystem.ErrNotSupported
+// Stat returns object metadata.
+func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return filesystem.Entry{}, err
+	}
+	output, err := s.client.HeadObject(ctx, &awss3.HeadObjectInput{
+		Bucket: ptr(s.bucket),
+		Key:    ptr(s.prefixer.Prefix(path)),
+	})
+	if err != nil {
+		return filesystem.Entry{}, wrapPathError("stat", path, err)
+	}
+
+	entry := filesystem.Entry{
+		Path:        path,
+		Kind:        filesystem.EntryKindFile,
+		ContentType: dereference(output.ContentType),
+		Metadata:    cloneMetadata(output.Metadata),
+	}
+	if output.ContentLength != nil {
+		entry.Size = *output.ContentLength
+	}
+	if output.LastModified != nil {
+		entry.LastModified = *output.LastModified
+	}
+	return entry, nil
 }
 
-func (s *Filesystem) Symlink(context.Context, string, string) error {
-	return filesystem.ErrNotSupported
+// List returns one page of objects and virtual directories below path.
+func (s *Filesystem) List(
+	ctx context.Context,
+	path string,
+	options filesystem.ListOptions,
+) (filesystem.ListPage, error) {
+	if err := filesystem.ValidatePath(path); err != nil {
+		return filesystem.ListPage{}, err
+	}
+	input := &awss3.ListObjectsV2Input{
+		Bucket: ptr(s.bucket),
+		Prefix: ptr(directoryPrefix(s.prefixer.Prefix(path))),
+	}
+	if !options.Recursive {
+		input.Delimiter = ptr("/")
+	}
+	if options.Cursor != "" {
+		input.ContinuationToken = ptr(options.Cursor)
+	}
+	if options.Limit > 0 {
+		limit := min(options.Limit, 1000)
+		input.MaxKeys = ptr(int32(limit))
+	}
+
+	output, err := s.client.ListObjectsV2(ctx, input)
+	if err != nil {
+		return filesystem.ListPage{}, wrapPathError("list", path, err)
+	}
+
+	page := filesystem.ListPage{Entries: s.entries(output, options.Kind)}
+	if output.NextContinuationToken != nil {
+		page.NextCursor = *output.NextContinuationToken
+	}
+	return page, nil
 }
 
-func (s *Filesystem) Files(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+// Copy copies src to dst using S3's native server-side copy operation.
+func (s *Filesystem) Copy(ctx context.Context, src, dst string) error {
+	if err := filesystem.ValidatePath(src); err != nil {
+		return err
+	}
+	if err := filesystem.ValidatePath(dst); err != nil {
+		return err
+	}
+	copySource := url.PathEscape(s.bucket + "/" + s.prefixer.Prefix(src))
+	_, err := s.client.CopyObject(ctx, &awss3.CopyObjectInput{
+		Bucket:     ptr(s.bucket),
+		CopySource: ptr(copySource),
+		Key:        ptr(s.prefixer.Prefix(dst)),
+	})
+	if err != nil {
+		return wrapPathError("copy", src, err)
+	}
+	return nil
 }
 
-func (s *Filesystem) AllFiles(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+// Move copies src to dst and then deletes src. The operation is not atomic.
+func (s *Filesystem) Move(ctx context.Context, src, dst string) error {
+	if err := s.Copy(ctx, src, dst); err != nil {
+		return err
+	}
+	return s.Delete(ctx, src)
 }
 
-func (s *Filesystem) Directories(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+func (s *Filesystem) entries(
+	output *awss3.ListObjectsV2Output,
+	kind filesystem.EntryKind,
+) []filesystem.Entry {
+	byPath := make(map[string]filesystem.Entry, len(output.Contents)+len(output.CommonPrefixes))
+	for _, object := range output.Contents {
+		key := dereference(object.Key)
+		entryKind := filesystem.EntryKindFile
+		if strings.HasSuffix(key, "/") {
+			entryKind = filesystem.EntryKindDirectory
+			key = strings.TrimSuffix(key, "/")
+		}
+		path, ok := s.prefixer.Strip(key)
+		if !ok || path == "." || !filesystem.ValidPath(path) || !matchesKind(entryKind, kind) {
+			continue
+		}
+		entry := filesystem.Entry{Path: path, Kind: entryKind}
+		if object.Size != nil {
+			entry.Size = *object.Size
+		}
+		if object.LastModified != nil {
+			entry.LastModified = *object.LastModified
+		}
+		byPath[path] = entry
+	}
+	for _, commonPrefix := range output.CommonPrefixes {
+		key := strings.TrimSuffix(dereference(commonPrefix.Prefix), "/")
+		path, ok := s.prefixer.Strip(key)
+		if !ok || path == "." || !filesystem.ValidPath(path) ||
+			!matchesKind(filesystem.EntryKindDirectory, kind) {
+			continue
+		}
+		byPath[path] = filesystem.Entry{Path: path, Kind: filesystem.EntryKindDirectory}
+	}
+
+	entries := make([]filesystem.Entry, 0, len(byPath))
+	for _, entry := range byPath {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Path < entries[j].Path
+	})
+	return entries
 }
 
-func (s *Filesystem) AllDirectories(ctx context.Context, path string) ([]string, error) {
-	// TODO implement me
-	panic("implement me")
+func directoryPrefix(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	return strings.TrimSuffix(prefix, "/") + "/"
 }
 
-func (s *Filesystem) IsFile(ctx context.Context, path string) (bool, error) {
-	// TODO implement me
-	panic("implement me")
+func matchesKind(entryKind, filter filesystem.EntryKind) bool {
+	return filter == filesystem.EntryKindAny || entryKind == filter
 }
 
-func (s *Filesystem) IsDir(ctx context.Context, path string) (bool, error) {
-	// TODO implement me
-	panic("implement me")
+func wrapPathError(op, path string, err error) error {
+	if isNotFound(err) {
+		err = filesystem.ErrNotFound
+	}
+	return &fs.PathError{Op: op, Path: path, Err: err}
 }
 
-func (s *Filesystem) Copy(ctx context.Context, oldPath, newPath string) error {
-	// TODO implement me
-	panic("implement me")
+func isNotFound(err error) bool {
+	var notFound *types.NotFound
+	if errors.As(err, &notFound) {
+		return true
+	}
+	var noSuchKey *types.NoSuchKey
+	if errors.As(err, &noSuchKey) {
+		return true
+	}
+	var apiError smithy.APIError
+	if errors.As(err, &apiError) {
+		switch apiError.ErrorCode() {
+		case "NotFound", "NoSuchKey", "404":
+			return true
+		}
+	}
+	return false
 }
 
-func ptr[T any](v T) *T {
-	return &v
+func cloneMetadata(metadata map[string]string) map[string]string {
+	return maps.Clone(metadata)
+}
+
+func dereference(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func ptr[T any](value T) *T {
+	return &value
 }

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -53,7 +53,6 @@ type s3Client interface {
 type Filesystem struct {
 	client   s3Client
 	prefixer *filesystem.PathPrefixer
-	root     string
 	bucket   string
 }
 
@@ -63,28 +62,18 @@ var (
 	_ filesystem.Mover  = (*Filesystem)(nil)
 )
 
-// Option configures an S3 filesystem.
-type Option func(*Filesystem)
-
-// WithRoot stores logical paths below root in the bucket.
-func WithRoot(root string) Option {
-	return func(s *Filesystem) {
-		s.root = root
-	}
-}
-
 // New creates an S3-backed filesystem.
-func New(client *awss3.Client, bucket string, options ...Option) *Filesystem {
-	return newFilesystem(client, bucket, options...)
+func New(client *awss3.Client, bucket string, opts ...Option) *Filesystem {
+	return newFilesystem(client, bucket, opts...)
 }
 
-func newFilesystem(client s3Client, bucket string, options ...Option) *Filesystem {
-	storage := &Filesystem{client: client, bucket: bucket}
-	for _, option := range options {
-		option(storage)
+func newFilesystem(client s3Client, bucket string, opts ...Option) *Filesystem {
+	cfg := newConfig(opts...)
+	return &Filesystem{
+		client:   client,
+		bucket:   bucket,
+		prefixer: filesystem.NewPathPrefixer(cfg.root),
 	}
-	storage.prefixer = filesystem.NewPathPrefixer(storage.root)
-	return storage
 }
 
 // Open opens path for streaming reads.

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -2,6 +2,8 @@ package s3
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -51,6 +53,23 @@ func TestFilesystemMove(t *testing.T) {
 	require.NotNil(t, client.deleteInput)
 	assert.Equal(t, "root/target.txt", dereference(client.copyInput.Key))
 	assert.Equal(t, "root/source file.txt", dereference(client.deleteInput.Key))
+}
+
+func TestFilesystemPutContentLength(t *testing.T) {
+	client := &fakeClient{}
+	storage := newFilesystem(client, "bucket")
+	source := struct{ io.Reader }{Reader: strings.NewReader("content")}
+
+	err := storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{})
+	assert.ErrorIs(t, err, filesystem.ErrContentLengthRequired)
+
+	length := int64(len("content"))
+	err = storage.Put(t.Context(), "file.txt", source, filesystem.PutOptions{
+		ContentLength: &length,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client.putInput)
+	assert.Equal(t, length, *client.putInput.ContentLength)
 }
 
 func TestFilesystemNotFound(t *testing.T) {
@@ -107,6 +126,7 @@ type fakeClient struct {
 	headOutput  *awss3.HeadObjectOutput
 	listInput   *awss3.ListObjectsV2Input
 	listOutput  *awss3.ListObjectsV2Output
+	putInput    *awss3.PutObjectInput
 	copyInput   *awss3.CopyObjectInput
 	deleteInput *awss3.DeleteObjectInput
 }
@@ -119,11 +139,12 @@ func (c *fakeClient) GetObject(
 	return nil, c.getErr
 }
 
-func (*fakeClient) PutObject(
-	context.Context,
-	*awss3.PutObjectInput,
-	...func(*awss3.Options),
+func (c *fakeClient) PutObject(
+	_ context.Context,
+	input *awss3.PutObjectInput,
+	_ ...func(*awss3.Options),
 ) (*awss3.PutObjectOutput, error) {
+	c.putInput = input
 	return &awss3.PutObjectOutput{}, nil
 }
 

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -71,8 +71,37 @@ func TestFilesystemRoot(t *testing.T) {
 	assert.ErrorIs(t, storage.Copy(t.Context(), ".", "target.txt"), filesystem.ErrInvalidPath)
 }
 
+func TestFilesystemStatVirtualDirectory(t *testing.T) {
+	client := &fakeClient{
+		headErr: &types.NoSuchKey{},
+		listOutput: &awss3.ListObjectsV2Output{
+			Contents: []types.Object{{Key: ptr("root/images/file.jpg")}},
+		},
+	}
+	storage := newFilesystem(client, "bucket", WithRoot("root"))
+
+	entry, err := storage.Stat(t.Context(), "images")
+	require.NoError(t, err)
+	assert.Equal(t, filesystem.Entry{Path: "images", Kind: filesystem.EntryKindDirectory}, entry)
+	assert.Equal(t, "root/images/", dereference(client.listInput.Prefix))
+	assert.Equal(t, int32(1), *client.listInput.MaxKeys)
+}
+
+func TestFilesystemStatMissing(t *testing.T) {
+	client := &fakeClient{
+		headErr:    &types.NoSuchKey{},
+		listOutput: &awss3.ListObjectsV2Output{},
+	}
+	storage := newFilesystem(client, "bucket")
+
+	_, err := storage.Stat(t.Context(), "missing")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
+}
+
 type fakeClient struct {
 	getErr      error
+	headErr     error
+	headOutput  *awss3.HeadObjectOutput
 	listInput   *awss3.ListObjectsV2Input
 	listOutput  *awss3.ListObjectsV2Output
 	copyInput   *awss3.CopyObjectInput
@@ -104,12 +133,15 @@ func (c *fakeClient) DeleteObject(
 	return &awss3.DeleteObjectOutput{}, nil
 }
 
-func (*fakeClient) HeadObject(
-	context.Context,
-	*awss3.HeadObjectInput,
-	...func(*awss3.Options),
+func (c *fakeClient) HeadObject(
+	_ context.Context,
+	_ *awss3.HeadObjectInput,
+	_ ...func(*awss3.Options),
 ) (*awss3.HeadObjectOutput, error) {
-	return &awss3.HeadObjectOutput{}, nil
+	if c.headOutput == nil {
+		c.headOutput = &awss3.HeadObjectOutput{}
+	}
+	return c.headOutput, c.headErr
 }
 
 func (c *fakeClient) ListObjectsV2(

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -1,1 +1,126 @@
 package s3
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/go-fries/fries/filesystem/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesystemList(t *testing.T) {
+	modified := time.Now()
+	client := &fakeClient{
+		listOutput: &awss3.ListObjectsV2Output{
+			Contents: []types.Object{{
+				Key:          ptr("root/dir/file.txt"),
+				Size:         ptr(int64(7)),
+				LastModified: &modified,
+			}},
+			CommonPrefixes:        []types.CommonPrefix{{Prefix: ptr("root/dir/nested/")}},
+			NextContinuationToken: ptr("next"),
+		},
+	}
+	storage := newFilesystem(client, "bucket", WithRoot("root"))
+
+	page, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
+		Limit:  2,
+		Cursor: "cursor",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "root/dir/", dereference(client.listInput.Prefix))
+	assert.Equal(t, "/", dereference(client.listInput.Delimiter))
+	assert.Equal(t, "cursor", dereference(client.listInput.ContinuationToken))
+	assert.Equal(t, []string{"dir/file.txt", "dir/nested"}, entryPaths(page.Entries))
+	assert.Equal(t, "next", page.NextCursor)
+}
+
+func TestFilesystemMove(t *testing.T) {
+	client := &fakeClient{}
+	storage := newFilesystem(client, "bucket", WithRoot("root"))
+
+	require.NoError(t, storage.Move(t.Context(), "source file.txt", "target.txt"))
+	require.NotNil(t, client.copyInput)
+	require.NotNil(t, client.deleteInput)
+	assert.Equal(t, "root/target.txt", dereference(client.copyInput.Key))
+	assert.Equal(t, "root/source file.txt", dereference(client.deleteInput.Key))
+}
+
+func TestFilesystemNotFound(t *testing.T) {
+	client := &fakeClient{getErr: &types.NoSuchKey{}}
+	storage := newFilesystem(client, "bucket")
+
+	_, err := storage.Open(t.Context(), "missing.txt")
+	assert.ErrorIs(t, err, filesystem.ErrNotFound)
+}
+
+type fakeClient struct {
+	getErr      error
+	listInput   *awss3.ListObjectsV2Input
+	listOutput  *awss3.ListObjectsV2Output
+	copyInput   *awss3.CopyObjectInput
+	deleteInput *awss3.DeleteObjectInput
+}
+
+func (c *fakeClient) GetObject(
+	context.Context,
+	*awss3.GetObjectInput,
+	...func(*awss3.Options),
+) (*awss3.GetObjectOutput, error) {
+	return nil, c.getErr
+}
+
+func (*fakeClient) PutObject(
+	context.Context,
+	*awss3.PutObjectInput,
+	...func(*awss3.Options),
+) (*awss3.PutObjectOutput, error) {
+	return &awss3.PutObjectOutput{}, nil
+}
+
+func (c *fakeClient) DeleteObject(
+	_ context.Context,
+	input *awss3.DeleteObjectInput,
+	_ ...func(*awss3.Options),
+) (*awss3.DeleteObjectOutput, error) {
+	c.deleteInput = input
+	return &awss3.DeleteObjectOutput{}, nil
+}
+
+func (*fakeClient) HeadObject(
+	context.Context,
+	*awss3.HeadObjectInput,
+	...func(*awss3.Options),
+) (*awss3.HeadObjectOutput, error) {
+	return &awss3.HeadObjectOutput{}, nil
+}
+
+func (c *fakeClient) ListObjectsV2(
+	_ context.Context,
+	input *awss3.ListObjectsV2Input,
+	_ ...func(*awss3.Options),
+) (*awss3.ListObjectsV2Output, error) {
+	c.listInput = input
+	return c.listOutput, nil
+}
+
+func (c *fakeClient) CopyObject(
+	_ context.Context,
+	input *awss3.CopyObjectInput,
+	_ ...func(*awss3.Options),
+) (*awss3.CopyObjectOutput, error) {
+	c.copyInput = input
+	return &awss3.CopyObjectOutput{}, nil
+}
+
+func entryPaths(entries []filesystem.Entry) []string {
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
+	}
+	return paths
+}

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -30,7 +30,7 @@ func TestFilesystemList(t *testing.T) {
 	}
 	storage := newFilesystem(client, "bucket", WithRoot("root"))
 
-	page, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
+	page, err := storage.ListFiles(t.Context(), "dir", filesystem.ListOptions{
 		Limit:  2,
 		Cursor: "cursor",
 	})
@@ -40,12 +40,6 @@ func TestFilesystemList(t *testing.T) {
 	assert.Equal(t, "cursor", dereference(client.listInput.ContinuationToken))
 	assert.Equal(t, []string{"dir/file.txt"}, entryPaths(page.Entries))
 	assert.Equal(t, "next", page.NextCursor)
-
-	directories, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
-		Kind: filesystem.EntryKindDirectory,
-	})
-	require.NoError(t, err)
-	assert.Empty(t, directories.Entries)
 }
 
 func TestFilesystemMove(t *testing.T) {

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -16,11 +16,14 @@ func TestFilesystemList(t *testing.T) {
 	modified := time.Now()
 	client := &fakeClient{
 		listOutput: &awss3.ListObjectsV2Output{
-			Contents: []types.Object{{
-				Key:          ptr("root/dir/file.txt"),
-				Size:         ptr(int64(7)),
-				LastModified: &modified,
-			}},
+			Contents: []types.Object{
+				{
+					Key:          ptr("root/dir/file.txt"),
+					Size:         ptr(int64(7)),
+					LastModified: &modified,
+				},
+				{Key: ptr("root/dir/marker/")},
+			},
 			CommonPrefixes:        []types.CommonPrefix{{Prefix: ptr("root/dir/nested/")}},
 			NextContinuationToken: ptr("next"),
 		},
@@ -35,8 +38,14 @@ func TestFilesystemList(t *testing.T) {
 	assert.Equal(t, "root/dir/", dereference(client.listInput.Prefix))
 	assert.Equal(t, "/", dereference(client.listInput.Delimiter))
 	assert.Equal(t, "cursor", dereference(client.listInput.ContinuationToken))
-	assert.Equal(t, []string{"dir/file.txt", "dir/nested"}, entryPaths(page.Entries))
+	assert.Equal(t, []string{"dir/file.txt"}, entryPaths(page.Entries))
 	assert.Equal(t, "next", page.NextCursor)
+
+	directories, err := storage.List(t.Context(), "dir", filesystem.ListOptions{
+		Kind: filesystem.EntryKindDirectory,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, directories.Entries)
 }
 
 func TestFilesystemMove(t *testing.T) {

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -58,6 +58,19 @@ func TestFilesystemNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, filesystem.ErrNotFound)
 }
 
+func TestFilesystemRoot(t *testing.T) {
+	storage := newFilesystem(&fakeClient{}, "bucket", WithRoot("root"))
+
+	entry, err := storage.Stat(t.Context(), ".")
+	require.NoError(t, err)
+	assert.Equal(t, filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, entry)
+
+	_, err = storage.Open(t.Context(), ".")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath)
+	assert.ErrorIs(t, storage.Delete(t.Context(), "."), filesystem.ErrInvalidPath)
+	assert.ErrorIs(t, storage.Copy(t.Context(), ".", "target.txt"), filesystem.ErrInvalidPath)
+}
+
 type fakeClient struct {
 	getErr      error
 	listInput   *awss3.ListObjectsV2Input

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
 	github.com/aws/smithy-go v1.27.3
 	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.1
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
@@ -20,4 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.30 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.31 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/filesystem/s3/go.sum
+++ b/filesystem/s3/go.sum
@@ -26,5 +26,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

Redesign the `filesystem` component around a small, streaming `Driver` contract shared by local filesystems, Amazon S3, and Alibaba Cloud OSS. The refactor separates portable operations from backend-specific capabilities, aligns path/error/listing semantics across drivers, and adds migration-oriented documentation for every filesystem module.

## Motivation

The previous `Filesystem` interface mixed file I/O, path helpers, directory operations, links, metadata, and convenience methods into one large contract. This forced object-storage drivers to expose operations that were unsupported or incomplete and made it difficult for callers to know which behavior was portable.

The new design keeps the common contract intentionally small and moves whole-file helpers and optional features into explicit layers.

## Changes

- Replace the broad `Filesystem` interface with the streaming `Driver` contract: `Open`, `Put`, `Delete`, `Stat`, and `ListFiles`
- Add `Entry`, `EntryKind`, `PutOptions`, `ListOptions`, and `ListPage` as portable metadata, upload, and pagination types
- Convert `Repository` into a concrete wrapper with `ReadFile`, `WriteFile`, `Exists`, `Copy`, and `Move` helpers
- Add optional capability interfaces: `Copier`, `Mover`, `Linker`, `Symlinker`, and `DirectoryManager`
- Standardize logical paths as unrooted, slash-separated paths; `.` represents the logical root
- Standardize not-found errors through `ErrNotFound` and `errors.Is`, while making `Delete` idempotent
- Add bounded pagination with a default and maximum page size of 1000
- Make `ListFiles` consistently return files/objects only, excluding directories and object-storage directory markers
- Add S3/OSS virtual-directory detection in `Stat` and native server-side copy support
- Harden the local driver with root-confined operations and rejection of symlink traversal outside the configured root
- Add package documentation and usage-focused READMEs for the core, Local, S3, and OSS modules

## Breaking Changes

| Previous API | New API | Migration |
| --- | --- | --- |
| `filesystem.Filesystem` | `filesystem.Driver` | Implement only `Open`, `Put`, `Delete`, `Stat`, and `ListFiles`; expose optional features through capability interfaces |
| `Read` / `Write` | `Open` / `Put` | Use streaming APIs directly, or `Repository.ReadFile` / `Repository.WriteFile` for `[]byte` values |
| `Files` / `AllFiles` | `ListFiles` | Set `ListOptions.Recursive` and consume pages until `NextCursor` is empty |
| `Exists`, `IsFile`, `IsDir`, `Size`, `LastModified` | `Repository.Exists` / `Stat` | Read kind, size, and timestamps from `Entry` |
| `Rename` | `Move` | Use `Repository.Move` or assert `filesystem.Mover` when the native capability is required |
| `MakeDirectory` / `DeleteDirectory` | `filesystem.DirectoryManager` | Available on the Local driver; S3 and OSS now use virtual prefixes instead of directory marker operations |
| `Link` / `Symlink` | `filesystem.Linker` / `filesystem.Symlinker` | Assert the optional capability or use the concrete Local driver |
| `Copyable` | `Copier` | Use `Repository.Copy` for portable behavior or assert `filesystem.Copier` |
| `NewStorage(root)` | `local.New(root)` | Handle the returned `(*local.Filesystem, error)` |
| `Repository` interface | `*Repository` struct | Construct it with `filesystem.NewRepository(driver)` |
| `Get`, `Set`, byte-slice `Put`, `Destroy`, `Has`, `Missing` | `ReadFile`, `WriteFile`, `Delete`, `Exists` | Replace the convenience aliases with the canonical methods |
| `Append` / `Prepend` | Removed | Read, modify, and write explicitly when this behavior is needed |
| `ErrNotSupported` | `ErrUnsupported` | Use `errors.Is`; the core `Driver` contract does not return unsupported-operation errors |
| `NoopFilesystem` | Removed | Provide a small test driver implementing the new `Driver` contract when needed |
| `WithPathPrefixerSeparator` | Removed | Logical paths and object keys always use `/` |

Additional behavior changes:

- Paths such as `/file`, `dir/../file`, trailing slashes, and backslash-separated paths are rejected with an error wrapping `ErrInvalidPath`
- `Open` returns an `io.ReadCloser`; callers are responsible for closing it
- `Put` accepts an `io.Reader`. `ContentLength` is inferred for common readers and seekable files; opaque streams must set `PutOptions.ContentLength`
- An explicit content length must match an inferable remaining length and cannot be negative
- Deleting a missing file or object now succeeds and returns `nil`
- `ListFiles` returns an empty page with `nil` error for a missing path or a path that names a file
- Only an empty `NextCursor` means listing is complete; a page may contain no entries and still have another cursor
- S3/OSS moves are copy-then-delete operations and are not atomic
- Custom S3/OSS option functions are no longer supported; use the exported options such as `WithRoot`

## Migration Guide

### 1. Update the modules

After this change is released, update the core module and the backend modules used by the application to the same v4 release:

```bash
go get github.com/go-fries/fries/filesystem/v4@latest
go get github.com/go-fries/fries/filesystem/local/v4@latest
# or: github.com/go-fries/fries/filesystem/s3/v4@latest
# or: github.com/go-fries/fries/filesystem/oss/v4@latest
go mod tidy
```

Use a specific v4 tag instead of `@latest` when the application pins dependency versions.

### 2. Replace construction and whole-file operations

Before:

```go
driver := local.NewStorage("./storage")
storage := filesystem.NewRepository(driver)

if err := storage.Write(ctx, "documents/example.txt", data); err != nil {
	return err
}

data, err := storage.Read(ctx, "documents/example.txt")
files, err := storage.AllFiles(ctx, "documents")
```

After:

```go
driver, err := local.New("./storage")
if err != nil {
	return err
}
storage := filesystem.NewRepository(driver)

if err := storage.WriteFile(
	ctx,
	"documents/example.txt",
	data,
	filesystem.PutOptions{},
); err != nil {
	return err
}

data, err = storage.ReadFile(ctx, "documents/example.txt")
if err != nil {
	return err
}

options := filesystem.ListOptions{Recursive: true}
for {
	page, err := storage.ListFiles(ctx, "documents", options)
	if err != nil {
		return err
	}
	for _, entry := range page.Entries {
		fmt.Println(entry.Path)
	}
	if page.NextCursor == "" {
		break
	}
	options.Cursor = page.NextCursor
}
```

The Local root directory should be created by the application before it is used. Use `.` when listing or stating the logical root.

### 3. Migrate streaming writes

Readers with a known remaining length, such as `bytes.Reader`, `strings.Reader`, and seekable files, can be passed directly:

```go
err := storage.Put(
	ctx,
	"documents/example.txt",
	strings.NewReader("content"),
	filesystem.PutOptions{ContentType: "text/plain"},
)
```

For an opaque stream, provide its remaining byte length:

```go
length := int64(contentLength)
err := storage.Put(ctx, path, stream, filesystem.PutOptions{
	ContentLength: &length,
})
```

### 4. Access optional capabilities explicitly

Portable copy and move should normally go through `Repository`. Backend-specific features can be accessed through the wrapped driver:

```go
directories, ok := storage.Driver().(filesystem.DirectoryManager)
if !ok {
	return filesystem.ErrUnsupported
}
if err := directories.MakeDirectory(ctx, "documents"); err != nil {
	return err
}
```

### 5. Handle portable errors

```go
entry, err := storage.Stat(ctx, "documents/example.txt")
if errors.Is(err, filesystem.ErrNotFound) {
	// The file or object does not exist.
}
if err != nil {
	return err
}
fmt.Println(entry.Size, entry.LastModified)
```

## Testing

- `go test ./...` in `filesystem`
- `go test ./...` in `filesystem/local`
- `go test ./...` in `filesystem/s3`
- `go test ./...` in `filesystem/oss`
- `git diff --check`
