### PR TITLE
ci: restrict test workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - 4.x
+
+permissions:
+  contents: read
+
 env:
   GOPROXY: "https://proxy.golang.org"
 


### PR DESCRIPTION
## Summary
Restrict the test workflow's GitHub token to the minimum repository permission it requires.

## Changes
- Add workflow-level `contents: read` permission to the Go test workflow
- Keep the existing test matrix and Codecov upload behavior unchanged

## Motivation
- Resolve CodeQL alert #12 (`actions/missing-workflow-permissions`)
- Prevent the workflow from inheriting broader repository token defaults

## Testing
- `git diff --check`
- Parsed `.github/workflows/test.yml` as YAML and verified `permissions.contents` is `read`
- Statically reviewed all workflow steps for required token permissions