### PR TITLE
ci(lint): improve Go cache reuse

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,28 +18,29 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-go@v6
+        id: setup-go
+        with:
+          go-version-file: go.mod
+          check-latest: false
+          cache: false
+
+      - name: Go cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.setup-go.outputs.go-version }}-
+
       - name: GolangCI-Lint cache
         uses: actions/cache@v6
         with:
           path: ~/.cache/golangci-lint
           key: ${{ runner.os }}-golangci-lint-${{ hashFiles('**/.golangci.yml') }}
           restore-keys: ${{ runner.os }}-golangci-lint-
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          check-latest: false
-          cache: true
-          cache-dependency-path: |  
-            **/go.sum
-
-      - name: Tools cache
-        uses: actions/cache@v6
-        with:
-          path: .tools
-          key: ${{ runner.os }}-go-tools-${{ hashFiles('internal/tools/go.mod', 'internal/tools/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-tools-
 
       - name: Run lint
         run: make lint


### PR DESCRIPTION
## Summary

Improve Go cache reuse in the full-repository lint workflow without changing which modules or checks run.

## Changes

- Disable setup-go's exact-only dependency cache
- Cache the Go module and build caches explicitly using OS, architecture, installed Go version, and all module files
- Add a Go-version-specific restore prefix so module changes can reuse the latest compatible cache
- Remove the separate `.tools` cache and let tool compilation reuse the restored Go build cache
- Keep `make lint`, `make build`, and `make check-clean-work-tree` unchanged

## Motivation

The analyzed lint job took 8 minutes 4 seconds, including 7 minutes 29 seconds in `Run lint`. A change to one module file caused the setup-go cache to miss completely, which forced dependency downloads, package recompilation, and a 46-second golangci-lint build.

Historical warm-cache runs were roughly one to two minutes faster. Restoring the newest cache for the same Go version should retain that benefit when an individual `go.mod` or `go.sum` changes, while still saving a new exact cache for the updated dependency graph.

## Behavior

- Pull requests still lint and build the full repository
- Pushes to `4.x` still lint and build the full repository
- No changed-module resolver, matrix expansion, or additional CI script is introduced
- The serial 82-module lint remains the dominant cost; this PR intentionally prioritizes workflow simplicity over more aggressive sharding or incremental linting

## Testing

- Parsed `.github/workflows/lint.yml` as YAML
- Passed actionlint v1.7.12
- Passed focused hashing lint targets
- Passed the full repository build target
- Passed `git diff --check`

## Measurement

The actual timing improvement should be evaluated from this PR's lint runs. The first run may populate a new cache key; subsequent runs with dependency changes are expected to demonstrate the restore-prefix benefit more clearly.
