### PR TITLE
refactor(codec)!: replace shared instances with zero-value types

### DIFF
--- a/cache/redis/store.go
+++ b/cache/redis/store.go
@@ -47,7 +47,7 @@ const flushScanCount = 1000
 
 func New(redis redis.UniversalClient, opts ...Option) *Store {
 	story := &Store{
-		codec: json.Codec,
+		codec: json.Codec{},
 		redis: redis,
 	}
 	for _, o := range opts {

--- a/cache/redis/store_test.go
+++ b/cache/redis/store_test.go
@@ -39,7 +39,7 @@ func TestRedis_Prefix(t *testing.T) {
 }
 
 func TestRedis_Base(t *testing.T) {
-	store := New(createRedis(t), Prefix("cache:redis"), Codec(json.Codec))
+	store := New(createRedis(t), Prefix("cache:redis"), Codec(json.Codec{}))
 
 	ok1, err := store.Put(ctx, "test", "test", time.Second)
 	assert.Nil(t, err)

--- a/codec/README.md
+++ b/codec/README.md
@@ -1,45 +1,31 @@
 # Codec
 
-Unified interface for encoding and decoding data, with support for multiple formats.
-
-## Installation
-
-```bash
-go get github.com/go-fries/fries/codec/v4
-# Install specific codecs as needed, e.g.:
-go get github.com/go-fries/fries/codec/json/v4
-```
-
-## Usage
+`codec` defines the shared contract used by Fries components that serialize and
+deserialize values.
 
 ```go
-package main
-
-import (
-	"fmt"
-	"log"
-
-	"github.com/go-fries/fries/codec/json/v4"
-)
-
-var j = json.Codec
-
-func main() {
-	// Marshal
-	bytes, err := j.Marshal(map[string]string{
-		"key": "value",
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("JSON: %s\n", bytes)
-
-	// Unmarshal
-	var dest map[string]string
-	err = j.Unmarshal(bytes, &dest)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("Decoded: %v\n", dest)
+type Codec interface {
+    Marshal(data any) ([]byte, error)
+    Unmarshal(src []byte, dest any) error
 }
 ```
+
+Applications can depend on this interface without coupling business code to a
+specific data format:
+
+```go
+func store(c codec.Codec, value any) ([]byte, error) {
+    return c.Marshal(value)
+}
+```
+
+Concrete implementations are published as separate modules:
+
+- `codec/json`
+- `codec/msgpack`
+- `codec/proto`
+- `codec/sonic`
+- `codec/xml`
+- `codec/yaml`
+
+Custom codecs only need to implement the two interface methods.

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -1,22 +1,11 @@
 package codec
 
-// Codec is an interface for serialization and deserialization operations.
+// Codec marshals and unmarshals values.
 type Codec interface {
-	// Marshal converts the given data into a byte slice.
-	// This method supports converting data structures of any type into a byte slice for transmission or storage.
-	// Parameters:
-	//   data - The data to be serialized, of any type.
-	// Return value:
-	//   It returns the byte slice obtained after serialization, and an error if serialization fails.
+	// Marshal encodes data.
 	Marshal(data any) ([]byte, error)
 
-	// Unmarshal converts the given byte slice into a data structure.
-	// This method supports deserializing a byte slice into a data structure of any type.
-	// Parameters:
-	//   src   - The byte slice to be deserialized.
-	//   dest  - A pointer to the destination data structure where the deserialized data will be stored.
-	//            The specific type of the data structure needs to match the content of the byte slice.
-	// Return value:
-	//   It returns an error if deserialization fails.
+	// Unmarshal decodes src into dest. Dest must be a value accepted by the
+	// concrete codec, typically a non-nil pointer.
 	Unmarshal(src []byte, dest any) error
 }

--- a/codec/doc.go
+++ b/codec/doc.go
@@ -1,0 +1,5 @@
+// Package codec defines the common contract implemented by codec modules.
+//
+// Concrete formats are provided by sibling modules such as codec/json,
+// codec/msgpack, codec/proto, codec/sonic, codec/xml, and codec/yaml.
+package codec

--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,3 +1,11 @@
 module github.com/go-fries/fries/codec/v4
 
 go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/codec/go.sum
+++ b/codec/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/codec/json/README.md
+++ b/codec/json/README.md
@@ -1,0 +1,17 @@
+# JSON Codec
+
+JSON support for `github.com/go-fries/fries/codec/v4`, implemented with the Go
+standard library's `encoding/json` package.
+
+```go
+c := json.Codec{}
+
+data, err := c.Marshal(value)
+if err != nil {
+    return err
+}
+
+err = c.Unmarshal(data, &value)
+```
+
+The zero value is ready to use and safe for concurrent use.

--- a/codec/json/codec.go
+++ b/codec/json/codec.go
@@ -6,14 +6,17 @@ import (
 	"github.com/go-fries/fries/codec/v4"
 )
 
-var Codec codec.Codec = &jsonCodec{}
+// Codec encodes and decodes JSON values. Its zero value is ready to use.
+type Codec struct{}
 
-type jsonCodec struct{}
+var _ codec.Codec = Codec{}
 
-func (j *jsonCodec) Marshal(data any) ([]byte, error) {
+// Marshal encodes data as JSON.
+func (Codec) Marshal(data any) ([]byte, error) {
 	return json.Marshal(data)
 }
 
-func (j *jsonCodec) Unmarshal(src []byte, dest any) error {
+// Unmarshal decodes JSON data into dest.
+func (Codec) Unmarshal(src []byte, dest any) error {
 	return json.Unmarshal(src, dest)
 }

--- a/codec/json/codec_test.go
+++ b/codec/json/codec_test.go
@@ -1,67 +1,62 @@
-package json
+package json_test
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/go-fries/fries/codec/json/v4"
+	"github.com/go-fries/fries/codec/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestJSON(t *testing.T) {
-	j1, j2 := Codec, Codec
-
-	assert.Same(t, j1, j2)
-
-	data := map[string]any{
-		"foo": "bar",
-	}
-
-	// marshal
-	bytes1, err := json.Marshal(data)
-	assert.NoError(t, err)
-
-	bytes2, err := j1.Marshal(data)
-	assert.NoError(t, err)
-
-	assert.Equal(t, bytes1, bytes2)
-
-	// unmarshal
-	dest1, dest2 := make(map[string]any), make(map[string]any)
-	assert.NoError(t, json.Unmarshal(bytes1, &dest1))
-	assert.NoError(t, j1.Unmarshal(bytes1, &dest2))
-
-	assert.Equal(t, dest1, dest2)
+type message struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
 }
 
-func BenchmarkJSONCodec_Marshal(b *testing.B) {
-	data := map[string]any{
-		"foo": "bar",
-	}
+func TestCodec(t *testing.T) {
+	c := json.Codec{}
+	assert.Implements(t, (*codec.Codec)(nil), c)
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := Codec.Marshal(data)
-			assert.NoError(b, err)
-		}
-	})
+	want := message{Name: "test", Value: 123}
+	data, err := c.Marshal(want)
+	require.NoError(t, err)
+
+	var got message
+	require.NoError(t, c.Unmarshal(data, &got))
+	assert.Equal(t, want, got)
 }
 
-func BenchmarkJSONCodec_Unmarshal(b *testing.B) {
-	data := map[string]any{
-		"foo": "bar",
-	}
+func TestCodecErrors(t *testing.T) {
+	c := json.Codec{}
 
-	bytes, err := Codec.Marshal(data)
-	assert.NoError(b, err)
+	_, err := c.Marshal(make(chan int))
+	assert.Error(t, err)
+	assert.Error(t, c.Unmarshal([]byte("{"), &message{}))
+}
+
+func BenchmarkCodecMarshal(b *testing.B) {
+	c := json.Codec{}
+	value := message{Name: "test", Value: 123}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			var dest map[string]any
-			assert.NoError(b, Codec.Unmarshal(bytes, &dest))
+	for b.Loop() {
+		if _, err := c.Marshal(value); err != nil {
+			b.Fatal(err)
 		}
-	})
+	}
+}
+
+func BenchmarkCodecUnmarshal(b *testing.B) {
+	c := json.Codec{}
+	data, err := c.Marshal(message{Name: "test", Value: 123})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var value message
+		if err := c.Unmarshal(data, &value); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/codec/json/doc.go
+++ b/codec/json/doc.go
@@ -1,0 +1,2 @@
+// Package json implements codec.Codec using encoding/json.
+package json

--- a/codec/json/version.go
+++ b/codec/json/version.go
@@ -1,0 +1,6 @@
+package json
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/json/version_test.go
+++ b/codec/json/version_test.go
@@ -1,0 +1,19 @@
+package json_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/json/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := json.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/codec/msgpack/README.md
+++ b/codec/msgpack/README.md
@@ -1,0 +1,17 @@
+# MessagePack Codec
+
+MessagePack support for `github.com/go-fries/fries/codec/v4`, implemented with
+`github.com/vmihailenco/msgpack/v5`.
+
+```go
+c := msgpack.Codec{}
+
+data, err := c.Marshal(value)
+if err != nil {
+    return err
+}
+
+err = c.Unmarshal(data, &value)
+```
+
+The zero value is ready to use and safe for concurrent use.

--- a/codec/msgpack/codec.go
+++ b/codec/msgpack/codec.go
@@ -5,14 +5,17 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-var Codec codec.Codec = &msgPackCodec{}
+// Codec encodes and decodes MessagePack values. Its zero value is ready to use.
+type Codec struct{}
 
-type msgPackCodec struct{}
+var _ codec.Codec = Codec{}
 
-func (j *msgPackCodec) Marshal(data any) ([]byte, error) {
+// Marshal encodes data as MessagePack.
+func (Codec) Marshal(data any) ([]byte, error) {
 	return msgpack.Marshal(data)
 }
 
-func (j *msgPackCodec) Unmarshal(src []byte, dest any) error {
+// Unmarshal decodes MessagePack data into dest.
+func (Codec) Unmarshal(src []byte, dest any) error {
 	return msgpack.Unmarshal(src, dest)
 }

--- a/codec/msgpack/codec_test.go
+++ b/codec/msgpack/codec_test.go
@@ -1,58 +1,62 @@
-package msgpack
+package msgpack_test
 
 import (
 	"testing"
 
+	"github.com/go-fries/fries/codec/msgpack/v4"
+	"github.com/go-fries/fries/codec/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestJSON(t *testing.T) {
-	c1, c2 := Codec, Codec
-
-	assert.Same(t, c1, c2)
-
-	data := map[string]any{
-		"foo": "bar",
-	}
-
-	// marshal
-	bytes, err := c1.Marshal(data)
-	assert.NoError(t, err)
-
-	// unmarshal
-	dest := make(map[string]any)
-	assert.NoError(t, c1.Unmarshal(bytes, &dest))
+type message struct {
+	Name  string `msgpack:"name"`
+	Value int    `msgpack:"value"`
 }
 
-func BenchmarkMsgPackCodec_Marshal(b *testing.B) {
-	data := map[string]any{
-		"foo": "bar",
-	}
+func TestCodec(t *testing.T) {
+	c := msgpack.Codec{}
+	assert.Implements(t, (*codec.Codec)(nil), c)
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := Codec.Marshal(data)
-			assert.NoError(b, err)
-		}
-	})
+	want := message{Name: "test", Value: 123}
+	data, err := c.Marshal(want)
+	require.NoError(t, err)
+
+	var got message
+	require.NoError(t, c.Unmarshal(data, &got))
+	assert.Equal(t, want, got)
 }
 
-func BenchmarkMsgPackCodec_Unmarshal(b *testing.B) {
-	data := map[string]any{
-		"foo": "bar",
-	}
+func TestCodecErrors(t *testing.T) {
+	c := msgpack.Codec{}
 
-	bytes, err := Codec.Marshal(data)
-	assert.NoError(b, err)
+	_, err := c.Marshal(make(chan int))
+	assert.Error(t, err)
+	assert.Error(t, c.Unmarshal([]byte{0xc1}, &message{}))
+}
+
+func BenchmarkCodecMarshal(b *testing.B) {
+	c := msgpack.Codec{}
+	value := message{Name: "test", Value: 123}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			var dest map[string]any
-			assert.NoError(b, Codec.Unmarshal(bytes, &dest))
+	for b.Loop() {
+		if _, err := c.Marshal(value); err != nil {
+			b.Fatal(err)
 		}
-	})
+	}
+}
+
+func BenchmarkCodecUnmarshal(b *testing.B) {
+	c := msgpack.Codec{}
+	data, err := c.Marshal(message{Name: "test", Value: 123})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var value message
+		if err := c.Unmarshal(data, &value); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/codec/msgpack/doc.go
+++ b/codec/msgpack/doc.go
@@ -1,0 +1,2 @@
+// Package msgpack implements codec.Codec using MessagePack.
+package msgpack

--- a/codec/msgpack/version.go
+++ b/codec/msgpack/version.go
@@ -1,0 +1,6 @@
+package msgpack
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/msgpack/version_test.go
+++ b/codec/msgpack/version_test.go
@@ -1,0 +1,19 @@
+package msgpack_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/msgpack/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := msgpack.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/codec/proto/README.md
+++ b/codec/proto/README.md
@@ -1,0 +1,19 @@
+# Protocol Buffers Codec
+
+Protocol Buffers support for `github.com/go-fries/fries/codec/v4`, implemented
+with `google.golang.org/protobuf/proto`.
+
+```go
+c := proto.Codec{}
+
+data, err := c.Marshal(message)
+if err != nil {
+    return err
+}
+
+err = c.Unmarshal(data, destination)
+```
+
+Values passed to `Marshal` and `Unmarshal` must implement
+`google.golang.org/protobuf/proto.Message`. The zero codec value is ready to use
+and safe for concurrent use.

--- a/codec/proto/codec.go
+++ b/codec/proto/codec.go
@@ -1,33 +1,34 @@
 package proto
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/go-fries/fries/codec/v4"
 	"google.golang.org/protobuf/proto"
 )
 
-var Codec codec.Codec = &protoCodec{}
+// ErrInvalidMessage is returned when a value does not implement proto.Message.
+var ErrInvalidMessage = errors.New("codec/proto: value must implement proto.Message")
 
-var ErrInvalidProtoMessage = fmt.Errorf("data must implement proto.Message interface")
+// Codec encodes and decodes Protocol Buffers messages. Its zero value is ready to use.
+type Codec struct{}
 
-// protoCodec is a Protocol Buffers codec.
-type protoCodec struct{}
+var _ codec.Codec = Codec{}
 
-// Marshal converts the given data into a byte slice using Protocol Buffers.
-func (c *protoCodec) Marshal(data any) ([]byte, error) {
+// Marshal encodes data as a Protocol Buffers message.
+func (Codec) Marshal(data any) ([]byte, error) {
 	msg, ok := data.(proto.Message)
 	if !ok {
-		return nil, ErrInvalidProtoMessage
+		return nil, ErrInvalidMessage
 	}
 	return proto.Marshal(msg)
 }
 
-// Unmarshal converts the given byte slice into a data structure using Protocol Buffers.
-func (c *protoCodec) Unmarshal(src []byte, dest any) error {
+// Unmarshal decodes a Protocol Buffers message into dest.
+func (Codec) Unmarshal(src []byte, dest any) error {
 	msg, ok := dest.(proto.Message)
 	if !ok {
-		return ErrInvalidProtoMessage
+		return ErrInvalidMessage
 	}
 	return proto.Unmarshal(src, msg)
 }

--- a/codec/proto/codec_test.go
+++ b/codec/proto/codec_test.go
@@ -1,36 +1,39 @@
-package proto
+package proto_test
 
 import (
 	"testing"
 
-	"github.com/go-fries/fries/codec/proto/v4/internal/proto"
+	"github.com/go-fries/fries/codec/proto/v4"
+	testproto "github.com/go-fries/fries/codec/proto/v4/internal/proto"
+	"github.com/go-fries/fries/codec/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCodec(t *testing.T) {
-	msg := &proto.TestMessage{
-		Name:  "test",
-		Value: 123,
-	}
+	c := proto.Codec{}
+	assert.Implements(t, (*codec.Codec)(nil), c)
 
-	data, err := Codec.Marshal(msg)
-	assert.NoError(t, err)
+	want := &testproto.TestMessage{Name: "test", Value: 123}
+	data, err := c.Marshal(want)
+	require.NoError(t, err)
 
-	newMsg := &proto.TestMessage{}
-	err = Codec.Unmarshal(data, newMsg)
-	assert.NoError(t, err)
-
-	assert.Equal(t, msg.Name, newMsg.Name)
-	assert.Equal(t, msg.Value, newMsg.Value)
+	got := &testproto.TestMessage{}
+	require.NoError(t, c.Unmarshal(data, got))
+	assert.Equal(t, want.GetName(), got.GetName())
+	assert.Equal(t, want.GetValue(), got.GetValue())
 }
 
-func TestCodec_ErrInvalidProtoMessage(t *testing.T) {
-	_, err := Codec.Marshal("invalid data")
-	assert.Error(t, err)
-	assert.Equal(t, ErrInvalidProtoMessage, err)
+func TestCodecInvalidMessage(t *testing.T) {
+	c := proto.Codec{}
 
-	var newMsg string
-	err = Codec.Unmarshal([]byte("invalid data"), &newMsg)
+	_, err := c.Marshal("invalid")
+	assert.ErrorIs(t, err, proto.ErrInvalidMessage)
+	assert.ErrorIs(t, c.Unmarshal(nil, new(string)), proto.ErrInvalidMessage)
+}
+
+func TestCodecInvalidData(t *testing.T) {
+	c := proto.Codec{}
+	err := c.Unmarshal([]byte{0xff}, &testproto.TestMessage{})
 	assert.Error(t, err)
-	assert.Equal(t, ErrInvalidProtoMessage, err)
 }

--- a/codec/proto/doc.go
+++ b/codec/proto/doc.go
@@ -1,0 +1,2 @@
+// Package proto implements codec.Codec for Protocol Buffers messages.
+package proto

--- a/codec/proto/version.go
+++ b/codec/proto/version.go
@@ -1,0 +1,6 @@
+package proto
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/proto/version_test.go
+++ b/codec/proto/version_test.go
@@ -1,0 +1,19 @@
+package proto_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/proto/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := proto.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/codec/sonic/README.md
+++ b/codec/sonic/README.md
@@ -1,0 +1,17 @@
+# Sonic Codec
+
+JSON support for `github.com/go-fries/fries/codec/v4`, implemented with
+`github.com/bytedance/sonic`.
+
+```go
+c := sonic.Codec{}
+
+data, err := c.Marshal(value)
+if err != nil {
+    return err
+}
+
+err = c.Unmarshal(data, &value)
+```
+
+The zero value is ready to use and safe for concurrent use.

--- a/codec/sonic/codec.go
+++ b/codec/sonic/codec.go
@@ -5,14 +5,17 @@ import (
 	"github.com/go-fries/fries/codec/v4"
 )
 
-var Codec codec.Codec = &sonicCodec{}
+// Codec encodes and decodes JSON values using Sonic. Its zero value is ready to use.
+type Codec struct{}
 
-type sonicCodec struct{}
+var _ codec.Codec = Codec{}
 
-func (j *sonicCodec) Marshal(data any) ([]byte, error) {
+// Marshal encodes data as JSON.
+func (Codec) Marshal(data any) ([]byte, error) {
 	return sonic.Marshal(data)
 }
 
-func (j *sonicCodec) Unmarshal(src []byte, dest any) error {
+// Unmarshal decodes JSON data into dest.
+func (Codec) Unmarshal(src []byte, dest any) error {
 	return sonic.Unmarshal(src, dest)
 }

--- a/codec/sonic/codec_test.go
+++ b/codec/sonic/codec_test.go
@@ -1,58 +1,62 @@
-package sonic
+package sonic_test
 
 import (
 	"testing"
 
+	"github.com/go-fries/fries/codec/sonic/v4"
+	"github.com/go-fries/fries/codec/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSonic(t *testing.T) {
-	c1, c2 := Codec, Codec
-
-	assert.Same(t, c1, c2)
-
-	data := map[string]any{
-		"foo": "bar",
-	}
-
-	// marshal
-	bytes, err := c1.Marshal(data)
-	assert.NoError(t, err)
-
-	// unmarshal
-	dest := make(map[string]any)
-	assert.NoError(t, c1.Unmarshal(bytes, &dest))
+type message struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
 }
 
-func BenchmarkSonicCodec_Marshal(b *testing.B) {
-	data := map[string]any{
-		"foo": "bar",
-	}
+func TestCodec(t *testing.T) {
+	c := sonic.Codec{}
+	assert.Implements(t, (*codec.Codec)(nil), c)
 
-	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_, err := Codec.Marshal(data)
-			assert.NoError(b, err)
-		}
-	})
+	want := message{Name: "test", Value: 123}
+	data, err := c.Marshal(want)
+	require.NoError(t, err)
+
+	var got message
+	require.NoError(t, c.Unmarshal(data, &got))
+	assert.Equal(t, want, got)
 }
 
-func BenchmarkSonicCodec_Unmarshal(b *testing.B) {
-	data := map[string]any{
-		"foo": "bar",
-	}
+func TestCodecErrors(t *testing.T) {
+	c := sonic.Codec{}
 
-	bytes, err := Codec.Marshal(data)
-	assert.NoError(b, err)
+	_, err := c.Marshal(make(chan int))
+	assert.Error(t, err)
+	assert.Error(t, c.Unmarshal([]byte("{"), &message{}))
+}
+
+func BenchmarkCodecMarshal(b *testing.B) {
+	c := sonic.Codec{}
+	value := message{Name: "test", Value: 123}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			var dest map[string]any
-			assert.NoError(b, Codec.Unmarshal(bytes, &dest))
+	for b.Loop() {
+		if _, err := c.Marshal(value); err != nil {
+			b.Fatal(err)
 		}
-	})
+	}
+}
+
+func BenchmarkCodecUnmarshal(b *testing.B) {
+	c := sonic.Codec{}
+	data, err := c.Marshal(message{Name: "test", Value: 123})
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var value message
+		if err := c.Unmarshal(data, &value); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/codec/sonic/doc.go
+++ b/codec/sonic/doc.go
@@ -1,0 +1,2 @@
+// Package sonic implements codec.Codec using Sonic.
+package sonic

--- a/codec/sonic/version.go
+++ b/codec/sonic/version.go
@@ -1,0 +1,6 @@
+package sonic
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/sonic/version_test.go
+++ b/codec/sonic/version_test.go
@@ -1,0 +1,19 @@
+package sonic_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/sonic/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := sonic.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/codec/version.go
+++ b/codec/version.go
@@ -1,0 +1,6 @@
+package codec
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/version_test.go
+++ b/codec/version_test.go
@@ -1,0 +1,20 @@
+package codec_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := codec.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/codec/xml/README.md
+++ b/codec/xml/README.md
@@ -1,0 +1,17 @@
+# XML Codec
+
+XML support for `github.com/go-fries/fries/codec/v4`, implemented with the Go
+standard library's `encoding/xml` package.
+
+```go
+c := xml.Codec{}
+
+data, err := c.Marshal(value)
+if err != nil {
+    return err
+}
+
+err = c.Unmarshal(data, &value)
+```
+
+The zero value is ready to use and safe for concurrent use.

--- a/codec/xml/codec.go
+++ b/codec/xml/codec.go
@@ -6,19 +6,17 @@ import (
 	"github.com/go-fries/fries/codec/v4"
 )
 
-var Codec codec.Codec = &xmlCodec{}
+// Codec encodes and decodes XML values. Its zero value is ready to use.
+type Codec struct{}
 
-// codec is an XML codec.
-type xmlCodec struct{}
+var _ codec.Codec = Codec{}
 
-var _ codec.Codec = (*xmlCodec)(nil)
-
-// Marshal converts the given data into a byte slice using XML.
-func (c *xmlCodec) Marshal(data any) ([]byte, error) {
+// Marshal encodes data as XML.
+func (Codec) Marshal(data any) ([]byte, error) {
 	return xml.Marshal(data)
 }
 
-// Unmarshal converts the given byte slice into a data structure using XML.
-func (c *xmlCodec) Unmarshal(src []byte, dest any) error {
+// Unmarshal decodes XML data into dest.
+func (Codec) Unmarshal(src []byte, dest any) error {
 	return xml.Unmarshal(src, dest)
 }

--- a/codec/xml/codec_test.go
+++ b/codec/xml/codec_test.go
@@ -1,39 +1,36 @@
-package xml
+package xml_test
 
 import (
 	"testing"
 
+	"github.com/go-fries/fries/codec/v4"
+	"github.com/go-fries/fries/codec/xml/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var xmlBytes = []byte(`<TestMessage><name>test</name><value>123</value></TestMessage>`)
-
-type TestMessage struct {
+type message struct {
 	Name  string `xml:"name"`
-	Value int32  `xml:"value"`
+	Value int    `xml:"value"`
 }
 
 func TestCodec(t *testing.T) {
-	msg := &TestMessage{
-		Name:  "test",
-		Value: 123,
-	}
+	c := xml.Codec{}
+	assert.Implements(t, (*codec.Codec)(nil), c)
 
-	data, err := Codec.Marshal(msg)
-	require.NoError(t, err)
-	assert.Equal(t, xmlBytes, data)
-
-	newMsg := &TestMessage{}
-	err = Codec.Unmarshal(data, newMsg)
+	want := message{Name: "test", Value: 123}
+	data, err := c.Marshal(want)
 	require.NoError(t, err)
 
-	assert.Equal(t, msg.Name, newMsg.Name)
-	assert.Equal(t, msg.Value, newMsg.Value)
+	var got message
+	require.NoError(t, c.Unmarshal(data, &got))
+	assert.Equal(t, want, got)
+}
 
-	// Test Unmarshal with XML bytes
-	err = Codec.Unmarshal(xmlBytes, newMsg)
-	require.NoError(t, err)
-	assert.Equal(t, msg.Name, newMsg.Name)
-	assert.Equal(t, msg.Value, newMsg.Value)
+func TestCodecErrors(t *testing.T) {
+	c := xml.Codec{}
+
+	_, err := c.Marshal(make(chan int))
+	assert.Error(t, err)
+	assert.Error(t, c.Unmarshal([]byte("<message>"), &message{}))
 }

--- a/codec/xml/doc.go
+++ b/codec/xml/doc.go
@@ -1,0 +1,2 @@
+// Package xml implements codec.Codec using encoding/xml.
+package xml

--- a/codec/xml/version.go
+++ b/codec/xml/version.go
@@ -1,0 +1,6 @@
+package xml
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/xml/version_test.go
+++ b/codec/xml/version_test.go
@@ -1,0 +1,19 @@
+package xml_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/xml/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := xml.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/codec/yaml/README.md
+++ b/codec/yaml/README.md
@@ -1,0 +1,17 @@
+# YAML Codec
+
+YAML support for `github.com/go-fries/fries/codec/v4`, implemented with
+`gopkg.in/yaml.v3`.
+
+```go
+c := yaml.Codec{}
+
+data, err := c.Marshal(value)
+if err != nil {
+    return err
+}
+
+err = c.Unmarshal(data, &value)
+```
+
+The zero value is ready to use and safe for concurrent use.

--- a/codec/yaml/codec.go
+++ b/codec/yaml/codec.go
@@ -5,17 +5,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var Codec codec.Codec = &yamlCodec{}
+// Codec encodes and decodes YAML values. Its zero value is ready to use.
+type Codec struct{}
 
-// yamlCodec is a YAML codec.
-type yamlCodec struct{}
+var _ codec.Codec = Codec{}
 
-// Marshal converts the given data into a byte slice using YAML.
-func (c *yamlCodec) Marshal(data any) ([]byte, error) {
+// Marshal encodes data as YAML.
+func (Codec) Marshal(data any) ([]byte, error) {
 	return yaml.Marshal(data)
 }
 
-// Unmarshal converts the given byte slice into a data structure using YAML.
-func (c *yamlCodec) Unmarshal(src []byte, dest any) error {
+// Unmarshal decodes YAML data into dest.
+func (Codec) Unmarshal(src []byte, dest any) error {
 	return yaml.Unmarshal(src, dest)
 }

--- a/codec/yaml/codec_test.go
+++ b/codec/yaml/codec_test.go
@@ -1,41 +1,34 @@
-package yaml
+package yaml_test
 
 import (
 	"testing"
 
+	"github.com/go-fries/fries/codec/v4"
+	"github.com/go-fries/fries/codec/yaml/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var yamlBytes = []byte(`name: test
-value: 123
-`)
-
-type TestMessage struct {
+type message struct {
 	Name  string `yaml:"name"`
-	Value int32  `yaml:"value"`
+	Value int    `yaml:"value"`
 }
 
 func TestCodec(t *testing.T) {
-	msg := &TestMessage{
-		Name:  "test",
-		Value: 123,
-	}
+	c := yaml.Codec{}
+	assert.Implements(t, (*codec.Codec)(nil), c)
 
-	data, err := Codec.Marshal(msg)
-	require.NoError(t, err)
-	assert.Equal(t, yamlBytes, data)
-
-	newMsg := &TestMessage{}
-	err = Codec.Unmarshal(data, newMsg)
+	want := message{Name: "test", Value: 123}
+	data, err := c.Marshal(want)
 	require.NoError(t, err)
 
-	assert.Equal(t, msg.Name, newMsg.Name)
-	assert.Equal(t, msg.Value, newMsg.Value)
+	var got message
+	require.NoError(t, c.Unmarshal(data, &got))
+	assert.Equal(t, want, got)
+}
 
-	// Test Unmarshal with YAML bytes
-	err = Codec.Unmarshal(yamlBytes, newMsg)
-	require.NoError(t, err)
-	assert.Equal(t, msg.Name, newMsg.Name)
-	assert.Equal(t, msg.Value, newMsg.Value)
+func TestCodecErrors(t *testing.T) {
+	c := yaml.Codec{}
+
+	assert.Error(t, c.Unmarshal([]byte("value: ["), &message{}))
 }

--- a/codec/yaml/doc.go
+++ b/codec/yaml/doc.go
@@ -1,0 +1,2 @@
+// Package yaml implements codec.Codec using YAML.
+package yaml

--- a/codec/yaml/version.go
+++ b/codec/yaml/version.go
@@ -1,0 +1,6 @@
+package yaml
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/codec/yaml/version_test.go
+++ b/codec/yaml/version_test.go
@@ -1,0 +1,19 @@
+package yaml_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/codec/yaml/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := yaml.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/eino/components/embedding/cached/cacher/redis/cacher.go
+++ b/eino/components/embedding/cached/cacher/redis/cacher.go
@@ -12,8 +12,6 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var defaultCodec codec.Codec = sonic.Codec{}
-
 type Cacher struct {
 	rdb    redis.UniversalClient
 	prefix string
@@ -48,7 +46,7 @@ func NewCacher(rdb redis.UniversalClient, opts ...Option) *Cacher {
 	cacher := &Cacher{
 		rdb:    rdb,
 		prefix: "eino:",
-		codec:  defaultCodec,
+		codec:  sonic.Codec{},
 	}
 	for _, opt := range opts {
 		opt.apply(cacher)

--- a/eino/components/embedding/cached/cacher/redis/cacher.go
+++ b/eino/components/embedding/cached/cacher/redis/cacher.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var defaultCodec = sonic.Codec
+var defaultCodec codec.Codec = sonic.Codec{}
 
 type Cacher struct {
 	rdb    redis.UniversalClient

--- a/eino/components/embedding/cached/cacher/redis/cacher_test.go
+++ b/eino/components/embedding/cached/cacher/redis/cacher_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-fries/fries/codec/sonic/v4"
 	"github.com/go-fries/fries/codec/v4"
 	"github.com/go-fries/fries/eino/components/embedding/cached/v4"
 	"github.com/redis/go-redis/v9"
@@ -61,7 +62,7 @@ func TestCacher(t *testing.T) {
 	value := []float64{1.1, 2.2, 3.3}
 	expire := time.Second * 10
 
-	valueBytes, err := defaultCodec.Marshal(value)
+	valueBytes, err := (sonic.Codec{}).Marshal(value)
 	require.NoError(t, err)
 
 	t.Run("Set and Get", func(t *testing.T) {

--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-fries/fries/codec/v4"
 )
 
-var DefaultCodec = json.Codec
+var DefaultCodec codec.Codec = json.Codec{}
 
 // Client represents a JSON-RPC client that can invoke remote methods.
 // It supports namespacing to organize method calls and uses a Transport

--- a/mysql/canal/positioner/redis/positioner.go
+++ b/mysql/canal/positioner/redis/positioner.go
@@ -32,7 +32,7 @@ type Option interface {
 func NewPositioner(client redis.UniversalClient, opts ...Option) *Positioner {
 	positioner := &Positioner{
 		client: client,
-		codec:  json.Codec,
+		codec:  json.Codec{},
 	}
 
 	for _, opt := range opts {

--- a/mysql/canal/positioner/redis/positioner_test.go
+++ b/mysql/canal/positioner/redis/positioner_test.go
@@ -28,9 +28,9 @@ func createRedisClient(t *testing.T) redis.UniversalClient {
 }
 
 func TestPositioner(t *testing.T) {
-	positioner := NewPositioner(createRedisClient(t), WithPrefix("canal"), WithCodec(json.Codec))
+	positioner := NewPositioner(createRedisClient(t), WithPrefix("canal"), WithCodec(json.Codec{}))
 	assert.Equal(t, "canal:"+name, positioner.prefix+name)
-	assert.Equal(t, json.Codec, positioner.codec)
+	assert.Equal(t, json.Codec{}, positioner.codec)
 
 	pos, err := positioner.Get(ctx)
 	require.NoError(t, err)
@@ -51,11 +51,11 @@ func TestPositioner(t *testing.T) {
 func TestBufferedPositioner(t *testing.T) {
 	positioner := NewBufferedPositioner(
 		createRedisClient(t),
-		WithPrefix("buffered:canal"), WithCodec(json.Codec),
+		WithPrefix("buffered:canal"), WithCodec(json.Codec{}),
 		WithFlushInterval(5*time.Second), WithBatchSize(100),
 	)
 	assert.Equal(t, "buffered:canal:"+name, positioner.prefix+name)
-	assert.Equal(t, json.Codec, positioner.codec)
+	assert.Equal(t, json.Codec{}, positioner.codec)
 	assert.Equal(t, 5*time.Second, positioner.flushInterval)
 	assert.Equal(t, 100, positioner.batchSize)
 


### PR DESCRIPTION
## Summary

Refactor the codec family around zero-value concrete implementations while preserving the small root `codec.Codec` contract. This removes mutable shared codec instances, standardizes all format modules, and updates repository consumers to the new API.

## Changes

- Keep the root `codec.Codec` interface limited to `Marshal` and `Unmarshal`
- Replace package-level mutable `Codec` variables with exported zero-value `Codec` structs in:
  - JSON
  - MessagePack
  - Protocol Buffers
  - Sonic
  - XML
  - YAML
- Use value receivers and compile-time `codec.Codec` assertions for every implementation
- Add package documentation, module READMEs, `Version()` helpers, and semver tests across the codec family
- Rewrite codec tests as external-package contract tests covering interface conformance, round trips, invalid input, and benchmarks where applicable
- Replace Proto's `ErrInvalidProtoMessage` with the more concise `ErrInvalidMessage` sentinel created with `errors.New`
- Migrate default codecs and tests in cache/redis, JSON-RPC, Eino Redis cacher, and MySQL canal Redis positioner
- Rewrite the root README around the shared interface contract instead of a JSON-specific example

## Motivation

- The previous exported codec variables were mutable global state and could be reassigned by importing packages
- All implementations are stateless, so zero-value concrete structs are simpler, allocation-free, and safe to construct where needed
- The codec modules had inconsistent documentation, interface assertions, version metadata, tests, and naming
- Keeping the root interface unchanged preserves its usefulness for dependency injection without expanding it with format-specific behavior

## Breaking Changes

### Default codec instances are now concrete types

The exported `Codec` identifier in each implementation package changed from a shared variable to a concrete struct type.

Before:

```go
var c codec.Codec = json.Codec
store := redis.New(client, redis.Codec(json.Codec))
```

After:

```go
var c codec.Codec = json.Codec{}
store := redis.New(client, redis.Codec(json.Codec{}))
```

The same migration applies to `msgpack.Codec`, `proto.Codec`, `sonic.Codec`, `xml.Codec`, and `yaml.Codec`.

Code relying on pointer identity or mutation of the previous shared package variable must instead construct and pass an explicit codec value.

### Proto error rename

Before:

```go
errors.Is(err, proto.ErrInvalidProtoMessage)
```

After:

```go
errors.Is(err, proto.ErrInvalidMessage)
```

## Upgrade Guide

1. Find uses of the implementation package's `Codec` value.
2. Add `{}` to construct the zero-value codec:

   ```go
   json.Codec    // old
   json.Codec{}  // new
   ```

3. Apply the same change when assigning to `codec.Codec`, passing options, or defining defaults.
4. Rename `proto.ErrInvalidProtoMessage` references to `proto.ErrInvalidMessage`.
5. No changes are required for custom implementations of the root `codec.Codec` interface because its method set is unchanged.

## Before and After

| Area | Before | After |
| --- | --- | --- |
| Implementation API | Mutable shared `var Codec codec.Codec` | Zero-value concrete `type Codec struct{}` |
| Construction | `json.Codec` | `json.Codec{}` |
| Receivers | Private pointer implementations | Exported stateless value implementations |
| Interface validation | Inconsistent | Compile-time assertion in every module |
| Proto invalid value error | `ErrInvalidProtoMessage` | `ErrInvalidMessage` |
| Package metadata | Incomplete | `doc.go`, README, `Version()`, semver tests |
| Tests | Mostly internal happy-path tests | External contract, error, round-trip, and version tests |

## Testing

- `go test -race ./...` in the root codec module and all six implementation modules
- Module-specific lint targets for all seven codec modules
- `go test -race ./...` for JSON-RPC and the Eino Redis cacher
- Compile-only tests for cache/redis and MySQL canal Redis positioner; full integration tests require a local Redis service
- Module-specific lint targets for all four migrated consumer modules
- Repository-wide `make build`
- `git diff --check 4.x...HEAD`
