### PR TITLE
feat(retry): add retry component

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -87,6 +87,7 @@ fixes:
   - github.com/go-fries/fries/mysql/canal/server/v4::mysql/canal/server/
   - github.com/go-fries/fries/otel/otlp/v4::otel/otlp/
   - github.com/go-fries/fries/recovery/v4::recovery/
+  - github.com/go-fries/fries/retry/v4::retry/
   - github.com/go-fries/fries/signal/v4::signal/
   - github.com/go-fries/fries/support/v4::support/
   - github.com/go-fries/fries/timezone/v4::timezone/

--- a/retry/README.md
+++ b/retry/README.md
@@ -1,0 +1,113 @@
+# Retry
+
+`retry` executes transiently failing operations with bounded, context-aware
+retries. It supports typed results, retry filtering, reusable backoff
+strategies, jitter, permanent errors, retry-after overrides, and retry
+notifications.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/retry/v4
+```
+
+## Retry an operation
+
+```go
+err := retry.Do(ctx, func(ctx context.Context) error {
+	return repository.Refresh(ctx)
+})
+```
+
+The default configuration allows three total attempts and uses exponential
+backoff starting at 100 milliseconds and capped at one second. The initial
+execution counts as the first attempt.
+
+Use options to make the retry behavior explicit for a call:
+
+```go
+err := retry.Do(ctx, func(ctx context.Context) error {
+	return client.Send(ctx, request)
+},
+	retry.WithMaxAttempts(5),
+	retry.WithBackoff(retry.Jitter(
+		retry.Exponential(200*time.Millisecond, 5*time.Second),
+		100*time.Millisecond,
+	)),
+	retry.WithRetryIf(func(err error) bool {
+		return errors.Is(err, ErrUnavailable)
+	}),
+)
+```
+
+The caller's context controls the complete retry lifetime, including waits
+between attempts:
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+defer cancel()
+
+err := retry.Do(ctx, operation)
+```
+
+The operation itself must observe the supplied context while it is running.
+
+## Return a value
+
+Use `DoValue` for typed results:
+
+```go
+profile, err := retry.DoValue(ctx, func(ctx context.Context) (Profile, error) {
+	return service.LoadProfile(ctx, userID)
+})
+```
+
+When all attempts fail, `DoValue` returns the value and error produced by the
+final execution.
+
+## Stop retrying
+
+Return `Permanent` for errors that another attempt cannot resolve:
+
+```go
+if errors.Is(err, ErrInvalidRequest) {
+	return retry.Permanent(err)
+}
+```
+
+`Do` and `DoValue` return the underlying error, so normal `errors.Is` and
+`errors.As` checks continue to work.
+
+## Override the next delay
+
+Use `After` when a service supplies an explicit retry interval, such as an HTTP
+`Retry-After` response:
+
+```go
+return retry.After(delay, ErrRateLimited)
+```
+
+The override still respects the attempt limit, retry predicate, and context.
+
+## Observe scheduled retries
+
+```go
+err := retry.Do(ctx, operation,
+	retry.WithNotify(func(ctx context.Context, event retry.Event) {
+		logger.WarnContext(ctx, "operation will retry",
+			"attempt", event.Attempt,
+			"max_attempts", event.MaxAttempts,
+			"delay", event.Delay,
+			"error", event.Err,
+		)
+	}),
+)
+```
+
+Notifications run synchronously before the wait for the next attempt. A
+notification callback should return quickly and must be safe for concurrent use
+when shared by multiple callers.
+
+`retry` handles in-process operation retries only. Durable message redelivery,
+acknowledgement, and dead-letter behavior remain responsibilities of queue
+implementations.

--- a/retry/README.md
+++ b/retry/README.md
@@ -51,6 +51,8 @@ err := retry.Do(ctx, operation)
 ```
 
 The operation itself must observe the supplied context while it is running.
+If the context is canceled during an attempt and that attempt returns an error,
+the context error takes precedence.
 
 `Do` and `DoValue` panic when the operation is nil. As with other Go APIs that
 accept `context.Context`, callers must not pass a nil context. Attempt counts
@@ -84,7 +86,8 @@ if errors.Is(err, ErrInvalidRequest) {
 ```
 
 `Do` and `DoValue` return the underlying error, so normal `errors.Is` and
-`errors.As` checks continue to work.
+`errors.As` checks continue to work. Errors wrapped around the `Permanent`
+marker are preserved.
 
 ## Override the next delay
 
@@ -96,6 +99,7 @@ return retry.After(delay, ErrRateLimited)
 ```
 
 The override still respects the attempt limit, retry predicate, and context.
+Errors wrapped around the `After` marker are preserved.
 
 ## Observe scheduled retries
 

--- a/retry/README.md
+++ b/retry/README.md
@@ -52,6 +52,14 @@ err := retry.Do(ctx, operation)
 
 The operation itself must observe the supplied context while it is running.
 
+`Do` and `DoValue` panic when the operation is nil. As with other Go APIs that
+accept `context.Context`, callers must not pass a nil context. Attempt counts
+below one, nil backoff, and nil retry predicates leave the current configuration
+unchanged. Backoff constructors and `After` panic on negative durations so
+invalid static configuration fails immediately. A negative duration returned
+dynamically by a custom backoff is treated as zero. The package does not recover
+panics raised by an operation or notification callback.
+
 ## Return a value
 
 Use `DoValue` for typed results:

--- a/retry/backoff.go
+++ b/retry/backoff.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-// Backoff returns the delay after a failed attempt. attempt starts at one and
-// identifies the execution that just failed.
+// Backoff returns the delay after a failed attempt. The attempt parameter
+// starts at one and identifies the execution that just failed.
 //
 // A Backoff must be safe for concurrent use when shared by callers.
 type Backoff func(attempt int) time.Duration
@@ -80,11 +80,11 @@ func Exponential(initial, maximum time.Duration) Backoff {
 	}
 }
 
-// Jitter wraps backoff and adds a random duration from zero through maximum to
-// each positive delay.
+// Jitter wraps backoff and adds a random duration in the inclusive range from
+// zero through maximum to each positive delay.
 //
-// A nil backoff is treated as NoBackoff. Jitter panics if maximum is negative.
-// Overflow is clamped to the largest duration.
+// A nil backoff is treated as [NoBackoff]. Jitter panics if maximum is
+// negative. Overflow is clamped to the largest duration.
 func Jitter(backoff Backoff, maximum time.Duration) Backoff {
 	if backoff == nil {
 		backoff = NoBackoff()

--- a/retry/backoff.go
+++ b/retry/backoff.go
@@ -1,0 +1,122 @@
+package retry
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Backoff returns the delay after a failed attempt. attempt starts at one and
+// identifies the execution that just failed.
+//
+// A Backoff must be safe for concurrent use when shared by callers.
+type Backoff func(attempt int) time.Duration
+
+// NoBackoff returns a strategy that never waits between attempts.
+func NoBackoff() Backoff {
+	return func(int) time.Duration {
+		return 0
+	}
+}
+
+// Fixed returns a strategy that always waits for delay.
+//
+// It panics if delay is negative.
+func Fixed(delay time.Duration) Backoff {
+	validateDelay("fixed delay", delay)
+	return func(int) time.Duration {
+		return delay
+	}
+}
+
+// Linear returns a strategy whose delay is delay multiplied by the failed
+// attempt number.
+//
+// It panics if delay is negative. Overflow is clamped to the largest duration.
+func Linear(delay time.Duration) Backoff {
+	validateDelay("linear delay", delay)
+	return func(attempt int) time.Duration {
+		if attempt < 1 || delay == 0 {
+			return 0
+		}
+		return multiplyDuration(delay, uint64(attempt))
+	}
+}
+
+// Exponential returns a strategy that starts at initial and doubles after each
+// failed attempt. A maximum of zero disables the upper bound.
+//
+// It panics if either duration is negative, or if maximum is positive and less
+// than initial. Overflow is clamped to maximum or the largest duration.
+func Exponential(initial, maximum time.Duration) Backoff {
+	validateDelay("exponential initial delay", initial)
+	validateDelay("exponential maximum delay", maximum)
+	if maximum > 0 && maximum < initial {
+		panic("retry: exponential maximum delay must not be less than initial delay")
+	}
+
+	return func(attempt int) time.Duration {
+		if attempt < 1 || initial == 0 {
+			return 0
+		}
+
+		delay := initial
+		for range attempt - 1 {
+			if maximum > 0 && delay >= maximum {
+				return maximum
+			}
+			if delay > time.Duration(math.MaxInt64/2) {
+				if maximum > 0 {
+					return maximum
+				}
+				return time.Duration(math.MaxInt64)
+			}
+			delay *= 2
+		}
+		if maximum > 0 && delay > maximum {
+			return maximum
+		}
+		return delay
+	}
+}
+
+// Jitter wraps backoff and adds a random duration from zero through maximum to
+// each positive delay.
+//
+// It panics if backoff is nil or maximum is negative. Overflow is clamped to
+// the largest duration.
+func Jitter(backoff Backoff, maximum time.Duration) Backoff {
+	if backoff == nil {
+		panic("retry: nil jitter backoff")
+	}
+	validateDelay("jitter maximum delay", maximum)
+	if maximum == 0 {
+		return backoff
+	}
+
+	return func(attempt int) time.Duration {
+		delay := backoff(attempt)
+		if delay <= 0 {
+			return delay
+		}
+
+		jitter := time.Duration(rand.Uint64N(uint64(maximum) + 1)) //nolint:gosec
+		if delay > time.Duration(math.MaxInt64)-jitter {
+			return time.Duration(math.MaxInt64)
+		}
+		return delay + jitter
+	}
+}
+
+func validateDelay(name string, delay time.Duration) {
+	if delay < 0 {
+		panic("retry: " + name + " must not be negative")
+	}
+}
+
+func multiplyDuration(delay time.Duration, multiplier uint64) time.Duration {
+	if multiplier > uint64(math.MaxInt64)/uint64(delay) {
+		return time.Duration(math.MaxInt64)
+	}
+	return delay * time.Duration(multiplier)
+}

--- a/retry/backoff.go
+++ b/retry/backoff.go
@@ -83,11 +83,11 @@ func Exponential(initial, maximum time.Duration) Backoff {
 // Jitter wraps backoff and adds a random duration from zero through maximum to
 // each positive delay.
 //
-// It panics if backoff is nil or maximum is negative. Overflow is clamped to
-// the largest duration.
+// A nil backoff is treated as NoBackoff. Jitter panics if maximum is negative.
+// Overflow is clamped to the largest duration.
 func Jitter(backoff Backoff, maximum time.Duration) Backoff {
 	if backoff == nil {
-		panic("retry: nil jitter backoff")
+		backoff = NoBackoff()
 	}
 	validateDelay("jitter maximum delay", maximum)
 	if maximum == 0 {

--- a/retry/backoff_test.go
+++ b/retry/backoff_test.go
@@ -1,0 +1,133 @@
+package retry
+
+import (
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackoffStrategies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		backoff  Backoff
+		attempts []int
+		want     []time.Duration
+	}{
+		{
+			name:     "none",
+			backoff:  NoBackoff(),
+			attempts: []int{0, 1, 2},
+			want:     []time.Duration{0, 0, 0},
+		},
+		{
+			name:     "fixed",
+			backoff:  Fixed(time.Second),
+			attempts: []int{0, 1, 2},
+			want:     []time.Duration{time.Second, time.Second, time.Second},
+		},
+		{
+			name:     "linear",
+			backoff:  Linear(time.Second),
+			attempts: []int{0, 1, 2, 3},
+			want:     []time.Duration{0, time.Second, 2 * time.Second, 3 * time.Second},
+		},
+		{
+			name:     "exponential",
+			backoff:  Exponential(time.Second, 0),
+			attempts: []int{0, 1, 2, 3},
+			want:     []time.Duration{0, time.Second, 2 * time.Second, 4 * time.Second},
+		},
+		{
+			name:     "exponential capped",
+			backoff:  Exponential(time.Second, 2500*time.Millisecond),
+			attempts: []int{1, 2, 3, 4},
+			want:     []time.Duration{time.Second, 2 * time.Second, 2500 * time.Millisecond, 2500 * time.Millisecond},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			for i, attempt := range tt.attempts {
+				assert.Equal(t, tt.want[i], tt.backoff(attempt))
+			}
+		})
+	}
+}
+
+func TestBackoffOverflowIsClamped(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, time.Duration(math.MaxInt64), Linear(time.Duration(math.MaxInt64))(2))
+	assert.Equal(t, time.Duration(math.MaxInt64), Exponential(time.Duration(math.MaxInt64), 0)(2))
+	assert.Equal(t, 5*time.Second, Exponential(4*time.Second, 5*time.Second)(2))
+}
+
+func TestJitter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		base    = time.Second
+		maximum = 100 * time.Millisecond
+	)
+	backoff := Jitter(Fixed(base), maximum)
+
+	for range 100 {
+		delay := backoff(1)
+		assert.GreaterOrEqual(t, delay, base)
+		assert.LessOrEqual(t, delay, base+maximum)
+	}
+
+	assert.Zero(t, Jitter(NoBackoff(), maximum)(1))
+	assert.Equal(t, base, Jitter(Fixed(base), 0)(1))
+	assert.Equal(
+		t,
+		time.Duration(math.MaxInt64),
+		Jitter(Fixed(time.Duration(math.MaxInt64)), time.Second)(1),
+	)
+}
+
+func TestJitterIsSafeForConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	backoff := Jitter(Fixed(time.Second), time.Millisecond)
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Go(func() {
+			delay := backoff(1)
+			assert.GreaterOrEqual(t, delay, time.Second)
+			assert.LessOrEqual(t, delay, time.Second+time.Millisecond)
+		})
+	}
+	wg.Wait()
+}
+
+func TestBackoffPanicsOnInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		{name: "negative fixed delay", fn: func() { Fixed(-1) }},
+		{name: "negative linear delay", fn: func() { Linear(-1) }},
+		{name: "negative exponential initial", fn: func() { Exponential(-1, 0) }},
+		{name: "negative exponential maximum", fn: func() { Exponential(0, -1) }},
+		{name: "maximum below initial", fn: func() { Exponential(time.Second, time.Millisecond) }},
+		{name: "nil jitter backoff", fn: func() { Jitter(nil, 0) }},
+		{name: "negative jitter maximum", fn: func() { Jitter(NoBackoff(), -1) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Panics(t, tt.fn)
+		})
+	}
+}

--- a/retry/backoff_test.go
+++ b/retry/backoff_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBackoffStrategies(t *testing.T) {
@@ -108,7 +107,13 @@ func TestJitterIsSafeForConcurrentUse(t *testing.T) {
 	wg.Wait()
 }
 
-func TestBackoffPanicsOnInvalidConfiguration(t *testing.T) {
+func TestJitterNormalizesNilBackoff(t *testing.T) {
+	t.Parallel()
+
+	assert.Zero(t, Jitter(nil, 0)(1))
+}
+
+func TestBackoffPanicsOnInvalidDelay(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -120,14 +125,13 @@ func TestBackoffPanicsOnInvalidConfiguration(t *testing.T) {
 		{name: "negative exponential initial", fn: func() { Exponential(-1, 0) }},
 		{name: "negative exponential maximum", fn: func() { Exponential(0, -1) }},
 		{name: "maximum below initial", fn: func() { Exponential(time.Second, time.Millisecond) }},
-		{name: "nil jitter backoff", fn: func() { Jitter(nil, 0) }},
 		{name: "negative jitter maximum", fn: func() { Jitter(NoBackoff(), -1) }},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Panics(t, tt.fn)
+			assert.Panics(t, tt.fn)
 		})
 	}
 }

--- a/retry/config.go
+++ b/retry/config.go
@@ -1,0 +1,111 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const (
+	defaultMaxAttempts  = 3
+	defaultInitialDelay = 100 * time.Millisecond
+	defaultMaximumDelay = time.Second
+)
+
+// Event describes a failed operation that will be retried.
+type Event struct {
+	Attempt     int
+	MaxAttempts int
+	Err         error
+	Delay       time.Duration
+}
+
+// NotifyFunc receives an Event before the wait for the next attempt begins.
+//
+// Notifications run synchronously. Implementations should return quickly and
+// must be safe for concurrent use when the same function is shared by callers.
+type NotifyFunc func(context.Context, Event)
+
+type config struct {
+	maxAttempts int
+	backoff     Backoff
+	retryIf     func(error) bool
+	notify      NotifyFunc
+}
+
+// Option configures retry execution.
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+
+// WithMaxAttempts sets the total number of allowed executions, including the
+// initial attempt.
+//
+// It panics if attempts is less than one.
+func WithMaxAttempts(attempts int) Option {
+	if attempts < 1 {
+		panic("retry: max attempts must be greater than zero")
+	}
+	return optionFunc(func(c *config) {
+		c.maxAttempts = attempts
+	})
+}
+
+// WithBackoff sets the delay strategy used between attempts.
+//
+// It panics if backoff is nil.
+func WithBackoff(backoff Backoff) Option {
+	if backoff == nil {
+		panic("retry: nil backoff")
+	}
+	return optionFunc(func(c *config) {
+		c.backoff = backoff
+	})
+}
+
+// WithRetryIf sets the predicate that decides whether an operation error may
+// be retried. The predicate is not called after the final allowed attempt.
+//
+// It panics if predicate is nil.
+func WithRetryIf(predicate func(error) bool) Option {
+	if predicate == nil {
+		panic("retry: nil retry predicate")
+	}
+	return optionFunc(func(c *config) {
+		c.retryIf = predicate
+	})
+}
+
+// WithNotify sets the function called before each scheduled retry.
+//
+// Passing nil disables notifications.
+func WithNotify(notify NotifyFunc) Option {
+	return optionFunc(func(c *config) {
+		c.notify = notify
+	})
+}
+
+func newConfig(options ...Option) *config {
+	c := &config{
+		maxAttempts: defaultMaxAttempts,
+		backoff:     Exponential(defaultInitialDelay, defaultMaximumDelay),
+		retryIf:     defaultRetryIf,
+	}
+	for _, option := range options {
+		if option != nil {
+			option.apply(c)
+		}
+	}
+	return c
+}
+
+func defaultRetryIf(err error) bool {
+	return !errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
+}

--- a/retry/config.go
+++ b/retry/config.go
@@ -14,10 +14,15 @@ const (
 
 // Event describes a failed operation that will be retried.
 type Event struct {
-	Attempt     int
+	// Attempt is the one-based number of the execution that failed.
+	Attempt int
+	// MaxAttempts is the configured total execution limit, including the
+	// initial attempt.
 	MaxAttempts int
-	Err         error
-	Delay       time.Duration
+	// Err is the underlying error returned by the failed operation.
+	Err error
+	// Delay is the duration to wait before the next attempt.
+	Delay time.Duration
 }
 
 // NotifyFunc receives an Event before the wait for the next attempt begins.
@@ -81,7 +86,7 @@ func WithRetryIf(predicate func(error) bool) Option {
 
 // WithNotify sets the function called before each scheduled retry.
 //
-// Passing nil disables notifications.
+// Passing a nil [NotifyFunc] disables notifications.
 func WithNotify(notify NotifyFunc) Option {
 	return optionFunc(func(c *config) {
 		c.notify = notify

--- a/retry/config.go
+++ b/retry/config.go
@@ -47,38 +47,35 @@ func (f optionFunc) apply(c *config) {
 // WithMaxAttempts sets the total number of allowed executions, including the
 // initial attempt.
 //
-// It panics if attempts is less than one.
+// Values less than one leave the current attempt limit unchanged.
 func WithMaxAttempts(attempts int) Option {
-	if attempts < 1 {
-		panic("retry: max attempts must be greater than zero")
-	}
 	return optionFunc(func(c *config) {
-		c.maxAttempts = attempts
+		if attempts >= 1 {
+			c.maxAttempts = attempts
+		}
 	})
 }
 
 // WithBackoff sets the delay strategy used between attempts.
 //
-// It panics if backoff is nil.
+// A nil backoff leaves the current strategy unchanged.
 func WithBackoff(backoff Backoff) Option {
-	if backoff == nil {
-		panic("retry: nil backoff")
-	}
 	return optionFunc(func(c *config) {
-		c.backoff = backoff
+		if backoff != nil {
+			c.backoff = backoff
+		}
 	})
 }
 
 // WithRetryIf sets the predicate that decides whether an operation error may
 // be retried. The predicate is not called after the final allowed attempt.
 //
-// It panics if predicate is nil.
+// A nil predicate leaves the current predicate unchanged.
 func WithRetryIf(predicate func(error) bool) Option {
-	if predicate == nil {
-		panic("retry: nil retry predicate")
-	}
 	return optionFunc(func(c *config) {
-		c.retryIf = predicate
+		if predicate != nil {
+			c.retryIf = predicate
+		}
 	})
 }
 

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -1,0 +1,8 @@
+// Package retry executes transiently failing operations with bounded,
+// context-aware retries.
+//
+// Retry delays are controlled by reusable Backoff functions. Callers can stop
+// retrying with Permanent, override the next delay with After, and restrict
+// retryable errors with WithRetryIf. The caller's context owns the total retry
+// lifetime, including waits between attempts.
+package retry

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -1,11 +1,11 @@
 // Package retry executes transiently failing operations with bounded,
 // context-aware retries.
 //
-// Retry delays are controlled by reusable Backoff functions. Callers can stop
-// retrying with Permanent, override the next delay with After, and restrict
-// retryable errors with WithRetryIf. The caller's context owns the total retry
-// lifetime, including waits between attempts. Contexts must not be nil, and a
-// nil operation panics. Invalid optional values are ignored or normalized when
-// execution can remain well-defined, while backoff constructors reject invalid
-// durations immediately.
+// Retry delays are controlled by reusable [Backoff] functions. Callers can stop
+// retrying with [Permanent], override the next delay with [After], and restrict
+// retryable errors with [WithRetryIf]. The caller's context owns the total
+// retry lifetime, including waits between attempts. Contexts must not be nil,
+// and a nil operation panics. Invalid optional values are ignored or normalized
+// when execution can remain well-defined, while backoff constructors reject
+// invalid durations immediately.
 package retry

--- a/retry/doc.go
+++ b/retry/doc.go
@@ -4,5 +4,8 @@
 // Retry delays are controlled by reusable Backoff functions. Callers can stop
 // retrying with Permanent, override the next delay with After, and restrict
 // retryable errors with WithRetryIf. The caller's context owns the total retry
-// lifetime, including waits between attempts.
+// lifetime, including waits between attempts. Contexts must not be nil, and a
+// nil operation panics. Invalid optional values are ignored or normalized when
+// execution can remain well-defined, while backoff constructors reject invalid
+// durations immediately.
 package retry

--- a/retry/example_test.go
+++ b/retry/example_test.go
@@ -1,0 +1,31 @@
+package retry_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-fries/fries/retry/v4"
+)
+
+func ExampleDo() {
+	attempts := 0
+	err := retry.Do(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < 3 {
+			return fmt.Errorf("temporarily unavailable")
+		}
+		return nil
+	}, retry.WithBackoff(retry.NoBackoff()))
+
+	fmt.Println(attempts, err)
+	// Output: 3 <nil>
+}
+
+func ExampleDoValue() {
+	value, err := retry.DoValue(context.Background(), func(context.Context) (string, error) {
+		return "ready", nil
+	})
+
+	fmt.Println(value, err)
+	// Output: ready <nil>
+}

--- a/retry/go.mod
+++ b/retry/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/retry/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/retry/go.sum
+++ b/retry/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -15,7 +15,7 @@ type ValueOperation[T any] func(context.Context) (T, error)
 // Do executes operation until it succeeds, cannot be retried, exhausts the
 // configured attempts, or ctx is canceled.
 //
-// Do panics if ctx or operation is nil.
+// ctx must not be nil. Do panics if operation is nil.
 func Do(ctx context.Context, operation Operation, options ...Option) error {
 	if operation == nil {
 		panic("retry: nil operation")
@@ -30,15 +30,12 @@ func Do(ctx context.Context, operation Operation, options ...Option) error {
 // the configured attempts, or ctx is canceled. It returns the value produced
 // by the final operation execution, including when that execution fails.
 //
-// DoValue panics if ctx or operation is nil.
+// ctx must not be nil. DoValue panics if operation is nil.
 func DoValue[T any](
 	ctx context.Context,
 	operation ValueOperation[T],
 	options ...Option,
 ) (T, error) {
-	if ctx == nil {
-		panic("retry: nil context")
-	}
 	if operation == nil {
 		panic("retry: nil operation")
 	}
@@ -46,7 +43,7 @@ func DoValue[T any](
 	c := newConfig(options...)
 	var result T
 
-	for attempt := 1; attempt <= c.maxAttempts; attempt++ {
+	for attempt := 1; ; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return result, err
 		}
@@ -68,10 +65,7 @@ func DoValue[T any](
 			return result, info.cause
 		}
 
-		delay := c.backoff(attempt)
-		if delay < 0 {
-			panic("retry: backoff returned a negative delay")
-		}
+		delay := max(c.backoff(attempt), 0)
 		if info.override {
 			delay = info.overrideDelay
 		}
@@ -87,8 +81,6 @@ func DoValue[T any](
 			return result, err
 		}
 	}
-
-	panic("retry: unreachable")
 }
 
 // Permanent marks err as non-retryable. It returns nil when err is nil.

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,188 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Operation is an error-returning operation that may be retried.
+type Operation func(context.Context) error
+
+// ValueOperation is a value-returning operation that may be retried.
+type ValueOperation[T any] func(context.Context) (T, error)
+
+// Do executes operation until it succeeds, cannot be retried, exhausts the
+// configured attempts, or ctx is canceled.
+//
+// Do panics if ctx or operation is nil.
+func Do(ctx context.Context, operation Operation, options ...Option) error {
+	if operation == nil {
+		panic("retry: nil operation")
+	}
+	_, err := DoValue(ctx, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, operation(ctx)
+	}, options...)
+	return err
+}
+
+// DoValue executes operation until it succeeds, cannot be retried, exhausts
+// the configured attempts, or ctx is canceled. It returns the value produced
+// by the final operation execution, including when that execution fails.
+//
+// DoValue panics if ctx or operation is nil.
+func DoValue[T any](
+	ctx context.Context,
+	operation ValueOperation[T],
+	options ...Option,
+) (T, error) {
+	if ctx == nil {
+		panic("retry: nil context")
+	}
+	if operation == nil {
+		panic("retry: nil operation")
+	}
+
+	c := newConfig(options...)
+	var result T
+
+	for attempt := 1; attempt <= c.maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+
+		var err error
+		result, err = operation(ctx)
+		if err == nil {
+			return result, nil
+		}
+
+		info := inspectError(err)
+		if info.permanent {
+			return result, info.cause
+		}
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if attempt == c.maxAttempts || !c.retryIf(info.cause) {
+			return result, info.cause
+		}
+
+		delay := c.backoff(attempt)
+		if delay < 0 {
+			panic("retry: backoff returned a negative delay")
+		}
+		if info.override {
+			delay = info.overrideDelay
+		}
+		if c.notify != nil {
+			c.notify(ctx, Event{
+				Attempt:     attempt,
+				MaxAttempts: c.maxAttempts,
+				Err:         info.cause,
+				Delay:       delay,
+			})
+		}
+		if err := wait(ctx, delay); err != nil {
+			return result, err
+		}
+	}
+
+	panic("retry: unreachable")
+}
+
+// Permanent marks err as non-retryable. It returns nil when err is nil.
+//
+// The marker supports errors.Is and errors.As through error unwrapping. Do and
+// DoValue return the underlying error rather than the marker.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &permanentError{err: err}
+}
+
+// After requests delay before the next attempt. It returns nil when err is nil.
+//
+// The override still respects context cancellation, the retry predicate, and
+// the configured attempt limit. After panics if delay is negative.
+func After(delay time.Duration, err error) error {
+	validateDelay("retry-after delay", delay)
+	if err == nil {
+		return nil
+	}
+	return &afterError{delay: delay, err: err}
+}
+
+type permanentError struct {
+	err error
+}
+
+func (e *permanentError) Error() string {
+	return e.err.Error()
+}
+
+func (e *permanentError) Unwrap() error {
+	return e.err
+}
+
+type afterError struct {
+	delay time.Duration
+	err   error
+}
+
+func (e *afterError) Error() string {
+	return e.err.Error()
+}
+
+func (e *afterError) Unwrap() error {
+	return e.err
+}
+
+type errorInfo struct {
+	cause         error
+	permanent     bool
+	override      bool
+	overrideDelay time.Duration
+}
+
+func inspectError(err error) errorInfo {
+	info := errorInfo{cause: err}
+
+	var permanentErr *permanentError
+	if errors.As(err, &permanentErr) {
+		info.permanent = true
+		info.cause = permanentErr.err
+	}
+
+	var afterErr *afterError
+	if errors.As(err, &afterErr) {
+		info.override = true
+		info.overrideDelay = afterErr.delay
+		info.cause = afterErr.err
+	}
+
+	var nestedPermanent *permanentError
+	if errors.As(info.cause, &nestedPermanent) {
+		info.permanent = true
+		info.cause = nestedPermanent.err
+	}
+
+	return info
+}
+
+func wait(ctx context.Context, delay time.Duration) error {
+	if delay == 0 {
+		return ctx.Err()
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -15,7 +15,7 @@ type ValueOperation[T any] func(context.Context) (T, error)
 // Do executes operation until it succeeds, cannot be retried, exhausts the
 // configured attempts, or ctx is canceled.
 //
-// ctx must not be nil. Do panics if operation is nil.
+// The context must not be nil. Do panics if operation is nil.
 func Do(ctx context.Context, operation Operation, options ...Option) error {
 	if operation == nil {
 		panic("retry: nil operation")
@@ -30,7 +30,7 @@ func Do(ctx context.Context, operation Operation, options ...Option) error {
 // the configured attempts, or ctx is canceled. It returns the value produced
 // by the final operation execution, including when that execution fails.
 //
-// ctx must not be nil. DoValue panics if operation is nil.
+// The context must not be nil. DoValue panics if operation is nil.
 func DoValue[T any](
 	ctx context.Context,
 	operation ValueOperation[T],
@@ -83,10 +83,11 @@ func DoValue[T any](
 	}
 }
 
-// Permanent marks err as non-retryable. It returns nil when err is nil.
+// Permanent returns an error that marks err as non-retryable. It returns nil
+// when err is nil.
 //
-// The marker supports errors.Is and errors.As through error unwrapping. Do and
-// DoValue return the underlying error rather than the marker.
+// The returned error unwraps to err. [Do] and [DoValue] return err rather than
+// the marker when execution stops.
 func Permanent(err error) error {
 	if err == nil {
 		return nil
@@ -94,7 +95,8 @@ func Permanent(err error) error {
 	return &permanentError{err: err}
 }
 
-// After requests delay before the next attempt. It returns nil when err is nil.
+// After returns an error that requests delay before the next attempt. It
+// returns nil when err is nil. The returned error unwraps to err.
 //
 // The override still respects context cancellation, the retry predicate, and
 // the configured attempt limit. After panics if delay is negative.

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -15,7 +15,8 @@ type ValueOperation[T any] func(context.Context) (T, error)
 // Do executes operation until it succeeds, cannot be retried, exhausts the
 // configured attempts, or ctx is canceled.
 //
-// The context must not be nil. Do panics if operation is nil.
+// The context must not be nil. Context cancellation takes precedence over an
+// operation error returned by the same attempt. Do panics if operation is nil.
 func Do(ctx context.Context, operation Operation, options ...Option) error {
 	if operation == nil {
 		panic("retry: nil operation")
@@ -30,7 +31,9 @@ func Do(ctx context.Context, operation Operation, options ...Option) error {
 // the configured attempts, or ctx is canceled. It returns the value produced
 // by the final operation execution, including when that execution fails.
 //
-// The context must not be nil. DoValue panics if operation is nil.
+// The context must not be nil. Context cancellation takes precedence over an
+// operation error returned by the same attempt. DoValue panics if operation is
+// nil.
 func DoValue[T any](
 	ctx context.Context,
 	operation ValueOperation[T],
@@ -53,13 +56,15 @@ func DoValue[T any](
 		if err == nil {
 			return result, nil
 		}
+		// Prefer cancellation that occurred during the attempt over its
+		// returned error.
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
 
 		info := inspectError(err)
 		if info.permanent {
 			return result, info.cause
-		}
-		if err := ctx.Err(); err != nil {
-			return result, err
 		}
 		if attempt == c.maxAttempts || !c.retryIf(info.cause) {
 			return result, info.cause
@@ -86,8 +91,8 @@ func DoValue[T any](
 // Permanent returns an error that marks err as non-retryable. It returns nil
 // when err is nil.
 //
-// The returned error unwraps to err. [Do] and [DoValue] return err rather than
-// the marker when execution stops.
+// The returned error unwraps to err. [Do] and [DoValue] remove a root marker
+// when execution stops, while preserving any error that wraps the marker.
 func Permanent(err error) error {
 	if err == nil {
 		return nil
@@ -99,7 +104,9 @@ func Permanent(err error) error {
 // returns nil when err is nil. The returned error unwraps to err.
 //
 // The override still respects context cancellation, the retry predicate, and
-// the configured attempt limit. After panics if delay is negative.
+// the configured attempt limit. [Do] and [DoValue] remove a root marker from
+// the final error, while preserving any error that wraps the marker. After
+// panics if delay is negative.
 func After(delay time.Duration, err error) error {
 	validateDelay("retry-after delay", delay)
 	if err == nil {
@@ -146,23 +153,24 @@ func inspectError(err error) errorInfo {
 	var permanentErr *permanentError
 	if errors.As(err, &permanentErr) {
 		info.permanent = true
-		info.cause = permanentErr.err
 	}
 
 	var afterErr *afterError
 	if errors.As(err, &afterErr) {
 		info.override = true
 		info.overrideDelay = afterErr.delay
-		info.cause = afterErr.err
 	}
 
-	var nestedPermanent *permanentError
-	if errors.As(info.cause, &nestedPermanent) {
-		info.permanent = true
-		info.cause = nestedPermanent.err
+	for {
+		switch root := info.cause.(type) {
+		case *permanentError:
+			info.cause = root.err
+		case *afterError:
+			info.cause = root.err
+		default:
+			return info
+		}
 	}
-
-	return info
 }
 
 func wait(ctx context.Context, delay time.Duration) error {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -268,42 +268,47 @@ func TestBackoffIsNotCalledAfterFinalAttempt(t *testing.T) {
 	assert.Zero(t, calls)
 }
 
-func TestDoPanicsOnInvalidInput(t *testing.T) {
+func TestDoPanicsOnNilOperation(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name string
-		fn   func()
-	}{
-		{
-			name: "nil context",
-			fn: func() {
-				_ = Do(nil, func(context.Context) error { return nil }) //nolint:staticcheck // Verify the documented nil-context panic.
-			},
-		},
-		{name: "nil operation", fn: func() { _ = Do(t.Context(), nil) }},
-		{name: "nil value operation", fn: func() { _, _ = DoValue[string](t.Context(), nil) }},
-		{name: "zero attempts", fn: func() { WithMaxAttempts(0) }},
-		{name: "nil backoff", fn: func() { WithBackoff(nil) }},
-		{name: "nil predicate", fn: func() { WithRetryIf(nil) }},
-		{name: "negative retry after", fn: func() { _ = After(-1, assert.AnError) }},
-		{
-			name: "negative custom backoff",
-			fn: func() {
-				_ = Do(
-					t.Context(), func(context.Context) error { return assert.AnError },
-					WithBackoff(func(int) time.Duration { return -1 }),
-				)
-			},
-		},
-	}
+	assert.PanicsWithValue(t, "retry: nil operation", func() {
+		_ = Do(t.Context(), nil)
+	})
+	assert.PanicsWithValue(t, "retry: nil operation", func() {
+		_, _ = DoValue[string](t.Context(), nil)
+	})
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Panics(t, tt.fn)
-		})
-	}
+func TestConfigurationNormalization(t *testing.T) {
+	t.Parallel()
+
+	var attempts int
+	err := Do(t.Context(), func(context.Context) error {
+		attempts++
+		return assert.AnError
+	}, WithMaxAttempts(0), WithBackoff(NoBackoff()))
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, defaultMaxAttempts, attempts)
+
+	c := newConfig(WithBackoff(nil), WithRetryIf(nil))
+	require.NotNil(t, c.backoff)
+	require.NotNil(t, c.retryIf)
+	assert.Equal(t, 5, newConfig(WithMaxAttempts(5), WithMaxAttempts(0)).maxAttempts)
+
+	attempts = 0
+	err = Do(t.Context(), func(context.Context) error {
+		attempts++
+		if attempts == 1 {
+			return assert.AnError
+		}
+		return nil
+	}, WithBackoff(func(int) time.Duration { return -1 }))
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+
+	assert.Panics(t, func() {
+		_ = After(-1, assert.AnError)
+	})
 }
 
 func TestSharedBackoffAcrossConcurrentRetries(t *testing.T) {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -139,6 +139,19 @@ func TestDoContext(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 		assert.Equal(t, 1, attempts)
 	})
+
+	t.Run("operation cancellation wins over permanent error", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		var attempts int
+		err := Do(ctx, func(context.Context) error {
+			attempts++
+			cancel()
+			return Permanent(assert.AnError)
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, attempts)
+	})
 }
 
 func TestDoRetryPredicate(t *testing.T) {
@@ -202,6 +215,20 @@ func TestPermanent(t *testing.T) {
 	assert.Equal(t, 1, attempts)
 }
 
+func TestPermanentPreservesWrappingContext(t *testing.T) {
+	t.Parallel()
+
+	operationErr := errors.New("invalid user")
+	var attempts int
+	err := Do(t.Context(), func(context.Context) error {
+		attempts++
+		return fmt.Errorf("save user: %w", Permanent(operationErr))
+	})
+	require.ErrorIs(t, err, operationErr)
+	assert.EqualError(t, err, "save user: invalid user")
+	assert.Equal(t, 1, attempts)
+}
+
 func TestAfter(t *testing.T) {
 	t.Parallel()
 
@@ -228,6 +255,33 @@ func TestAfter(t *testing.T) {
 	assert.Equal(t, 2, attempts)
 	assert.Zero(t, event.Delay)
 	assert.Equal(t, assert.AnError, event.Err)
+}
+
+func TestAfterPreservesWrappingContext(t *testing.T) {
+	t.Parallel()
+
+	operationErr := errors.New("rate limited")
+	var (
+		attempts int
+		events   []Event
+	)
+	err := Do(
+		t.Context(), func(context.Context) error {
+			attempts++
+			return fmt.Errorf("send request: %w", After(0, operationErr))
+		},
+		WithMaxAttempts(2),
+		WithBackoff(Fixed(time.Hour)),
+		WithNotify(func(_ context.Context, event Event) {
+			events = append(events, event)
+		}),
+	)
+	require.ErrorIs(t, err, operationErr)
+	assert.EqualError(t, err, "send request: rate limited")
+	assert.Equal(t, 2, attempts)
+	require.Len(t, events, 1)
+	assert.EqualError(t, events[0].Err, "send request: rate limited")
+	assert.Zero(t, events[0].Delay)
 }
 
 func TestNotify(t *testing.T) {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,335 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("immediate success", func(t *testing.T) {
+		t.Parallel()
+		var attempts int
+		err := Do(t.Context(), func(context.Context) error {
+			attempts++
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("eventual success", func(t *testing.T) {
+		t.Parallel()
+		var attempts int
+		err := Do(t.Context(), func(context.Context) error {
+			attempts++
+			if attempts < 3 {
+				return assert.AnError
+			}
+			return nil
+		}, WithBackoff(NoBackoff()))
+		require.NoError(t, err)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("exhaustion returns last error", func(t *testing.T) {
+		t.Parallel()
+		firstErr := errors.New("first")
+		lastErr := errors.New("last")
+		var attempts int
+		err := Do(t.Context(), func(context.Context) error {
+			attempts++
+			if attempts == 1 {
+				return firstErr
+			}
+			return lastErr
+		}, WithMaxAttempts(2), WithBackoff(NoBackoff()))
+		require.ErrorIs(t, err, lastErr)
+		assert.Equal(t, 2, attempts)
+	})
+}
+
+func TestDoValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns successful value", func(t *testing.T) {
+		t.Parallel()
+		var attempts int
+		value, err := DoValue(t.Context(), func(context.Context) (string, error) {
+			attempts++
+			if attempts == 1 {
+				return "partial", assert.AnError
+			}
+			return "complete", nil
+		}, WithBackoff(NoBackoff()))
+		require.NoError(t, err)
+		assert.Equal(t, "complete", value)
+	})
+
+	t.Run("preserves final failed value", func(t *testing.T) {
+		t.Parallel()
+		value, err := DoValue(t.Context(), func(context.Context) (string, error) {
+			return "partial", assert.AnError
+		}, WithMaxAttempts(1))
+		require.ErrorIs(t, err, assert.AnError)
+		assert.Equal(t, "partial", value)
+	})
+}
+
+func TestDoContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("already canceled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		var called bool
+		err := Do(ctx, func(context.Context) error {
+			called = true
+			return nil
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, called)
+	})
+
+	t.Run("canceled while waiting", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		var attempts int
+		err := Do(
+			ctx,
+			func(context.Context) error {
+				attempts++
+				return assert.AnError
+			},
+			WithBackoff(Fixed(time.Hour)),
+			WithNotify(func(context.Context, Event) { cancel() }),
+		)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("deadline while waiting", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		err := Do(ctx, func(context.Context) error {
+			return assert.AnError
+		}, WithBackoff(Fixed(time.Hour)))
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("operation cancellation wins", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		var attempts int
+		err := Do(ctx, func(context.Context) error {
+			attempts++
+			cancel()
+			return assert.AnError
+		}, WithBackoff(NoBackoff()))
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, attempts)
+	})
+}
+
+func TestDoRetryPredicate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects error", func(t *testing.T) {
+		t.Parallel()
+		var attempts int
+		err := Do(t.Context(), func(context.Context) error {
+			attempts++
+			return assert.AnError
+		}, WithRetryIf(func(error) bool { return false }))
+		require.ErrorIs(t, err, assert.AnError)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("is not called after final attempt", func(t *testing.T) {
+		t.Parallel()
+		var predicateCalls int
+		err := Do(
+			t.Context(), func(context.Context) error {
+				return assert.AnError
+			},
+			WithMaxAttempts(2),
+			WithBackoff(NoBackoff()),
+			WithRetryIf(func(error) bool {
+				predicateCalls++
+				return true
+			}),
+		)
+		require.ErrorIs(t, err, assert.AnError)
+		assert.Equal(t, 1, predicateCalls)
+	})
+
+	t.Run("does not retry context errors by default", func(t *testing.T) {
+		t.Parallel()
+		var attempts int
+		err := Do(t.Context(), func(context.Context) error {
+			attempts++
+			return fmt.Errorf("request: %w", context.DeadlineExceeded)
+		})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, 1, attempts)
+	})
+}
+
+func TestPermanent(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, Permanent(nil))
+	marked := Permanent(assert.AnError)
+	require.ErrorIs(t, marked, assert.AnError)
+
+	var attempts int
+	err := Do(t.Context(), func(context.Context) error {
+		attempts++
+		return Permanent(assert.AnError)
+	})
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, assert.AnError, err)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestAfter(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, After(time.Second, nil))
+	marked := After(time.Second, assert.AnError)
+	require.ErrorIs(t, marked, assert.AnError)
+
+	var (
+		attempts int
+		event    Event
+	)
+	err := Do(
+		t.Context(), func(context.Context) error {
+			attempts++
+			if attempts == 1 {
+				return After(0, assert.AnError)
+			}
+			return nil
+		},
+		WithBackoff(Fixed(time.Hour)),
+		WithNotify(func(_ context.Context, got Event) { event = got }),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+	assert.Zero(t, event.Delay)
+	assert.Equal(t, assert.AnError, event.Err)
+}
+
+func TestNotify(t *testing.T) {
+	t.Parallel()
+
+	var events []Event
+	err := Do(
+		t.Context(), func(context.Context) error {
+			return assert.AnError
+		},
+		WithMaxAttempts(3),
+		WithBackoff(Linear(time.Nanosecond)),
+		WithNotify(func(_ context.Context, event Event) {
+			events = append(events, event)
+		}),
+	)
+	require.ErrorIs(t, err, assert.AnError)
+	require.Len(t, events, 2)
+	assert.Equal(t, Event{Attempt: 1, MaxAttempts: 3, Err: assert.AnError, Delay: time.Nanosecond}, events[0])
+	assert.Equal(t, Event{Attempt: 2, MaxAttempts: 3, Err: assert.AnError, Delay: 2 * time.Nanosecond}, events[1])
+}
+
+func TestBackoffIsNotCalledAfterFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	err := Do(
+		t.Context(), func(context.Context) error {
+			return assert.AnError
+		},
+		WithMaxAttempts(1),
+		WithBackoff(func(int) time.Duration {
+			calls++
+			return 0
+		}),
+	)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Zero(t, calls)
+}
+
+func TestDoPanicsOnInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		{
+			name: "nil context",
+			fn: func() {
+				_ = Do(nil, func(context.Context) error { return nil }) //nolint:staticcheck // Verify the documented nil-context panic.
+			},
+		},
+		{name: "nil operation", fn: func() { _ = Do(t.Context(), nil) }},
+		{name: "nil value operation", fn: func() { _, _ = DoValue[string](t.Context(), nil) }},
+		{name: "zero attempts", fn: func() { WithMaxAttempts(0) }},
+		{name: "nil backoff", fn: func() { WithBackoff(nil) }},
+		{name: "nil predicate", fn: func() { WithRetryIf(nil) }},
+		{name: "negative retry after", fn: func() { _ = After(-1, assert.AnError) }},
+		{
+			name: "negative custom backoff",
+			fn: func() {
+				_ = Do(
+					t.Context(), func(context.Context) error { return assert.AnError },
+					WithBackoff(func(int) time.Duration { return -1 }),
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Panics(t, tt.fn)
+		})
+	}
+}
+
+func TestSharedBackoffAcrossConcurrentRetries(t *testing.T) {
+	t.Parallel()
+
+	backoff := Jitter(Fixed(time.Nanosecond), time.Nanosecond)
+	var completed atomic.Int64
+	t.Run("concurrent", func(t *testing.T) {
+		t.Parallel()
+		for range 20 {
+			t.Run("retry", func(t *testing.T) {
+				t.Parallel()
+				var attempts int
+				err := Do(t.Context(), func(context.Context) error {
+					attempts++
+					if attempts == 1 {
+						return assert.AnError
+					}
+					completed.Add(1)
+					return nil
+				}, WithBackoff(backoff))
+				require.NoError(t, err)
+			})
+		}
+	})
+	t.Cleanup(func() {
+		assert.Equal(t, int64(20), completed.Load())
+	})
+}

--- a/retry/version.go
+++ b/retry/version.go
@@ -1,0 +1,6 @@
+package retry
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.1"
+}

--- a/retry/version_test.go
+++ b/retry/version_test.go
@@ -1,0 +1,20 @@
+package retry_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/retry/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := retry.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -121,6 +121,9 @@ module-sets:
       # Recovery
       - github.com/go-fries/fries/recovery/v4
 
+      # Retry
+      - github.com/go-fries/fries/retry/v4
+
       # Signal
       - github.com/go-fries/fries/signal/v4
 


### PR DESCRIPTION
## Summary
Add a standalone, context-aware retry component for bounded in-process operation retries.

## Changes
- Add `Do` and generic `DoValue` execution helpers with context cancellation and configurable attempt limits
- Add fixed, linear, exponential, no-delay, and jitter backoff strategies
- Add retry predicates, permanent errors, retry-after overrides, and scheduled-retry notifications
- Document nil handling, invalid configuration behavior, defaults, and queue redelivery boundaries
- Register the new public module in `versions.yaml` and `codecov.yml`

## Motivation
- Provide one reusable retry primitive for transient business and infrastructure operations without coupling it to HTTP, queues, or framework-specific middleware
- Keep retry timing, cancellation, filtering, and observability behavior explicit and consistent

## Testing
- `make test/retry`
- `go test -race -cover ./...` in `retry` (96.1% statement coverage)
- `make build/retry`
- `make lint/retry`
- `git diff --check`

## Notes
- This PR only adds the retry component and required release metadata
- Existing `support`, Hyperf, Queue, and Locker implementations are intentionally unchanged; any migration will use separate follow-up PRs