### PR TITLE
refactor(support)!: remove retry helper

### DIFF
--- a/support/helpers.go
+++ b/support/helpers.go
@@ -10,30 +10,6 @@ import (
 	"github.com/go-fries/fries/errors/v4"
 )
 
-// Retry retries the given function until it returns nil or the attempts are exhausted.
-// `sleeps` is the time to sleep between each attempt.
-// If `sleeps` is not provided, it will not sleep.
-//
-//	Retry(func() error { return nil }, 3) => nil
-//	Retry(func() error { return nil }, 3, time.Second) => nil
-//	Retry(func() error { return fmt.Errorf("error") }, 3) => error
-func Retry(fn func() error, attempts int, sleeps ...time.Duration) (err error) {
-	var sleep time.Duration
-	if len(sleeps) > 0 {
-		sleep = sleeps[0]
-	}
-
-	for range attempts {
-		if err = fn(); err == nil {
-			return nil
-		}
-		if sleep > 0 {
-			time.Sleep(sleep)
-		}
-	}
-	return err
-}
-
 // Until retries the given function until it returns true.
 // `sleeps` is the time to sleep between each attempt.
 // If `sleeps` is not provided, it will not sleep.

--- a/support/helpers_test.go
+++ b/support/helpers_test.go
@@ -14,27 +14,6 @@ type foo struct {
 	Age  int
 }
 
-func TestRetry(t *testing.T) {
-	// success
-	var i int
-	err := Retry(func() error {
-		i++
-		if i < 3 {
-			return assert.AnError
-		}
-		return nil
-	}, 3)
-	assert.Nil(t, err)
-	assert.Equal(t, 3, i)
-
-	// failed
-	err = Retry(func() error {
-		return assert.AnError
-	}, 3)
-	assert.Error(t, err)
-	assert.Equal(t, 3, i)
-}
-
 func TestUntil(t *testing.T) {
 	// no sleep
 	var i int


### PR DESCRIPTION
## Summary
Remove the legacy `support.Retry` helper now that the dedicated, context-aware `retry` component is available.

## Changes
- Remove `support.Retry`
- Remove the obsolete `support.Retry` tests
- Keep Hyperf, Queue, Locker, and other retry implementations unchanged

## Motivation
- `support.Retry` cannot observe context cancellation while waiting
- It always uses no delay or one fixed delay and cannot express retry filtering, jitter, permanent errors, or retry-after overrides
- It waits once more after the final failed attempt
- The dedicated `retry` component provides a clearer and reusable retry contract

## Breaking Changes
`support.Retry` has been removed. Existing users of `github.com/go-fries/fries/support/v4` that call this function will no longer compile and must migrate to `github.com/go-fries/fries/retry/v4`.

This removal is made during the v4 beta period. The repository has no internal consumers of `support.Retry`, so no compatibility wrapper is retained.

## Migration
### No-delay retries

Before:

```go
err := support.Retry(func() error {
    return refresh()
}, 3)
```

After:

```go
err := retry.Do(ctx, func(_ context.Context) error {
    return refresh()
},
    retry.WithMaxAttempts(3),
    retry.WithBackoff(retry.NoBackoff()),
)
```

`NoBackoff` must be explicit because `retry.Do` otherwise uses exponential backoff starting at 100 milliseconds and capped at one second.

### Fixed-delay retries

Before:

```go
err := support.Retry(func() error {
    return refresh()
}, 3, time.Second)
```

After:

```go
err := retry.Do(ctx, func(_ context.Context) error {
    return refresh()
},
    retry.WithMaxAttempts(3),
    retry.WithBackoff(retry.Fixed(time.Second)),
)
```

When the underlying operation accepts a context, pass the callback context through so cancellation also interrupts the in-flight attempt.

### Behavior differences
- Retry waits are canceled through `context.Context`
- The final failed attempt returns immediately without another delay
- `WithMaxAttempts` counts the initial execution
- Non-positive values passed to `WithMaxAttempts` do not create a no-op; they leave the current attempt limit unchanged. Code that previously used non-positive attempts to skip execution should branch before calling `retry.Do`

## Testing
- `make test/support`
- `make test/retry`
- `make lint/support`
- `make lint/retry`
- `git diff --check`