### PR TITLE
feat(log): add slog provider

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -69,6 +69,7 @@ fixes:
   - github.com/go-fries/fries/hyperf/jet/middleware/retry/v4::hyperf/jet/middleware/retry/
   - github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4::hyperf/jet/middleware/timeout/
   - github.com/go-fries/fries/hyperf/jet/middleware/otel/v4::hyperf/jet/middleware/otel/
+  - github.com/go-fries/fries/log/slog/v4::log/slog/
   - github.com/go-fries/fries/log/slog/multi/v4::log/slog/multi/
   - github.com/go-fries/fries/log/slog/syslog/v4::log/slog/syslog/
   - github.com/go-fries/fries/kratos/middleware/cors/v4::kratos/middleware/cors/

--- a/log/slog/README.md
+++ b/log/slog/README.md
@@ -1,0 +1,44 @@
+# slog provider
+
+`log/slog` provides a lifecycle provider that sets the process-wide
+`slog.Default()` logger during application bootstrap.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/log/slog/v4
+```
+
+## Usage
+
+```go
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/go-fries/fries/foundation/v4"
+	slogprovider "github.com/go-fries/fries/log/slog/v4"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	providers := foundation.NewChain(slogprovider.NewProvider(logger))
+
+	ctx, err := providers.Bootstrap(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	slog.InfoContext(ctx, "service started")
+
+	if _, err := providers.Terminate(ctx); err != nil {
+		panic(err)
+	}
+}
+```
+
+`Bootstrap` replaces the process-wide default logger. `Terminate` does not
+restore the previous logger.

--- a/log/slog/go.mod
+++ b/log/slog/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/log/slog/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/log/slog/go.sum
+++ b/log/slog/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log/slog/provider.go
+++ b/log/slog/provider.go
@@ -1,0 +1,28 @@
+// Package slog provides lifecycle integration for the standard library's log/slog package.
+package slog
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Provider configures the process-wide default slog logger during bootstrap.
+type Provider struct {
+	logger *slog.Logger
+}
+
+// NewProvider creates a Provider backed by logger.
+func NewProvider(logger *slog.Logger) *Provider {
+	return &Provider{logger: logger}
+}
+
+// Bootstrap sets the process-wide default slog logger.
+func (p *Provider) Bootstrap(ctx context.Context) (context.Context, error) {
+	slog.SetDefault(p.logger)
+	return ctx, nil
+}
+
+// Terminate leaves the process-wide default slog logger unchanged.
+func (p *Provider) Terminate(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}

--- a/log/slog/provider_test.go
+++ b/log/slog/provider_test.go
@@ -1,0 +1,30 @@
+package slog
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	provider := NewProvider(logger)
+
+	ctx := t.Context()
+	bootstrapped, err := provider.Bootstrap(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, ctx, bootstrapped)
+	assert.Same(t, logger, slog.Default())
+
+	terminated, err := provider.Terminate(bootstrapped)
+	assert.NoError(t, err)
+	assert.Equal(t, bootstrapped, terminated)
+	assert.Same(t, logger, slog.Default())
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -90,6 +90,7 @@ module-sets:
       - github.com/go-fries/fries/jsonrpc/v4
 
       # Log
+      - github.com/go-fries/fries/log/slog/v4
       - github.com/go-fries/fries/log/slog/multi/v4
       - github.com/go-fries/fries/log/slog/syslog/v4
 


### PR DESCRIPTION
## Summary
Add a lifecycle provider for configuring the process-wide slog default logger during application bootstrap.

## Changes
- Add the github.com/go-fries/fries/log/slog/v4 module and Provider implementation
- Add focused tests and usage documentation
- Register the module in release and coverage metadata

## Motivation
- Allow applications to inject slog.Default through the existing foundation.Provider lifecycle

## Testing
- make lint/log/slog
- cd log/slog && go test ./...