### PR TITLE
Release v4.0.0-beta.2

### DIFF
--- a/cache/go.mod
+++ b/cache/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/locker/v4 => ../locker
 
 require (
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -11,11 +11,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/cache/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/json/version.go
+++ b/codec/json/version.go
@@ -2,5 +2,5 @@ package json
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )

--- a/codec/msgpack/version.go
+++ b/codec/msgpack/version.go
@@ -2,5 +2,5 @@ package msgpack
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/codec/proto/version.go
+++ b/codec/proto/version.go
@@ -2,5 +2,5 @@ package proto
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
 	github.com/bytedance/sonic v1.15.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/sonic/version.go
+++ b/codec/sonic/version.go
@@ -2,5 +2,5 @@ package sonic
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/codec/version.go
+++ b/codec/version.go
@@ -2,5 +2,5 @@ package codec
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/xml/version.go
+++ b/codec/xml/version.go
@@ -2,5 +2,5 @@ package xml
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/codec/yaml/version.go
+++ b/codec/yaml/version.go
@@ -2,5 +2,5 @@ package yaml
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/eino/components/embedding/cached/v4 => ../../
 
 require (
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.2
 	gorm.io/datatypes v1.2.7
 	gorm.io/gorm v1.31.2
 )

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.2
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	github.com/cloudwego/eino v0.9.12
-	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.2
 	github.com/redis/go-redis/v9 v9.21.0
 )
 
@@ -26,8 +26,8 @@ require (
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eino-contrib/jsonschema v1.0.3 // indirect
-	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
 	github.com/goph/emperror v0.17.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect

--- a/event/example/go.mod
+++ b/event/example/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/event/middleware/recovery/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/event/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/event/middleware/recovery/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/event/v4 v4.0.0-beta.2
 )
 
 require golang.org/x/sync v0.22.0 // indirect

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/event/v4 => ../../
 
 require (
-	github.com/go-fries/fries/event/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/event/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/examples/cache/go.mod
+++ b/examples/cache/go.mod
@@ -12,17 +12,17 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/redis/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/cache/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/cache/redis/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/cache/v4 v4.0.0-beta.2
 	github.com/redis/go-redis/v9 v9.21.0
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/examples/cloudevents/amqp091/go.mod
+++ b/examples/cloudevents/amqp091/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/cloudevents/protocol/amqp091/v4 => ../../../cl
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
-	github.com/go-fries/fries/cloudevents/protocol/amqp091/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/cloudevents/protocol/amqp091/v4 v4.0.0-beta.2
 	github.com/google/uuid v1.6.0
 	github.com/rabbitmq/amqp091-go v1.12.0
 )

--- a/examples/cloudevents/eventdispatcher/go.mod
+++ b/examples/cloudevents/eventdispatcher/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/cloudevents/eventdispatcher/v4 => ../../../clo
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
-	github.com/go-fries/fries/cloudevents/eventdispatcher/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/cloudevents/eventdispatcher/v4 v4.0.0-beta.2
 )
 
 require (

--- a/examples/mysql/canal/go.mod
+++ b/examples/mysql/canal/go.mod
@@ -10,8 +10,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/mysql/canal/positioner/redis/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/mysql/canal/positioner/redis/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.2
 )
 
 require (
@@ -19,8 +19,8 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
 	github.com/go-mysql-org/go-mysql v1.13.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/filesystem/v4 => ../
 
 require (
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/filesystem/v4 => ../
 
 require (
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.2
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -7,7 +7,7 @@ replace github.com/go-fries/fries/filesystem/v4 => ../
 require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
 	github.com/aws/smithy-go v1.27.3
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gorm/logger/multi/version.go
+++ b/gorm/logger/multi/version.go
@@ -2,5 +2,5 @@ package multi
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/gorm/logger/otel/version.go
+++ b/gorm/logger/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hashing/v4 => ../
 
 require (
-	github.com/go-fries/fries/hashing/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/hashing/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hashing/md5/version.go
+++ b/hashing/md5/version.go
@@ -2,5 +2,5 @@ package md5
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/hashing/version.go
+++ b/hashing/version.go
@@ -2,5 +2,5 @@ package hashing
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/capability/v4 => ../../capability
 
 require (
-	github.com/go-fries/fries/capability/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/capability/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/logger/go.mod
+++ b/hyperf/jet/middleware/logger/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/otel/go.mod
+++ b/hyperf/jet/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/hyperf/jet/middleware/otel/version.go
+++ b/hyperf/jet/middleware/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/version.go
+++ b/hyperf/jet/middleware/retry/version.go
@@ -2,5 +2,5 @@ package retry
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/jsonrpc/go.mod
+++ b/jsonrpc/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
 	github.com/google/uuid v1.6.0
 )
 

--- a/kratos/middleware/otel/version.go
+++ b/kratos/middleware/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/locker/v4 => ../
 
 require (
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/log/slog/multi/version.go
+++ b/log/slog/multi/version.go
@@ -2,5 +2,5 @@ package multi
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/log/slog/syslog/version.go
+++ b/log/slog/syslog/version.go
@@ -4,5 +4,5 @@ package syslog
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.2
 	github.com/go-mysql-org/go-mysql v1.13.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/mysql/canal/v4 => ../
 
 require (
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/foundation/v4 => ../../foundation
 
 require (
-	github.com/go-fries/fries/foundation/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/foundation/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/host v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0

--- a/parallel/version.go
+++ b/parallel/version.go
@@ -2,5 +2,5 @@ package parallel
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/poll/version.go
+++ b/poll/version.go
@@ -2,5 +2,5 @@ package poll
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/queue/adapter/memory/go.mod
+++ b/queue/adapter/memory/go.mod
@@ -9,14 +9,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/queue/adapter/rabbitmq/go.mod
+++ b/queue/adapter/rabbitmq/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
 	github.com/rabbitmq/amqp091-go v1.12.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/queue/adapter/redis/go.mod
+++ b/queue/adapter/redis/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -17,8 +17,8 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/queue/examples/tasker/go.mod
+++ b/queue/examples/tasker/go.mod
@@ -10,11 +10,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/adapter/memory/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/queue/adapter/memory/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
 )
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
 )

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/queue/kratos/server/go.mod
+++ b/queue/kratos/server/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
 	github.com/go-kratos/kratos/v3 v3.0.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
 	github.com/go-playground/form/v4 v4.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/queue/middleware/recovery/go.mod
+++ b/queue/middleware/recovery/go.mod
@@ -9,14 +9,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.1 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.1 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/retry/version.go
+++ b/retry/version.go
@@ -2,5 +2,5 @@ package retry
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/constraints/v4 => ../constraints
 
 require (
-	github.com/go-fries/fries/constraints/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/constraints/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/slices/version.go
+++ b/slices/version.go
@@ -2,5 +2,5 @@ package slices
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/strings/version.go
+++ b/strings/version.go
@@ -2,5 +2,5 @@ package strings
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/support/go.mod
+++ b/support/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/errors/v4 => ../errors
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/go-fries/fries/errors/v4 v4.0.0-beta.1
+	github.com/go-fries/fries/errors/v4 v4.0.0-beta.2
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package fries
 
 func Version() string {
-	return "4.0.0-beta.1"
+	return "4.0.0-beta.2"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.0.0-beta.1
+    version: v4.0.0-beta.2
     modules:
       - github.com/go-fries/fries/v4
       - github.com/go-fries/fries/errors/v4


### PR DESCRIPTION
## Summary

Prepare the stable module set for `v4.0.0-beta.2` and update generated module references and version helpers from `v4.0.0-beta.1`.

## Release Changes

- Bump the stable module-set version to `v4.0.0-beta.2`
- Update stable component `Version()` values to `4.0.0-beta.2`
- Update intra-repository module requirements to the new prerelease version
- Include the new `retry` and `poll` public modules in the stable release

## Highlights

- Redesign the Filesystem API and replace the Coroutines module with the more general Parallel component
- Refactor Hashing and Codec around reusable, zero-value-friendly types
- Add reusable Retry and Poll components, then integrate Retry with Hyperf middleware and Queue backoff configuration
- Add a `log/slog` provider and improve CI permissions, workflow scope, module cataloging, and Go cache reuse

## Pull Requests Since v4.0.0-beta.1

Range: [`v4.0.0-beta.1...17d35832`](https://github.com/go-fries/fries/compare/v4.0.0-beta.1...17d35832a84d0e1666a023692ca7fa3396cc1488) — 27 merged pull requests. The `v4.0.0-beta.1` release PR itself is excluded from this range.

### Breaking API Changes

- [#2604](https://github.com/go-fries/fries/pull/2604) `refactor(filesystem)!: redesign storage API`
- [#2607](https://github.com/go-fries/fries/pull/2607) `refactor(parallel)!: replace coroutines module`
- [#2608](https://github.com/go-fries/fries/pull/2608) `refactor(hashing)!: replace registry with reusable hashers`
- [#2613](https://github.com/go-fries/fries/pull/2613) `refactor(codec)!: replace shared instances with zero-value types`
- [#2615](https://github.com/go-fries/fries/pull/2615) `refactor(support)!: remove retry helper`
- [#2616](https://github.com/go-fries/fries/pull/2616) `refactor(hyperf)!: reuse retry component`
- [#2620](https://github.com/go-fries/fries/pull/2620) `refactor(queue)!: separate retry decisions from backoff`

Migration instructions and before/after examples are documented in the linked pull request descriptions.

### Features

- [#2614](https://github.com/go-fries/fries/pull/2614) `feat(retry): add retry component`
- [#2617](https://github.com/go-fries/fries/pull/2617) `feat(log): add slog provider`
- [#2622](https://github.com/go-fries/fries/pull/2622) `feat(poll): add context-aware polling component`

### CI and Documentation

- [#2605](https://github.com/go-fries/fries/pull/2605) `ci: remove static analysis workflow`
- [#2606](https://github.com/go-fries/fries/pull/2606) `ci: restrict test workflow permissions`
- [#2610](https://github.com/go-fries/fries/pull/2610) `docs: add component catalog to README`
- [#2611](https://github.com/go-fries/fries/pull/2611) `ci(lint): improve Go cache reuse`

### Dependencies

- [#2593](https://github.com/go-fries/fries/pull/2593) `chore(deps): update google.golang.org/genproto/googleapis/api digest to f0a9213`
- [#2597](https://github.com/go-fries/fries/pull/2597) `chore(deps): update module github.com/rogpeppe/go-internal to v1.15.0`
- [#2599](https://github.com/go-fries/fries/pull/2599) `chore(deps): update module golang.org/x/net to v0.55.0 [security]`
- [#2600](https://github.com/go-fries/fries/pull/2600) `chore(deps): update module go.mongodb.org/mongo-driver/v2 to v2.8.0`
- [#2601](https://github.com/go-fries/fries/pull/2601) `fix(deps): update bufbuild protovalidate generated module to v1.36.11-20260709200747-435963d16310.1`
- [#2602](https://github.com/go-fries/fries/pull/2602) `chore(deps): update module github.com/prometheus/common to v0.70.0`
- [#2603](https://github.com/go-fries/fries/pull/2603) `chore(deps): update module github.com/dlclark/regexp2/v2 to v2.3.0`
- [#2589](https://github.com/go-fries/fries/pull/2589) `fix(deps): update golang.org/x modules`
- [#2609](https://github.com/go-fries/fries/pull/2609) `chore(deps): update module github.com/dlclark/regexp2/v2 to v2.4.0`
- [#2612](https://github.com/go-fries/fries/pull/2612) `chore(deps): update module github.com/dlclark/regexp2/v2 to v2.5.0`
- [#2618](https://github.com/go-fries/fries/pull/2618) `chore(deps): update github.com/charmbracelet/ultraviolet digest to 4bee191`
- [#2619](https://github.com/go-fries/fries/pull/2619) `chore(deps): update github.com/petermattis/goid digest to 57ed88f`
- [#2621](https://github.com/go-fries/fries/pull/2621) `chore(deps): update github.com/petermattis/goid digest to 97594f2`

## Notes

- This release contains seven intentionally breaking refactors; review the linked migration guidance before upgrading
- The pull request list is derived from the Git history after the signed `v4.0.0-beta.1` tag and cross-checked against merged GitHub pull requests
