### PR TITLE
Release v4.0.0-beta.3

### DIFF
--- a/cache/go.mod
+++ b/cache/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/locker/v4 => ../locker
 
 require (
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -11,11 +11,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/cache/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/json/version.go
+++ b/codec/json/version.go
@@ -2,5 +2,5 @@ package json
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )

--- a/codec/msgpack/version.go
+++ b/codec/msgpack/version.go
@@ -2,5 +2,5 @@ package msgpack
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/codec/proto/version.go
+++ b/codec/proto/version.go
@@ -2,5 +2,5 @@ package proto
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
 	github.com/bytedance/sonic v1.15.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/sonic/version.go
+++ b/codec/sonic/version.go
@@ -2,5 +2,5 @@ package sonic
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/codec/version.go
+++ b/codec/version.go
@@ -2,5 +2,5 @@ package codec
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/xml/version.go
+++ b/codec/xml/version.go
@@ -2,5 +2,5 @@ package xml
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/codec/yaml/version.go
+++ b/codec/yaml/version.go
@@ -2,5 +2,5 @@ package yaml
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/eino/components/embedding/cached/v4 => ../../
 
 require (
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.3
 	gorm.io/datatypes v1.2.7
 	gorm.io/gorm v1.31.2
 )

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.3
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	github.com/cloudwego/eino v0.9.12
-	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.3
 	github.com/redis/go-redis/v9 v9.21.0
 )
 
@@ -26,8 +26,8 @@ require (
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eino-contrib/jsonschema v1.0.3 // indirect
-	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
 	github.com/goph/emperror v0.17.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/event/v4 => ../../
 
 require (
-	github.com/go-fries/fries/event/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/event/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/examples/cache/go.mod
+++ b/examples/cache/go.mod
@@ -12,17 +12,17 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/redis/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/cache/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/cache/redis/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/cache/v4 v4.0.0-beta.3
 	github.com/redis/go-redis/v9 v9.21.0
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/examples/cloudevents/amqp091/go.mod
+++ b/examples/cloudevents/amqp091/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/cloudevents/protocol/amqp091/v4 => ../../../cl
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
-	github.com/go-fries/fries/cloudevents/protocol/amqp091/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/cloudevents/protocol/amqp091/v4 v4.0.0-beta.3
 	github.com/google/uuid v1.6.0
 	github.com/rabbitmq/amqp091-go v1.12.0
 )

--- a/examples/cloudevents/eventdispatcher/go.mod
+++ b/examples/cloudevents/eventdispatcher/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/cloudevents/eventdispatcher/v4 => ../../../clo
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
-	github.com/go-fries/fries/cloudevents/eventdispatcher/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/cloudevents/eventdispatcher/v4 v4.0.0-beta.3
 )
 
 require (

--- a/examples/mysql/canal/go.mod
+++ b/examples/mysql/canal/go.mod
@@ -10,8 +10,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/mysql/canal/positioner/redis/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/mysql/canal/positioner/redis/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.3
 )
 
 require (
@@ -19,8 +19,8 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
 	github.com/go-mysql-org/go-mysql v1.13.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/filesystem/v4 => ../
 
 require (
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/filesystem/v4 => ../
 
 require (
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.2
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -7,7 +7,7 @@ replace github.com/go-fries/fries/filesystem/v4 => ../
 require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.1
 	github.com/aws/smithy-go v1.27.4
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gorm/logger/multi/version.go
+++ b/gorm/logger/multi/version.go
@@ -2,5 +2,5 @@ package multi
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/gorm/logger/otel/version.go
+++ b/gorm/logger/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hashing/v4 => ../
 
 require (
-	github.com/go-fries/fries/hashing/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hashing/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hashing/md5/version.go
+++ b/hashing/md5/version.go
@@ -2,5 +2,5 @@ package md5
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/hashing/version.go
+++ b/hashing/version.go
@@ -2,5 +2,5 @@ package hashing
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/capability/v4 => ../../capability
 
 require (
-	github.com/go-fries/fries/capability/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/capability/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/logger/go.mod
+++ b/hyperf/jet/middleware/logger/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/otel/go.mod
+++ b/hyperf/jet/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/hyperf/jet/middleware/otel/version.go
+++ b/hyperf/jet/middleware/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/version.go
+++ b/hyperf/jet/middleware/retry/version.go
@@ -2,5 +2,5 @@ package retry
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/jsonrpc/go.mod
+++ b/jsonrpc/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
 	github.com/google/uuid v1.6.0
 )
 

--- a/kratos/middleware/otel/version.go
+++ b/kratos/middleware/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/lifecycle/version.go
+++ b/lifecycle/version.go
@@ -2,5 +2,5 @@ package lifecycle
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/locker/v4 => ../
 
 require (
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/log/slog/multi/version.go
+++ b/log/slog/multi/version.go
@@ -2,5 +2,5 @@ package multi
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/log/slog/syslog/version.go
+++ b/log/slog/syslog/version.go
@@ -4,5 +4,5 @@ package syslog
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.3
 	github.com/go-mysql-org/go-mysql v1.13.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/mysql/canal/v4 => ../
 
 require (
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/lifecycle/v4 => ../../lifecycle
 
 require (
-	github.com/go-fries/fries/lifecycle/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/lifecycle/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/host v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0

--- a/parallel/version.go
+++ b/parallel/version.go
@@ -2,5 +2,5 @@ package parallel
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/poll/version.go
+++ b/poll/version.go
@@ -2,5 +2,5 @@ package poll
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/queue/adapter/memory/go.mod
+++ b/queue/adapter/memory/go.mod
@@ -9,14 +9,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/queue/adapter/rabbitmq/go.mod
+++ b/queue/adapter/rabbitmq/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
 	github.com/rabbitmq/amqp091-go v1.12.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/queue/adapter/redis/go.mod
+++ b/queue/adapter/redis/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -17,8 +17,8 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/queue/examples/tasker/go.mod
+++ b/queue/examples/tasker/go.mod
@@ -10,11 +10,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/adapter/memory/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/adapter/memory/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
 )
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
 )

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/queue/kratos/server/go.mod
+++ b/queue/kratos/server/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
 	github.com/go-kratos/kratos/v3 v3.0.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
 	github.com/go-playground/form/v4 v4.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/queue/middleware/recovery/go.mod
+++ b/queue/middleware/recovery/go.mod
@@ -9,14 +9,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.2 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.2 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/retry/version.go
+++ b/retry/version.go
@@ -2,5 +2,5 @@ package retry
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/constraints/v4 => ../constraints
 
 require (
-	github.com/go-fries/fries/constraints/v4 v4.0.0-beta.2
+	github.com/go-fries/fries/constraints/v4 v4.0.0-beta.3
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/slices/version.go
+++ b/slices/version.go
@@ -2,5 +2,5 @@ package slices
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/strings/version.go
+++ b/strings/version.go
@@ -2,5 +2,5 @@ package strings
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package fries
 
 func Version() string {
-	return "4.0.0-beta.2"
+	return "4.0.0-beta.3"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.0.0-beta.2
+    version: v4.0.0-beta.3
     modules:
       - github.com/go-fries/fries/v4
       - github.com/go-fries/fries/errors/v4


### PR DESCRIPTION
## Summary

Prepare the stable module set for `v4.0.0-beta.3` and update generated module references and version helpers from `v4.0.0-beta.2`.

## Release Changes

- Bump the stable module-set version to `v4.0.0-beta.3`
- Update stable component `Version()` values to `4.0.0-beta.3`
- Update intra-repository module requirements to the new prerelease version
- Replace the `foundation` module with the new `lifecycle` module in the stable release
- Remove the `eventbus` and standalone `event/example` modules after consolidating event dispatching into `event`

## Highlights

- Replace the Foundation kernel with a context-aware Lifecycle runner that provides ordered startup, rollback, reverse-order shutdown, joined errors, and manual lifecycle integration
- Redesign Locker around reusable backends, named locks, and explicit leases, with context-aware Redis acquisition, token-safe release and renewal, and project-scoped key prefixes
- Consolidate Event and EventBus into one synchronous, exact-type Dispatcher with explicit subscriptions, deterministic errors, bounded concurrency, middleware, and optional package-level access
- Remove legacy Support polling and timeout helpers in favor of `poll.Until` and standard Go contexts
- Refresh dependencies and move CI to `actions/setup-go@v7`

## Pull Requests Since v4.0.0-beta.2

Range: [`v4.0.0-beta.2...a1c57022`](https://github.com/go-fries/fries/compare/v4.0.0-beta.2...a1c57022d72b8c659fdecbd4da26cb48a3a41535) — 18 merged pull requests. The `v4.0.0-beta.2` release PR itself is excluded from this range.

### Breaking API Changes

- [#2629](https://github.com/go-fries/fries/pull/2629) `refactor(support)!: remove legacy polling and timeout helpers`
- [#2631](https://github.com/go-fries/fries/pull/2631) `refactor(lifecycle)!: replace foundation kernel`
- [#2636](https://github.com/go-fries/fries/pull/2636) `refactor(locker)!: redesign lock and lease contracts`
- [#2643](https://github.com/go-fries/fries/pull/2643) `refactor(event)!: redesign in-process event dispatching`

### Migration Summary

- **Support:** replace `support.Until` with `poll.Until`; combine `context.WithTimeout` with `poll.Until` for bounded polling; pass timeout contexts directly to context-aware operations instead of using `support.Timeout`
- **Lifecycle:** replace `foundation/v4` with `lifecycle/v4`, `NewKernel` with `New`, `Terminate` with `Shutdown`, and `WithTerminateTimeout` with `WithShutdownTimeout`; pass providers through `WithProviders` and handlers directly to `Runner.Run`
- **Locker:** replace key-bound lockers with `Locker -> Lock -> Lease`; construct Redis backends with `lockerredis.New(...).Lock(name, ttl)`; use `locker.Try` or `locker.Do`; replace owner and timeout errors with leases, context errors, `ErrNotAcquired`, and `ErrLeaseLost`
- **Event:** replace `eventbus/v4` with `event/v4`; construct dispatchers with `event.New`, register typed handlers through `HandlerFor[T]` and `Subscribe`, and replace fire-and-forget `EmitAsync` with `parallel` or `queue`

Full migration instructions, behavior notes, and before/after examples are documented in the linked pull request descriptions.

### CI

- [#2639](https://github.com/go-fries/fries/pull/2639) `chore(deps): update actions/setup-go action to v7`

### Dependencies

- [#2632](https://github.com/go-fries/fries/pull/2632) `fix(deps): update module github.com/cheggaaa/pb/v3 to v3.2.0`
- [#2630](https://github.com/go-fries/fries/pull/2630) `chore(deps): update module github.com/rogpeppe/go-internal to v1.15.0`
- [#2627](https://github.com/go-fries/fries/pull/2627) `fix(deps): update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.105.1`
- [#2626](https://github.com/go-fries/fries/pull/2626) `chore(deps): update bufbuild protocolbuffers generated module to v1.36.11-20260713175918-10d915f5b43b.1`
- [#2624](https://github.com/go-fries/fries/pull/2624) `chore(deps): update googleapis to f5fc221`
- [#2642](https://github.com/go-fries/fries/pull/2642) `chore(deps): update github.com/petermattis/goid digest to a9b348f`
- [#2640](https://github.com/go-fries/fries/pull/2640) `chore(deps): update module github.com/mattn/go-isatty to v0.0.23`
- [#2638](https://github.com/go-fries/fries/pull/2638) `fix(deps): update module google.golang.org/grpc to v1.82.1`
- [#2625](https://github.com/go-fries/fries/pull/2625) `chore(deps): update bufbuild connectrpc generated module to v1.20.0-20260713175918-10d915f5b43b.1`
- [#2637](https://github.com/go-fries/fries/pull/2637) `chore(deps): update googleapis to e75dac1`
- [#2645](https://github.com/go-fries/fries/pull/2645) `chore(deps): update module github.com/docker/cli to v29.6.2+incompatible`
- [#2646](https://github.com/go-fries/fries/pull/2646) `chore(deps): update github.com/pingcap/tidb/pkg/parser digest to 94b834d`
- [#2647](https://github.com/go-fries/fries/pull/2647) `fix(deps): update module github.com/aws/smithy-go to v1.27.4`

## Notes

- This release contains four intentionally breaking refactors; review the linked migration guidance before upgrading
- Redis lock keys now use the `locker:` prefix by default; coordinate mixed-version deployments because old and new processes do not contend on the same keys
- Event dispatch is now synchronous and fail-fast by default; use bounded concurrency explicitly and choose `parallel` or `queue` for asynchronous work