### PR TITLE
refactor(support)!: extract pointer helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ and internal development tools are not included.
 | MySQL | [`mysql/canal`](https://pkg.go.dev/github.com/go-fries/fries/mysql/canal/v4)<br>[`mysql/canal/positioner/redis`](https://pkg.go.dev/github.com/go-fries/fries/mysql/canal/positioner/redis/v4)<br>[`mysql/canal/server`](https://pkg.go.dev/github.com/go-fries/fries/mysql/canal/server/v4) | MySQL binlog processing with Redis position storage and server lifecycle integration. |
 | OpenTelemetry | [`otel/otlp`](https://pkg.go.dev/github.com/go-fries/fries/otel/otlp/v4) | Global OpenTelemetry provider configuration using OTLP exporters. |
 | Poll | [`poll`](https://pkg.go.dev/github.com/go-fries/fries/poll/v4) | Context-aware condition polling for eventually consistent state and asynchronous work. |
-| Ptr | [`ptr`](https://pkg.go.dev/github.com/go-fries/fries/ptr/v4) | Generic pointer construction helper. |
+| Ptr | [`ptr`](https://pkg.go.dev/github.com/go-fries/fries/ptr/v4) | Generic pointer helpers. |
 | Recovery | [`recovery`](https://pkg.go.dev/github.com/go-fries/fries/recovery/v4) | Shared panic recovery utilities. |
 | Signal | [`signal`](https://pkg.go.dev/github.com/go-fries/fries/signal/v4) | Signal handling integrated with application server lifecycles. |
 | Slices | [`slices`](https://pkg.go.dev/github.com/go-fries/fries/slices/v4) | Generic slice helpers. |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ and internal development tools are not included.
 | MySQL | [`mysql/canal`](https://pkg.go.dev/github.com/go-fries/fries/mysql/canal/v4)<br>[`mysql/canal/positioner/redis`](https://pkg.go.dev/github.com/go-fries/fries/mysql/canal/positioner/redis/v4)<br>[`mysql/canal/server`](https://pkg.go.dev/github.com/go-fries/fries/mysql/canal/server/v4) | MySQL binlog processing with Redis position storage and server lifecycle integration. |
 | OpenTelemetry | [`otel/otlp`](https://pkg.go.dev/github.com/go-fries/fries/otel/otlp/v4) | Global OpenTelemetry provider configuration using OTLP exporters. |
 | Poll | [`poll`](https://pkg.go.dev/github.com/go-fries/fries/poll/v4) | Context-aware condition polling for eventually consistent state and asynchronous work. |
+| Ptr | [`ptr`](https://pkg.go.dev/github.com/go-fries/fries/ptr/v4) | Generic pointer construction helper. |
 | Recovery | [`recovery`](https://pkg.go.dev/github.com/go-fries/fries/recovery/v4) | Shared panic recovery utilities. |
 | Signal | [`signal`](https://pkg.go.dev/github.com/go-fries/fries/signal/v4) | Signal handling integrated with application server lifecycles. |
 | Slices | [`slices`](https://pkg.go.dev/github.com/go-fries/fries/slices/v4) | Generic slice helpers. |

--- a/codecov.yml
+++ b/codecov.yml
@@ -87,6 +87,7 @@ fixes:
   - github.com/go-fries/fries/mysql/canal/server/v4::mysql/canal/server/
   - github.com/go-fries/fries/otel/otlp/v4::otel/otlp/
   - github.com/go-fries/fries/poll/v4::poll/
+  - github.com/go-fries/fries/ptr/v4::ptr/
   - github.com/go-fries/fries/recovery/v4::recovery/
   - github.com/go-fries/fries/retry/v4::retry/
   - github.com/go-fries/fries/signal/v4::signal/

--- a/ptr/README.md
+++ b/ptr/README.md
@@ -1,0 +1,51 @@
+# Ptr
+
+`ptr` constructs pointers and reads optional pointer values. It is useful when an API distinguishes an omitted value from a value's zero value.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/ptr/v4
+```
+
+## Usage
+
+```go
+package main
+
+import "github.com/go-fries/fries/ptr/v4"
+
+type Config struct {
+	Name    *string
+	Enabled *bool
+}
+
+func config() Config {
+	return Config{
+		Name:    ptr.Ptr("fries"),
+		Enabled: ptr.Ptr(true),
+	}
+}
+```
+
+`Ptr` always returns a pointer to the supplied value, including zero values and typed nil pointers.
+
+## Read a pointer
+
+`Value` returns the pointed-to value and reports whether the pointer is non-nil:
+
+```go
+name, ok := ptr.Value(config.Name)
+```
+
+For a nil pointer, `Value` returns the type's zero value and `false`. A non-nil pointer to a zero value returns that zero value and `true`.
+
+## Apply a fallback
+
+`Or` returns the pointed-to value, or the supplied fallback when the pointer is nil:
+
+```go
+name := ptr.Or(config.Name, "fries")
+```
+
+The fallback is used only when the pointer itself is nil. A non-nil pointer to a zero value does not use the fallback.

--- a/ptr/doc.go
+++ b/ptr/doc.go
@@ -1,0 +1,2 @@
+// Package ptr provides helpers for constructing pointers to values.
+package ptr

--- a/ptr/doc.go
+++ b/ptr/doc.go
@@ -1,2 +1,2 @@
-// Package ptr provides helpers for constructing pointers to values.
+// Package ptr provides helpers for constructing and reading pointer values.
 package ptr

--- a/ptr/example_test.go
+++ b/ptr/example_test.go
@@ -1,0 +1,28 @@
+package ptr_test
+
+import (
+	"fmt"
+
+	"github.com/go-fries/fries/ptr/v4"
+)
+
+func ExamplePtr() {
+	name := ptr.Ptr("fries")
+
+	fmt.Println(*name)
+	// Output: fries
+}
+
+func ExampleValue() {
+	name, ok := ptr.Value(ptr.Ptr("fries"))
+
+	fmt.Println(name, ok)
+	// Output: fries true
+}
+
+func ExampleOr() {
+	var name *string
+
+	fmt.Println(ptr.Or(name, "fries"))
+	// Output: fries
+}

--- a/ptr/go.mod
+++ b/ptr/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/ptr/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/ptr/go.sum
+++ b/ptr/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -1,0 +1,25 @@
+package ptr
+
+// Ptr returns a pointer to value.
+func Ptr[T any](value T) *T {
+	return &value
+}
+
+// Value returns the value pointed to by value and reports whether value is non-nil.
+func Value[T any](value *T) (T, bool) {
+	if value != nil {
+		return *value, true
+	}
+
+	var zero T
+	return zero, false
+}
+
+// Or returns the value pointed to by value, or fallback when value is nil.
+func Or[T any](value *T, fallback T) T {
+	if value != nil {
+		return *value
+	}
+
+	return fallback
+}

--- a/ptr/ptr_test.go
+++ b/ptr/ptr_test.go
@@ -1,0 +1,98 @@
+package ptr_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-fries/fries/ptr/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPtr(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		got := ptr.Ptr("foo")
+		require.NotNil(t, got)
+		assert.Equal(t, "foo", *got)
+	})
+
+	t.Run("integer", func(t *testing.T) {
+		got := ptr.Ptr(10)
+		require.NotNil(t, got)
+		assert.Equal(t, 10, *got)
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		type value struct {
+			Name string
+		}
+
+		got := ptr.Ptr(value{Name: "foo"})
+		require.NotNil(t, got)
+		assert.Equal(t, "foo", got.Name)
+	})
+
+	t.Run("time", func(t *testing.T) {
+		now := time.Now()
+		got := ptr.Ptr(now)
+		require.NotNil(t, got)
+		assert.Equal(t, now, *got)
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		got := ptr.Ptr[*int](nil)
+		require.NotNil(t, got)
+		assert.Nil(t, *got)
+	})
+
+	t.Run("independent values", func(t *testing.T) {
+		first := ptr.Ptr(1)
+		second := ptr.Ptr(1)
+		assert.NotSame(t, first, second)
+	})
+}
+
+func TestValue(t *testing.T) {
+	t.Run("value", func(t *testing.T) {
+		got, ok := ptr.Value(ptr.Ptr("foo"))
+		assert.True(t, ok)
+		assert.Equal(t, "foo", got)
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		got, ok := ptr.Value(ptr.Ptr(""))
+		assert.True(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		got, ok := ptr.Value[string](nil)
+		assert.False(t, ok)
+		assert.Empty(t, got)
+	})
+
+	t.Run("pointer containing nil", func(t *testing.T) {
+		got, ok := ptr.Value(ptr.Ptr[*int](nil))
+		assert.True(t, ok)
+		assert.Nil(t, got)
+	})
+}
+
+func TestOr(t *testing.T) {
+	t.Run("value", func(t *testing.T) {
+		assert.Equal(t, "foo", ptr.Or(ptr.Ptr("foo"), "fallback"))
+	})
+
+	t.Run("zero value", func(t *testing.T) {
+		assert.Empty(t, ptr.Or(ptr.Ptr(""), "fallback"))
+	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		assert.Equal(t, "fallback", ptr.Or(nil, "fallback"))
+	})
+
+	t.Run("pointer containing nil", func(t *testing.T) {
+		fallback := ptr.Ptr(10)
+		assert.Nil(t, ptr.Or(ptr.Ptr[*int](nil), fallback))
+	})
+}

--- a/ptr/version.go
+++ b/ptr/version.go
@@ -1,0 +1,6 @@
+package ptr
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.3"
+}

--- a/ptr/version_test.go
+++ b/ptr/version_test.go
@@ -1,0 +1,19 @@
+package ptr_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/ptr/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	version := ptr.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(version), "version is not semver: %s", version)
+}

--- a/support/values.go
+++ b/support/values.go
@@ -175,27 +175,6 @@ func DefaultWithFunc[T comparable](value T, callbacks ...func() T) T {
 	return zero
 }
 
-// Ptr returns a pointer to the value.
-//
-//	Ptr("foo") // *string("foo")
-//	Ptr(1) // *int(1)
-func Ptr[T any](value T) *T {
-	return &value
-}
-
-// Val returns the value of the pointer.
-// If the pointer is nil, return the zero value.
-//
-//	Val((*string)(nil)) // ""
-//	Val(Ptr("foo")) // "foo"
-func Val[T any](value *T) T {
-	if value != nil {
-		return *value
-	}
-	var zero T
-	return zero
-}
-
 // IsType returns true if the value is the type.
 //
 //	IsType[int](1) // true

--- a/support/values_test.go
+++ b/support/values_test.go
@@ -236,11 +236,12 @@ func TestOptional(t *testing.T) {
 	var nilStructVal *nilStruct
 	assert.Nil(t, Optional(nilStructVal).nilField)
 	assert.Nil(t, Optional(Optional(nilStructVal).nilField).nilField)
+	value := 10
 	valStructVal := &nilStruct{
 		nilField: &struct {
 			nilField *int
 		}{
-			nilField: Ptr(10),
+			nilField: &value,
 		},
 	}
 	assert.Equal(t, 10, *Optional(valStructVal).nilField.nilField)
@@ -366,47 +367,6 @@ func TestDefaultWithFunc(t *testing.T) {
 		return 0
 	})
 	assert.Equal(t, 0, got6)
-}
-
-func TestPtrAndVal(t *testing.T) {
-	// string
-	got := Ptr("foo")
-	assert.Equal(t, "foo", *got)
-	assert.Equal(t, "foo", Val(got))
-
-	// int
-	got2 := Ptr(10)
-	assert.Equal(t, 10, *got2)
-	assert.Equal(t, 10, Val(got2))
-
-	// struct
-	got3 := Ptr(foo{Name: "bar"})
-	assert.Equal(t, "bar", got3.Name)
-	assert.Equal(t, "bar", Val(got3).Name)
-
-	// time.Time
-	now := time.Now()
-	got4 := Ptr(now)
-	assert.Equal(t, now.String(), got4.String())
-	assert.Equal(t, now.String(), Val(got4).String())
-
-	// nil
-	got5 := Ptr[*int](nil)
-	assert.Nil(t, *got5)
-
-	// nil val
-	var nilVal *int
-	got6 := Val(nilVal)
-	assert.Equal(t, 0, got6)
-
-	// zero value
-	got7 := Ptr(0)
-	assert.Equal(t, 0, *got7)
-	assert.Equal(t, 0, Val(got7))
-
-	got8 := Ptr("")
-	assert.Equal(t, "", *got8)
-	assert.Equal(t, "", Val(got8))
 }
 
 type testInterface interface {

--- a/versions.yaml
+++ b/versions.yaml
@@ -124,6 +124,9 @@ module-sets:
       # Poll
       - github.com/go-fries/fries/poll/v4
 
+      # Ptr
+      - github.com/go-fries/fries/ptr/v4
+
       # Recovery
       - github.com/go-fries/fries/recovery/v4
 


### PR DESCRIPTION
## Summary

Extract pointer construction and optional pointer access from `support/v4` into a focused `ptr/v4` module.

## Changes

- Add `ptr.Ptr`, `ptr.Value`, and `ptr.Or` with package documentation, examples, version metadata, and Testify-based tests
- Register `ptr/v4` in the module set, Codecov path fixes, and the root component catalog
- Remove `support.Ptr` and `support.Val`; all other `support` APIs remain unchanged

## Motivation

- Give pointer helpers a clear package boundary instead of growing the general-purpose `support` module
- Make pointer presence and fallback behavior explicit through separate `Value` and `Or` APIs

## Breaking Changes

- `support.Ptr` has been removed; downstream users must import `github.com/go-fries/fries/ptr/v4` and use `ptr.Ptr`
- `support.Val` has been removed; use `ptr.Value` when presence matters, or `ptr.Or` when a fallback is required

## Before and After

| Before | After |
| --- | --- |
| `support.Ptr(value)` | `ptr.Ptr(value)` |
| `support.Val(pointer)` | `ptr.Value(pointer)` or `ptr.Or(pointer, fallback)` |

## Migration

1. Add `github.com/go-fries/fries/ptr/v4` to the consuming module.
2. Replace the `support/v4` import for pointer helpers with `ptr/v4`.
3. Replace `support.Ptr(value)` with `ptr.Ptr(value)`.
4. Replace `support.Val(pointer)` with `ptr.Value(pointer)` when the nil state must be observed, or `ptr.Or(pointer, fallback)` when a fallback value is desired.

## Behavior and Compatibility

- `ptr.Value(nil)` returns the type's zero value and `false`; a non-nil pointer to a zero value returns that value and `true`
- `ptr.Or` uses its fallback only when the pointer itself is nil
- APIs outside `support.Ptr` and `support.Val` are unchanged

## Testing

- `make build/ptr build/support`
- `go test -race ./...` in `ptr` and `support`
- `make lint/ptr lint/support`
- `make verify-mods`
- `git diff --check`