### PR TITLE
feat(http): add JSON response component

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -61,6 +61,7 @@ fixes:
   - github.com/go-fries/fries/hashing/v4::hashing/
   - github.com/go-fries/fries/hashing/md5/v4::hashing/md5/
   - github.com/go-fries/fries/health/v4::health/
+  - github.com/go-fries/fries/http/response/v4::http/response/
   - github.com/go-fries/fries/http/server/v4::http/server/
   - github.com/go-fries/fries/hyperf/jet/v4::hyperf/jet/
   - github.com/go-fries/fries/hyperf/jet/middleware/logger/v4::hyperf/jet/middleware/logger/

--- a/http/response/README.md
+++ b/http/response/README.md
@@ -1,0 +1,107 @@
+# HTTP Response
+
+`response` provides a small JSON envelope for HTTP APIs without binding
+applications to a router or web framework.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/http/response/v4
+```
+
+## Response format
+
+Every response includes an application status, a public message, and data. The
+application code is optional:
+
+```json
+{
+  "status": true,
+  "code": 10000,
+  "message": "Scratch 11 is working properly.",
+  "data": {
+    "id": 11,
+    "name": "Scratch 11"
+  }
+}
+```
+
+`status` reports whether the application operation succeeded. It does not
+replace the HTTP status code. `code` is application-defined and is not
+automatically copied from the HTTP status code. When there is no data, `data`
+is encoded as `null`.
+
+## Write a response
+
+Use `Success` or `Failure` to build a body, then pass the real HTTP status code
+to `Write`:
+
+```go
+func showScratch(w http.ResponseWriter, _ *http.Request) {
+	scratch := struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}{
+		ID:   11,
+		Name: "Scratch 11",
+	}
+
+	body := response.Success(
+		"Scratch 11 is working properly.",
+		scratch,
+		response.WithCode(10000),
+	)
+
+	if err := response.Write(w, http.StatusOK, body); err != nil {
+		slog.Error("write response", "error", err)
+	}
+}
+```
+
+Failures use the same envelope:
+
+```go
+body := response.Failure(
+	"Scratch does not exist.",
+	response.WithCode(10404),
+)
+
+if err := response.Write(w, http.StatusNotFound, body); err != nil {
+	slog.Error("write response", "error", err)
+}
+```
+
+Use `WithData` when a failure needs safe, structured details:
+
+```go
+body := response.Failure(
+	"The request contains invalid fields.",
+	response.WithCode(10422),
+	response.WithData(map[string][]string{
+		"name": {"name is required"},
+	}),
+)
+```
+
+Do not place internal errors, credentials, connection details, or stack traces
+in `message` or `data`. Log internal errors separately and return a message
+that is safe for API callers.
+
+`Write` serializes the complete body before committing the response headers.
+If serialization fails, it returns an error without sending a partial JSON
+response.
+
+## Frameworks
+
+`Body` is an ordinary Go value and can be passed directly to framework JSON
+helpers:
+
+```go
+c.JSON(
+	http.StatusOK,
+	response.Success("OK", data),
+)
+```
+
+Framework-specific adapters are not required.
+

--- a/http/response/README.md
+++ b/http/response/README.md
@@ -29,7 +29,7 @@ application code is optional:
 `status` reports whether the application operation succeeded. It does not
 replace the HTTP status code. `code` is application-defined and is not
 automatically copied from the HTTP status code. When there is no data, `data`
-is encoded as `null`.
+is omitted.
 
 ## Write a response
 
@@ -104,4 +104,3 @@ c.JSON(
 ```
 
 Framework-specific adapters are not required.
-

--- a/http/response/README.md
+++ b/http/response/README.md
@@ -28,8 +28,12 @@ application code and data are optional:
 
 `status` reports whether the application operation succeeded. It does not
 replace the HTTP status code. `code` is application-defined and is not
-automatically copied from the HTTP status code. When there is no data, `data`
-is omitted.
+automatically copied from the HTTP status code.
+
+`data` is omitted when its interface value is nil. Empty non-nil values,
+including slices, maps, strings, and numeric zero, remain in the response. A
+typed nil pointer, slice, or map stored in `data` is encoded as `null` because
+the containing interface is non-nil.
 
 ## Write a response
 

--- a/http/response/README.md
+++ b/http/response/README.md
@@ -11,8 +11,8 @@ go get github.com/go-fries/fries/http/response/v4
 
 ## Response format
 
-Every response includes an application status, a public message, and data. The
-application code is optional:
+Every response includes an application status and a public message. The
+application code and data are optional:
 
 ```json
 {
@@ -84,6 +84,51 @@ body := response.FromError(
 `FromError` uses `err.Error()` as the failure message. Do not pass database,
 network, credential, or other internal errors to it. Log those errors
 separately and use `Failure` with a public message instead.
+
+## Map application errors
+
+Use `ErrorMapper` to centralize the conversion from domain errors to HTTP
+status codes and safe response bodies:
+
+```go
+type applicationErrorMapper struct{}
+
+func (applicationErrorMapper) Map(
+	_ context.Context,
+	err error,
+) (int, response.Body) {
+	switch {
+	case err == nil:
+		return http.StatusOK, response.FromError(nil)
+
+	case errors.Is(err, repository.ErrNotFound):
+		return http.StatusNotFound, response.Failure(
+			"Resource not found.",
+			response.WithCode(10404),
+		)
+
+	default:
+		return http.StatusInternalServerError, response.Failure(
+			"Unable to process the request.",
+			response.WithCode(10500),
+		)
+	}
+}
+```
+
+Handlers can use the mapper without duplicating error rules:
+
+```go
+httpStatus, body := mapper.Map(r.Context(), err)
+if err := response.Write(w, httpStatus, body); err != nil {
+	slog.Error("write response", "error", err)
+}
+```
+
+`ErrorMapperFunc` adapts a function when a dedicated mapper type is
+unnecessary. Mappers should accept a nil error and return a successful
+response. Unknown errors should always use a safe fallback message rather than
+exposing `err.Error()`.
 
 Use `WithData` when a failure needs safe, structured details:
 

--- a/http/response/README.md
+++ b/http/response/README.md
@@ -71,6 +71,20 @@ if err := response.Write(w, http.StatusNotFound, body); err != nil {
 }
 ```
 
+For errors that are already safe to expose, `FromError` converts a nil error
+to a successful response and a non-nil error to a failed response:
+
+```go
+body := response.FromError(
+	err,
+	response.WithCode(10422),
+)
+```
+
+`FromError` uses `err.Error()` as the failure message. Do not pass database,
+network, credential, or other internal errors to it. Log those errors
+separately and use `Failure` with a public message instead.
+
 Use `WithData` when a failure needs safe, structured details:
 
 ```go

--- a/http/response/config.go
+++ b/http/response/config.go
@@ -1,0 +1,49 @@
+package response
+
+type config struct {
+	code *int
+	data any
+}
+
+// Option configures a response created by [Success] or [Failure].
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+
+// WithCode sets the optional application code.
+//
+// The application code is independent of the HTTP status code passed to
+// [Write].
+func WithCode(code int) Option {
+	return optionFunc(func(c *config) {
+		value := code
+		c.code = &value
+	})
+}
+
+// WithData sets the response data.
+//
+// It is most useful for attaching safe, structured details to a response
+// created by [Failure]. When used with [Success], it replaces the data passed
+// to Success.
+func WithData(data any) Option {
+	return optionFunc(func(c *config) {
+		c.data = data
+	})
+}
+
+func newConfig(data any, options ...Option) config {
+	c := config{data: data}
+	for _, option := range options {
+		if option != nil {
+			option.apply(&c)
+		}
+	}
+	return c
+}

--- a/http/response/config_test.go
+++ b/http/response/config_test.go
@@ -1,0 +1,86 @@
+package response
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfig(t *testing.T) {
+	t.Parallel()
+
+	defaultData := map[string]int{"id": 11}
+	replacementData := map[string]string{"field": "invalid"}
+
+	tests := []struct {
+		name     string
+		data     any
+		options  []Option
+		wantCode *int
+		wantData any
+	}{
+		{
+			name:     "keeps default data",
+			data:     defaultData,
+			wantData: defaultData,
+		},
+		{
+			name:     "sets code",
+			options:  []Option{WithCode(200)},
+			wantCode: intPointer(200),
+		},
+		{
+			name:     "keeps zero code",
+			options:  []Option{WithCode(0)},
+			wantCode: intPointer(0),
+		},
+		{
+			name:     "replaces data",
+			data:     defaultData,
+			options:  []Option{WithData(replacementData)},
+			wantData: replacementData,
+		},
+		{
+			name:     "ignores nil option",
+			data:     defaultData,
+			options:  []Option{nil},
+			wantData: defaultData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newConfig(tt.data, tt.options...)
+
+			if tt.wantCode == nil {
+				assert.Nil(t, c.code)
+			} else {
+				require.NotNil(t, c.code)
+				assert.Equal(t, *tt.wantCode, *c.code)
+			}
+			assert.Equal(t, tt.wantData, c.data)
+		})
+	}
+}
+
+func TestWithCodeDoesNotSharePointers(t *testing.T) {
+	t.Parallel()
+
+	option := WithCode(200)
+	first := newConfig(nil, option)
+	second := newConfig(nil, option)
+	require.NotNil(t, first.code)
+	require.NotNil(t, second.code)
+
+	*first.code = 500
+
+	assert.Equal(t, 500, *first.code)
+	assert.Equal(t, 200, *second.code)
+}
+
+func intPointer(value int) *int {
+	return &value
+}

--- a/http/response/doc.go
+++ b/http/response/doc.go
@@ -3,5 +3,6 @@
 //
 // A response body contains an application status, an optional application
 // code, a public message, and data. The application code is independent of the
-// HTTP status code passed to [Write].
+// HTTP status code passed to [Write]. Applications can implement [ErrorMapper]
+// to centralize safe conversions from domain errors to HTTP responses.
 package response

--- a/http/response/doc.go
+++ b/http/response/doc.go
@@ -1,0 +1,7 @@
+// Package response builds and writes a consistent JSON envelope for HTTP
+// APIs.
+//
+// A response body contains an application status, an optional application
+// code, a public message, and data. The application code is independent of the
+// HTTP status code passed to [Write].
+package response

--- a/http/response/example_test.go
+++ b/http/response/example_test.go
@@ -1,0 +1,29 @@
+package response_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-fries/fries/http/response/v4"
+)
+
+func Example() {
+	recorder := httptest.NewRecorder()
+	body := response.Success(
+		"Scratch 11 is working properly.",
+		map[string]any{
+			"id":   11,
+			"name": "Scratch 11",
+		},
+		response.WithCode(10000),
+	)
+
+	if err := response.Write(recorder, http.StatusOK, body); err != nil {
+		panic(err)
+	}
+
+	fmt.Print(recorder.Body.String())
+	// Output:
+	// {"status":true,"code":10000,"message":"Scratch 11 is working properly.","data":{"id":11,"name":"Scratch 11"}}
+}

--- a/http/response/go.mod
+++ b/http/response/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/http/response/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/http/response/go.sum
+++ b/http/response/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/http/response/mapper.go
+++ b/http/response/mapper.go
@@ -22,5 +22,8 @@ func (f ErrorMapperFunc) Map(
 	ctx context.Context,
 	err error,
 ) (httpStatus int, body Body) {
+	if f == nil {
+		panic("response: nil error mapper function")
+	}
 	return f(ctx, err)
 }

--- a/http/response/mapper.go
+++ b/http/response/mapper.go
@@ -1,0 +1,26 @@
+package response
+
+import "context"
+
+// ErrorMapper maps an application error to an HTTP status code and response
+// body.
+//
+// Implementations should accept a nil error and return a successful response.
+// They should also provide a safe fallback for unknown errors instead of
+// exposing internal error messages.
+type ErrorMapper interface {
+	Map(context.Context, error) (httpStatus int, body Body)
+}
+
+// ErrorMapperFunc adapts a function to [ErrorMapper].
+type ErrorMapperFunc func(context.Context, error) (httpStatus int, body Body)
+
+// Map calls f with ctx and err.
+//
+// Map panics if f is nil.
+func (f ErrorMapperFunc) Map(
+	ctx context.Context,
+	err error,
+) (httpStatus int, body Body) {
+	return f(ctx, err)
+}

--- a/http/response/mapper_test.go
+++ b/http/response/mapper_test.go
@@ -1,0 +1,72 @@
+package response_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/go-fries/fries/http/response/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorMapperFunc(t *testing.T) {
+	t.Parallel()
+
+	type contextKey struct{}
+	ctx := context.WithValue(t.Context(), contextKey{}, "value")
+	targetErr := errors.New("not found")
+	called := false
+
+	mapper := response.ErrorMapperFunc(func(
+		gotCtx context.Context,
+		gotErr error,
+	) (int, response.Body) {
+		called = true
+		assert.Same(t, ctx, gotCtx)
+		assert.ErrorIs(t, gotErr, targetErr)
+		return http.StatusNotFound, response.Failure(
+			"Resource not found.",
+			response.WithCode(10404),
+		)
+	})
+
+	httpStatus, body := mapper.Map(ctx, targetErr)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusNotFound, httpStatus)
+	assert.False(t, body.Status)
+	assert.Equal(t, "Resource not found.", body.Message)
+	require.NotNil(t, body.Code)
+	assert.Equal(t, 10404, *body.Code)
+}
+
+func TestErrorMapperFuncAcceptsNilError(t *testing.T) {
+	t.Parallel()
+
+	mapper := response.ErrorMapperFunc(func(
+		_ context.Context,
+		err error,
+	) (int, response.Body) {
+		return http.StatusOK, response.FromError(err)
+	})
+
+	httpStatus, body := mapper.Map(t.Context(), nil)
+
+	assert.Equal(t, http.StatusOK, httpStatus)
+	assert.True(t, body.Status)
+	assert.Empty(t, body.Message)
+}
+
+func TestErrorMapperFuncPanicsWhenNil(t *testing.T) {
+	t.Parallel()
+
+	var mapper response.ErrorMapperFunc
+
+	assert.Panics(t, func() {
+		_, _ = mapper.Map(t.Context(), errors.New("failure"))
+	})
+}
+
+var _ response.ErrorMapper = response.ErrorMapperFunc(nil)

--- a/http/response/mapper_test.go
+++ b/http/response/mapper_test.go
@@ -64,9 +64,13 @@ func TestErrorMapperFuncPanicsWhenNil(t *testing.T) {
 
 	var mapper response.ErrorMapperFunc
 
-	assert.Panics(t, func() {
-		_, _ = mapper.Map(t.Context(), errors.New("failure"))
-	})
+	assert.PanicsWithValue(
+		t,
+		"response: nil error mapper function",
+		func() {
+			_, _ = mapper.Map(t.Context(), errors.New("failure"))
+		},
+	)
 }
 
 var _ response.ErrorMapper = response.ErrorMapperFunc(nil)

--- a/http/response/response.go
+++ b/http/response/response.go
@@ -35,3 +35,15 @@ func Failure(message string, options ...Option) Body {
 		Data:    c.data,
 	}
 }
+
+// FromError returns a successful response when err is nil. Otherwise, it
+// returns a failed response using err.Error() as the message.
+//
+// FromError does not infer an HTTP status code or application code. Only pass
+// errors whose messages are safe to expose to API callers.
+func FromError(err error, options ...Option) Body {
+	if err == nil {
+		return Success("", nil, options...)
+	}
+	return Failure(err.Error(), options...)
+}

--- a/http/response/response.go
+++ b/http/response/response.go
@@ -4,7 +4,8 @@ package response
 //
 // Status reports whether the application operation succeeded. Code is an
 // optional application-defined code and does not represent the HTTP status
-// code. Data is omitted when it is nil.
+// code. Data is omitted when its interface value is nil. A typed nil stored in
+// Data is encoded as null.
 type Body struct {
 	Status  bool   `json:"status"`
 	Code    *int   `json:"code,omitempty"`

--- a/http/response/response.go
+++ b/http/response/response.go
@@ -4,12 +4,12 @@ package response
 //
 // Status reports whether the application operation succeeded. Code is an
 // optional application-defined code and does not represent the HTTP status
-// code. Data is always encoded, using null when it is nil.
+// code. Data is omitted when it is nil.
 type Body struct {
 	Status  bool   `json:"status"`
 	Code    *int   `json:"code,omitempty"`
 	Message string `json:"message"`
-	Data    any    `json:"data"`
+	Data    any    `json:"data,omitempty"`
 }
 
 // Success returns a successful response containing message and data.

--- a/http/response/response.go
+++ b/http/response/response.go
@@ -1,0 +1,37 @@
+package response
+
+// Body is the JSON response envelope.
+//
+// Status reports whether the application operation succeeded. Code is an
+// optional application-defined code and does not represent the HTTP status
+// code. Data is always encoded, using null when it is nil.
+type Body struct {
+	Status  bool   `json:"status"`
+	Code    *int   `json:"code,omitempty"`
+	Message string `json:"message"`
+	Data    any    `json:"data"`
+}
+
+// Success returns a successful response containing message and data.
+func Success(message string, data any, options ...Option) Body {
+	c := newConfig(data, options...)
+	return Body{
+		Status:  true,
+		Code:    c.code,
+		Message: message,
+		Data:    c.data,
+	}
+}
+
+// Failure returns a failed response containing message.
+//
+// Use [WithData] to include safe, structured failure details.
+func Failure(message string, options ...Option) Body {
+	c := newConfig(nil, options...)
+	return Body{
+		Status:  false,
+		Code:    c.code,
+		Message: message,
+		Data:    c.data,
+	}
+}

--- a/http/response/response_test.go
+++ b/http/response/response_test.go
@@ -1,0 +1,72 @@
+package response_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-fries/fries/http/response/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSuccess(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]int{"id": 11}
+	body := response.Success("working properly", data, response.WithCode(10000))
+
+	assert.True(t, body.Status)
+	require.NotNil(t, body.Code)
+	assert.Equal(t, 10000, *body.Code)
+	assert.Equal(t, "working properly", body.Message)
+	assert.Equal(t, data, body.Data)
+}
+
+func TestFailure(t *testing.T) {
+	t.Parallel()
+
+	data := map[string][]string{"name": {"name is required"}}
+	body := response.Failure(
+		"invalid request",
+		response.WithCode(10422),
+		response.WithData(data),
+	)
+
+	assert.False(t, body.Status)
+	require.NotNil(t, body.Code)
+	assert.Equal(t, 10422, *body.Code)
+	assert.Equal(t, "invalid request", body.Message)
+	assert.Equal(t, data, body.Data)
+}
+
+func TestBodyJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body response.Body
+		want string
+	}{
+		{
+			name: "omits unset code and keeps nil data",
+			body: response.Success("ok", nil),
+			want: `{"status":true,"message":"ok","data":null}`,
+		},
+		{
+			name: "keeps zero code",
+			body: response.Success("ok", nil, response.WithCode(0)),
+			want: `{"status":true,"code":0,"message":"ok","data":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload, err := json.Marshal(tt.body)
+
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(payload))
+		})
+	}
+}

--- a/http/response/response_test.go
+++ b/http/response/response_test.go
@@ -48,14 +48,14 @@ func TestBodyJSON(t *testing.T) {
 		want string
 	}{
 		{
-			name: "omits unset code and keeps nil data",
+			name: "omits unset code and nil data",
 			body: response.Success("ok", nil),
-			want: `{"status":true,"message":"ok","data":null}`,
+			want: `{"status":true,"message":"ok"}`,
 		},
 		{
-			name: "keeps zero code",
+			name: "keeps zero code and omits nil data",
 			body: response.Success("ok", nil, response.WithCode(0)),
-			want: `{"status":true,"code":0,"message":"ok","data":null}`,
+			want: `{"status":true,"code":0,"message":"ok"}`,
 		},
 	}
 

--- a/http/response/response_test.go
+++ b/http/response/response_test.go
@@ -100,6 +100,10 @@ func TestFromError(t *testing.T) {
 func TestBodyJSON(t *testing.T) {
 	t.Parallel()
 
+	var typedNilPointer *struct{}
+	var typedNilSlice []int
+	var typedNilMap map[string]int
+
 	tests := []struct {
 		name string
 		body response.Body
@@ -114,6 +118,41 @@ func TestBodyJSON(t *testing.T) {
 			name: "keeps zero code and omits nil data",
 			body: response.Success("ok", nil, response.WithCode(0)),
 			want: `{"status":true,"code":0,"message":"ok"}`,
+		},
+		{
+			name: "keeps zero data",
+			body: response.Success("ok", 0),
+			want: `{"status":true,"message":"ok","data":0}`,
+		},
+		{
+			name: "keeps empty string data",
+			body: response.Success("ok", ""),
+			want: `{"status":true,"message":"ok","data":""}`,
+		},
+		{
+			name: "keeps empty slice data",
+			body: response.Success("ok", []int{}),
+			want: `{"status":true,"message":"ok","data":[]}`,
+		},
+		{
+			name: "keeps empty map data",
+			body: response.Success("ok", map[string]int{}),
+			want: `{"status":true,"message":"ok","data":{}}`,
+		},
+		{
+			name: "encodes typed nil pointer as null",
+			body: response.Success("ok", typedNilPointer),
+			want: `{"status":true,"message":"ok","data":null}`,
+		},
+		{
+			name: "encodes typed nil slice as null",
+			body: response.Success("ok", typedNilSlice),
+			want: `{"status":true,"message":"ok","data":null}`,
+		},
+		{
+			name: "encodes typed nil map as null",
+			body: response.Success("ok", typedNilMap),
+			want: `{"status":true,"message":"ok","data":null}`,
 		},
 	}
 

--- a/http/response/response_test.go
+++ b/http/response/response_test.go
@@ -2,6 +2,7 @@ package response_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/go-fries/fries/http/response/v4"
@@ -39,6 +40,63 @@ func TestFailure(t *testing.T) {
 	assert.Equal(t, data, body.Data)
 }
 
+func TestFromError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		err         error
+		options     []response.Option
+		wantStatus  bool
+		wantCode    *int
+		wantMessage string
+		wantData    any
+	}{
+		{
+			name:       "returns success for nil error",
+			wantStatus: true,
+		},
+		{
+			name:        "returns failure for non-nil error",
+			err:         errors.New("invalid request"),
+			wantMessage: "invalid request",
+		},
+		{
+			name:       "applies options to success",
+			options:    []response.Option{response.WithCode(0), response.WithData("result")},
+			wantStatus: true,
+			wantCode:   intPointer(0),
+			wantData:   "result",
+		},
+		{
+			name:        "applies options to failure",
+			err:         errors.New("invalid request"),
+			options:     []response.Option{response.WithCode(10422), response.WithData("details")},
+			wantCode:    intPointer(10422),
+			wantMessage: "invalid request",
+			wantData:    "details",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := response.FromError(tt.err, tt.options...)
+
+			assert.Equal(t, tt.wantStatus, body.Status)
+			if tt.wantCode == nil {
+				assert.Nil(t, body.Code)
+			} else {
+				require.NotNil(t, body.Code)
+				assert.Equal(t, *tt.wantCode, *body.Code)
+			}
+			assert.Equal(t, tt.wantMessage, body.Message)
+			assert.Equal(t, tt.wantData, body.Data)
+		})
+	}
+}
+
 func TestBodyJSON(t *testing.T) {
 	t.Parallel()
 
@@ -69,4 +127,8 @@ func TestBodyJSON(t *testing.T) {
 			assert.JSONEq(t, tt.want, string(payload))
 		})
 	}
+}
+
+func intPointer(value int) *int {
+	return &value
 }

--- a/http/response/version.go
+++ b/http/response/version.go
@@ -1,0 +1,6 @@
+package response
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0-beta.3"
+}

--- a/http/response/version_test.go
+++ b/http/response/version_test.go
@@ -1,0 +1,20 @@
+package response_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/http/response/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := response.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/http/response/writer.go
+++ b/http/response/writer.go
@@ -1,0 +1,32 @@
+package response
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const contentType = "application/json; charset=utf-8"
+
+// Write encodes body as JSON and writes it with httpStatus.
+//
+// Body is encoded before the response headers are committed. If encoding
+// fails, Write returns an error without modifying w. Write panics if w is nil.
+func Write(w http.ResponseWriter, httpStatus int, body Body) error {
+	if w == nil {
+		panic("response: nil response writer")
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("response: marshal body: %w", err)
+	}
+	payload = append(payload, '\n')
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(httpStatus)
+	if _, err = w.Write(payload); err != nil {
+		return fmt.Errorf("response: write body: %w", err)
+	}
+	return nil
+}

--- a/http/response/writer_test.go
+++ b/http/response/writer_test.go
@@ -1,0 +1,99 @@
+package response_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-fries/fries/http/response/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrite(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	body := response.Success(
+		"working properly",
+		map[string]int{"id": 11},
+		response.WithCode(10000),
+	)
+
+	err := response.Write(recorder, http.StatusCreated, body)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, recorder.Code)
+	assert.Equal(t, "application/json; charset=utf-8", recorder.Header().Get("Content-Type"))
+	assert.JSONEq(t, `{
+		"status": true,
+		"code": 10000,
+		"message": "working properly",
+		"data": {"id": 11}
+	}`, recorder.Body.String())
+	assert.Equal(t, byte('\n'), recorder.Body.Bytes()[recorder.Body.Len()-1])
+}
+
+func TestWriteEncodingErrorDoesNotCommitResponse(t *testing.T) {
+	t.Parallel()
+
+	writer := newRecordingWriter()
+	body := response.Success("ok", make(chan int))
+
+	err := response.Write(writer, http.StatusOK, body)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response: marshal body")
+	assert.False(t, writer.committed)
+	assert.Empty(t, writer.header)
+	assert.Empty(t, writer.body)
+}
+
+func TestWriteReturnsWriterError(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("write failed")
+	writer := newRecordingWriter()
+	writer.writeErr = writeErr
+
+	err := response.Write(writer, http.StatusAccepted, response.Success("ok", nil))
+
+	require.ErrorIs(t, err, writeErr)
+	assert.True(t, writer.committed)
+	assert.Equal(t, http.StatusAccepted, writer.statusCode)
+}
+
+func TestWritePanicsWithNilWriter(t *testing.T) {
+	t.Parallel()
+
+	assert.PanicsWithValue(t, "response: nil response writer", func() {
+		_ = response.Write(nil, http.StatusOK, response.Success("ok", nil))
+	})
+}
+
+type recordingWriter struct {
+	header     http.Header
+	body       []byte
+	statusCode int
+	committed  bool
+	writeErr   error
+}
+
+func newRecordingWriter() *recordingWriter {
+	return &recordingWriter{header: make(http.Header)}
+}
+
+func (w *recordingWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *recordingWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.committed = true
+}
+
+func (w *recordingWriter) Write(payload []byte) (int, error) {
+	w.body = append(w.body, payload...)
+	return len(payload), w.writeErr
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -86,6 +86,7 @@ module-sets:
       - github.com/go-fries/fries/health/v4
 
       # Http
+      - github.com/go-fries/fries/http/response/v4
       - github.com/go-fries/fries/http/server/v4
 
       # JSON-RPC


### PR DESCRIPTION
## Summary

Add a standalone `http/response` module for consistent JSON response envelopes, safe HTTP output, and application-defined error mapping without coupling callers to a web framework.

## Changes

- Add `Body` with application `status`, optional application `code`, public `message`, and optional `data`
- Add `Success`, `Failure`, and `FromError` constructors with reusable `WithCode` and `WithData` options
- Preserve an explicitly configured zero application code while omitting unset codes and nil data from JSON
- Add `Write` to serialize the complete body before committing HTTP headers, keeping JSON encoding failures observable
- Keep the real HTTP status code explicit and independent from the application code
- Add `ErrorMapper` and `ErrorMapperFunc` for centralizing domain-error, HTTP-status, business-code, and public-message conversion
- Document safe error exposure, framework-neutral use, and direct integration with standard-library or framework JSON writers
- Register the new module in the release module set and Codecov path mapping

## Motivation

- Applications currently repeat response DTOs, JSON encoding, content-type handling, and success or failure conventions across handlers
- Mixing HTTP status codes with application codes makes client, gateway, and monitoring behavior harder to reason about
- Central error mapping prevents duplicated `errors.Is` and `errors.As` branches while keeping internal errors out of public responses
- A standard-library-only module can be shared by `net/http`, Chi, Gin, and other adapters without adding framework dependencies

## Breaking Changes

- None. This is an additive module and does not change existing packages, APIs, response formats, configuration, or runtime behavior.

## Before and After

Before, applications commonly define and encode response envelopes in each project or handler:

```go
payload := struct {
    Status  bool `json:"status"`
    Code    int `json:"code,omitempty"`
    Message string `json:"message"`
    Data    any `json:"data,omitempty"`
}{
    Status: true,
    Code: 10000,
    Message: "Scratch 11 is working properly.",
    Data: scratch,
}

w.Header().Set("Content-Type", "application/json")
w.WriteHeader(http.StatusOK)
_ = json.NewEncoder(w).Encode(payload)
```

After, callers construct the shared body and keep the HTTP status explicit:

```go
body := response.Success(
    "Scratch 11 is working properly.",
    scratch,
    response.WithCode(10000),
)

if err := response.Write(w, http.StatusOK, body); err != nil {
    return err
}
```

Applications can centralize domain error conversion:

```go
httpStatus, body := mapper.Map(r.Context(), err)
return response.Write(w, httpStatus, body)
```

## Migration

No migration is required for existing users. Optional adoption:

1. Add `github.com/go-fries/fries/http/response/v4`.
2. Replace project-local response envelopes with `response.Success`, `response.Failure`, or `response.FromError`.
3. Pass the real HTTP status separately to `response.Write`; keep `WithCode` for application-defined codes only.
4. Implement `ErrorMapper` or use `ErrorMapperFunc` when handlers repeat the same domain-error conversion rules.
5. Use `FromError` only for errors whose text is safe to expose. Map internal and unknown errors to a public fallback message.

## Behavior and Compatibility

- `status` reports application success and does not replace the HTTP status code
- `code` is optional, application-defined, and preserves an explicitly configured zero value
- `data` is omitted when nil
- `FromError(nil)` returns a successful body with an empty message; a non-nil error returns a failed body using `err.Error()`
- `ErrorMapper` implementations should accept nil errors and provide a safe fallback for unknown errors
- `Write` encodes JSON before setting headers, appends a newline, and returns encoding or writer errors
- `Write` panics for a nil `http.ResponseWriter`, which is treated as a programming error
- The module does not infer HTTP status codes, define business-code registries, register mapping rules, or add framework-specific adapters

## Testing

- `make test/http/response`
- `go test -race ./...` in `http/response`
- `make lint/http/response`
- `go build ./...` in `http/response`
- `go test -cover ./...` in `http/response`: 100.0% statement coverage
- `make verify-mods`
- `git diff --check`
- Repository-wide `make test` was attempted but stopped in the existing `cache/redis` integration tests because Redis was unavailable; the new module test suite completed independently
