### PR TITLE
Release v4.0.0

### DIFF
--- a/cache/go.mod
+++ b/cache/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/locker/v4 => ../locker
 
 require (
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/locker/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -11,11 +11,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/cache/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/locker/redis/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/cache/v4 v4.0.0
+	github.com/go-fries/fries/codec/json/v4 v4.0.0
+	github.com/go-fries/fries/codec/v4 v4.0.0
+	github.com/go-fries/fries/locker/redis/v4 v4.0.0
+	github.com/go-fries/fries/locker/v4 v4.0.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/json/version.go
+++ b/codec/json/version.go
@@ -2,5 +2,5 @@ package json
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )

--- a/codec/msgpack/version.go
+++ b/codec/msgpack/version.go
@@ -2,5 +2,5 @@ package msgpack
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/codec/proto/version.go
+++ b/codec/proto/version.go
@@ -2,5 +2,5 @@ package proto
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
 	github.com/bytedance/sonic v1.15.2
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/sonic/version.go
+++ b/codec/sonic/version.go
@@ -2,5 +2,5 @@ package sonic
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/codec/version.go
+++ b/codec/version.go
@@ -2,5 +2,5 @@ package codec
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/codec/xml/version.go
+++ b/codec/xml/version.go
@@ -2,5 +2,5 @@ package xml
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/codec/v4 => ../
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/codec/yaml/version.go
+++ b/codec/yaml/version.go
@@ -2,5 +2,5 @@ package yaml
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/eino/components/embedding/cached/v4 => ../../
 
 require (
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/gorm v1.31.2
 )

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/sonic/v4 v4.0.0
+	github.com/go-fries/fries/codec/v4 v4.0.0
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	github.com/cloudwego/eino v0.9.13
-	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4 v4.0.0
+	github.com/go-fries/fries/eino/components/embedding/cached/v4 v4.0.0
 	github.com/redis/go-redis/v9 v9.21.0
 )
 
@@ -26,8 +26,8 @@ require (
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/eino-contrib/jsonschema v1.0.3 // indirect
-	github.com/go-fries/fries/codec/sonic/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/sonic/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
 	github.com/goph/emperror v0.17.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/event/v4 => ../../
 
 require (
-	github.com/go-fries/fries/event/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/event/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/filesystem/v4 => ../
 
 require (
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/filesystem/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -6,7 +6,7 @@ replace github.com/go-fries/fries/filesystem/v4 => ../
 
 require (
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.3
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/filesystem/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -7,7 +7,7 @@ replace github.com/go-fries/fries/filesystem/v4 => ../
 require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
 	github.com/aws/smithy-go v1.27.4
-	github.com/go-fries/fries/filesystem/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/filesystem/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gorm/logger/multi/version.go
+++ b/gorm/logger/multi/version.go
@@ -2,5 +2,5 @@ package multi
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/gorm/logger/otel/version.go
+++ b/gorm/logger/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hashing/v4 => ../
 
 require (
-	github.com/go-fries/fries/hashing/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hashing/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hashing/md5/version.go
+++ b/hashing/md5/version.go
@@ -2,5 +2,5 @@ package md5
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/hashing/version.go
+++ b/hashing/version.go
@@ -2,5 +2,5 @@ package hashing
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/health/version.go
+++ b/health/version.go
@@ -2,5 +2,5 @@ package health
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/http/response/version.go
+++ b/http/response/version.go
@@ -2,5 +2,5 @@ package response
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/capability/v4 => ../../capability
 
 require (
-	github.com/go-fries/fries/capability/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/capability/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/logger/go.mod
+++ b/hyperf/jet/middleware/logger/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/otel/go.mod
+++ b/hyperf/jet/middleware/otel/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/hyperf/jet/middleware/otel/version.go
+++ b/hyperf/jet/middleware/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 v4.0.0
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0
+	github.com/go-fries/fries/retry/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/hyperf/jet/middleware/retry/version.go
+++ b/hyperf/jet/middleware/retry/version.go
@@ -2,5 +2,5 @@ package retry
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 
 require (
-	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/hyperf/jet/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/jsonrpc/go.mod
+++ b/jsonrpc/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/json/v4 v4.0.0
+	github.com/go-fries/fries/codec/v4 v4.0.0
 	github.com/google/uuid v1.6.0
 )
 

--- a/kratos/middleware/otel/version.go
+++ b/kratos/middleware/otel/version.go
@@ -2,5 +2,5 @@ package otel
 
 // Version returns the current release version of this instrumentation.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/lifecycle/version.go
+++ b/lifecycle/version.go
@@ -2,5 +2,5 @@ package lifecycle
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/locker/v4 => ../
 
 require (
-	github.com/go-fries/fries/locker/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/locker/v4 v4.0.0
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/log/slog/multi/version.go
+++ b/log/slog/multi/version.go
@@ -2,5 +2,5 @@ package multi
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/log/slog/syslog/version.go
+++ b/log/slog/syslog/version.go
@@ -4,5 +4,5 @@ package syslog
 
 // Version returns the current release version of this component.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -9,9 +9,9 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/json/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/json/v4 v4.0.0
+	github.com/go-fries/fries/codec/v4 v4.0.0
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0
 	github.com/go-mysql-org/go-mysql v1.13.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/mysql/canal/v4 => ../
 
 require (
-	github.com/go-fries/fries/mysql/canal/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/mysql/canal/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/lifecycle/v4 => ../../lifecycle
 
 require (
-	github.com/go-fries/fries/lifecycle/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/lifecycle/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/host v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0

--- a/parallel/version.go
+++ b/parallel/version.go
@@ -2,5 +2,5 @@ package parallel
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/poll/version.go
+++ b/poll/version.go
@@ -2,5 +2,5 @@ package poll
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/ptr/version.go
+++ b/ptr/version.go
@@ -2,5 +2,5 @@ package ptr
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/queue/adapter/memory/go.mod
+++ b/queue/adapter/memory/go.mod
@@ -9,14 +9,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/queue/adapter/rabbitmq/go.mod
+++ b/queue/adapter/rabbitmq/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/v4 v4.0.0
 	github.com/rabbitmq/amqp091-go v1.13.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/queue/adapter/redis/go.mod
+++ b/queue/adapter/redis/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/v4 v4.0.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -17,8 +17,8 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/queue/examples/tasker/go.mod
+++ b/queue/examples/tasker/go.mod
@@ -10,11 +10,11 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/adapter/memory/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/adapter/memory/v4 v4.0.0
+	github.com/go-fries/fries/queue/v4 v4.0.0
 )
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0 // indirect
 )

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -8,8 +8,8 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/codec/v4 v4.0.0
+	github.com/go-fries/fries/retry/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/queue/kratos/server/go.mod
+++ b/queue/kratos/server/go.mod
@@ -9,15 +9,15 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/v4 v4.0.0
 	github.com/go-kratos/kratos/v3 v3.0.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0 // indirect
 	github.com/go-playground/form/v4 v4.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/queue/middleware/recovery/go.mod
+++ b/queue/middleware/recovery/go.mod
@@ -9,14 +9,14 @@ replace (
 )
 
 require (
-	github.com/go-fries/fries/queue/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/queue/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-fries/fries/codec/v4 v4.0.0-beta.3 // indirect
-	github.com/go-fries/fries/retry/v4 v4.0.0-beta.3 // indirect
+	github.com/go-fries/fries/codec/v4 v4.0.0 // indirect
+	github.com/go-fries/fries/retry/v4 v4.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/retry/version.go
+++ b/retry/version.go
@@ -2,5 +2,5 @@ package retry
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/go-fries/fries/constraints/v4 => ../constraints
 
 require (
-	github.com/go-fries/fries/constraints/v4 v4.0.0-beta.3
+	github.com/go-fries/fries/constraints/v4 v4.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/slices/version.go
+++ b/slices/version.go
@@ -2,5 +2,5 @@ package slices
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/strings/version.go
+++ b/strings/version.go
@@ -2,5 +2,5 @@ package strings
 
 // Version returns the current release version of this package.
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package fries
 
 func Version() string {
-	return "4.0.0-beta.3"
+	return "4.0.0"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 module-sets:
   stable:
-    version: v4.0.0-beta.3
+    version: v4.0.0
     modules:
       - github.com/go-fries/fries/v4
       - github.com/go-fries/fries/errors/v4


### PR DESCRIPTION
## Summary

Finalize the stable `v4.0.0` module set and promote generated module references and version helpers from `v4.0.0-beta.3` to `v4.0.0`.

## Release Changes

- Promote the stable module-set version to `v4.0.0`
- Update stable component `Version()` values to `4.0.0`
- Update intra-repository module requirements to the stable release version
- Include the new `health`, `http/response`, and `ptr` modules in the stable release
- Keep component usage guidance close to each package after removing the standalone root example modules

## Highlights

- Add a standalone Health component with named Context-aware checks, bounded concurrency, structured reports, panic recovery, and standard liveness and readiness HTTP handlers
- Add a framework-neutral JSON Response component with consistent envelopes, explicit HTTP status handling, reusable options, safe serialization, and application-defined error mapping
- Move pointer construction and optional pointer access from `support/v4` into the focused `ptr/v4` module with `Ptr`, `Value`, and `Or`
- Consolidate root examples into component READMEs and package-local compile-checked examples
- Refresh dependencies across the multi-module repository before the stable release

## Pull Requests Since v4.0.0-beta.3

Range: [`v4.0.0-beta.3...08cf54e`](https://github.com/go-fries/fries/compare/v4.0.0-beta.3...08cf54edd6e0789585c012bbd794fec00cb3af83) — 38 merged pull requests. This `v4.0.0` release PR is excluded from the range.

### Breaking API Changes

- [#2656](https://github.com/go-fries/fries/pull/2656) `refactor(support)!: extract pointer helpers`

### New Components

- [#2654](https://github.com/go-fries/fries/pull/2654) `feat(health): add health check component`
- [#2658](https://github.com/go-fries/fries/pull/2658) `feat(http): add JSON response component`

### Documentation and Repository Structure

- [#2688](https://github.com/go-fries/fries/pull/2688) `refactor: consolidate examples with component documentation`

### Dependencies

- [#2651](https://github.com/go-fries/fries/pull/2651) `fix(deps): update module github.com/aws/aws-sdk-go-v2/service/s3 to v1.105.2`
- [#2650](https://github.com/go-fries/fries/pull/2650) `fix(deps): update module github.com/aliyun/alibabacloud-oss-go-sdk-v2 to v1.5.3`
- [#2649](https://github.com/go-fries/fries/pull/2649) `chore(deps): update module github.com/dlclark/regexp2/v2 to v2.5.1`
- [#2653](https://github.com/go-fries/fries/pull/2653) `fix(deps): update golang.org/x to 764159d`
- [#2655](https://github.com/go-fries/fries/pull/2655) `chore(deps): update module github.com/dlclark/regexp2/v2 to v2.5.2`
- [#2660](https://github.com/go-fries/fries/pull/2660) `chore(deps): update module github.com/klauspost/compress to v1.19.1`
- [#2659](https://github.com/go-fries/fries/pull/2659) `chore(deps): update github.com/charmbracelet/ultraviolet digest to 7cc6674`
- [#2670](https://github.com/go-fries/fries/pull/2670) `chore(deps): update module github.com/prometheus/common to v0.70.1`
- [#2669](https://github.com/go-fries/fries/pull/2669) `fix(deps): update module github.com/cloudwego/eino to v0.9.13`
- [#2667](https://github.com/go-fries/fries/pull/2667) `fix(deps): update module github.com/rabbitmq/amqp091-go to v1.13.0`
- [#2666](https://github.com/go-fries/fries/pull/2666) `chore(deps): update module github.com/prometheus/client_golang to v1.24.0`
- [#2665](https://github.com/go-fries/fries/pull/2665) `chore(deps): update module github.com/nunnatsa/ginkgolinter to v0.23.1`
- [#2664](https://github.com/go-fries/fries/pull/2664) `chore(deps): update module github.com/go-logr/logr to v1.4.4`
- [#2668](https://github.com/go-fries/fries/pull/2668) `fix(deps): update aws-sdk-go-v2 monorepo`
- [#2662](https://github.com/go-fries/fries/pull/2662) `chore(deps): update googleapis to 0afa2a6`
- [#2663](https://github.com/go-fries/fries/pull/2663) `chore(deps): update module github.com/ebitengine/purego to v0.10.2`
- [#2674](https://github.com/go-fries/fries/pull/2674) `chore(deps): update module github.com/leodido/go-urn to v1.5.0`
- [#2672](https://github.com/go-fries/fries/pull/2672) `chore(deps): update module buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go to v1.36.11-20260722160903-4d94f3df3a7b.1`
- [#2671](https://github.com/go-fries/fries/pull/2671) `chore(deps): update module github.com/gabriel-vasile/mimetype to v1.4.14`
- [#2679](https://github.com/go-fries/fries/pull/2679) `chore(deps): update module github.com/mattn/go-isatty to v0.0.24`
- [#2678](https://github.com/go-fries/fries/pull/2678) `chore(deps): update module github.com/gabriel-vasile/mimetype to v1.4.15`
- [#2675](https://github.com/go-fries/fries/pull/2675) `chore(deps): update github.com/timakin/bodyclose digest to 857993a`
- [#2677](https://github.com/go-fries/fries/pull/2677) `chore(deps): update googleapis to 3fe39f3`
- [#2682](https://github.com/go-fries/fries/pull/2682) `chore(deps): update module github.com/go-git/go-billy/v5 to v5.9.1`
- [#2681](https://github.com/go-fries/fries/pull/2681) `chore(deps): update github.com/petermattis/goid digest to f64c70f`
- [#2680](https://github.com/go-fries/fries/pull/2680) `chore(deps): update module github.com/mattn/go-runewidth to v0.0.27`
- [#2683](https://github.com/go-fries/fries/pull/2683) `chore(deps): update module github.com/prometheus/client_golang to v1.24.1`
- [#2673](https://github.com/go-fries/fries/pull/2673) `chore(deps): update module go.opentelemetry.io/proto/otlp to v1.11.0`
- [#2687](https://github.com/go-fries/fries/pull/2687) `chore(deps): update module github.com/docker/go-connections to v0.8.0`
- [#2686](https://github.com/go-fries/fries/pull/2686) `chore(deps): update github.com/petermattis/goid digest to 500c67a`
- [#2685](https://github.com/go-fries/fries/pull/2685) `chore(deps): update module github.com/quic-go/quic-go to v0.61.0`
- [#2684](https://github.com/go-fries/fries/pull/2684) `chore(deps): update googleapis to b2f2020`
- [#2690](https://github.com/go-fries/fries/pull/2690) `chore(deps): update module go.yaml.in/yaml/v3 to v3.0.5`
- [#2689](https://github.com/go-fries/fries/pull/2689) `chore(deps): update module github.com/google/cel-go to v0.30.0`

## Migration Summary

- **Pointer helpers:** replace `support.Ptr(value)` with `ptr.Ptr(value)`; replace `support.Val(pointer)` with `ptr.Value(pointer)` when pointer presence matters or `ptr.Or(pointer, fallback)` when a fallback is required
- **Examples:** stop building the removed root example module paths and use the corresponding component README, GoDoc examples, or package-local integration tests instead; nested component examples remain available
- **Health and JSON responses:** no migration is required because both modules are additive and opt-in

Full API behavior, adoption guidance, and before/after examples are documented in the linked pull request descriptions.

## Notes

- This stable release introduces one breaking public API change since `v4.0.0-beta.3`: pointer helpers moved from `support/v4` to `ptr/v4`
- The removed root example modules were excluded from releases and exposed only executable `package main` programs; no releasable library component was removed
- Users upgrading from `v3` or an earlier `v4` prerelease should also review the [v4.0.0-beta.3 release PR](https://github.com/go-fries/fries/pull/2648) for the Lifecycle, Locker, Event, and Support migration guidance
- The release metadata changes in this PR do not otherwise alter runtime behavior