### PR TITLE
feat(webhook): add signing, verification, and HTTP delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ and internal development tools are not included.
 | Support | [`support`](https://pkg.go.dev/github.com/go-fries/fries/support/v4) | General-purpose helper types and value utilities. |
 | Timezone | [`timezone`](https://pkg.go.dev/github.com/go-fries/fries/timezone/v4) | Time zone propagation through application contexts. |
 | UDP | [`udp`](https://pkg.go.dev/github.com/go-fries/fries/udp/v4) | A lifecycle-aware UDP server. |
+| Webhook | [`webhook`](https://pkg.go.dev/github.com/go-fries/fries/webhook/v4) | Standard Webhooks HMAC-SHA256 signing and verification with timestamp validation and secret rotation. |
 | X | [`x/pagination`](https://pkg.go.dev/github.com/go-fries/fries/x/pagination/v4)<br>[`x/prints`](https://pkg.go.dev/github.com/go-fries/fries/x/prints/v4)<br>[`x/container`](https://pkg.go.dev/github.com/go-fries/fries/x/container/v4) | Experimental pagination, terminal output, and dependency container utilities without compatibility guarantees. |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ and internal development tools are not included.
 | Support | [`support`](https://pkg.go.dev/github.com/go-fries/fries/support/v4) | General-purpose helper types and value utilities. |
 | Timezone | [`timezone`](https://pkg.go.dev/github.com/go-fries/fries/timezone/v4) | Time zone propagation through application contexts. |
 | UDP | [`udp`](https://pkg.go.dev/github.com/go-fries/fries/udp/v4) | A lifecycle-aware UDP server. |
-| Webhook | [`webhook`](https://pkg.go.dev/github.com/go-fries/fries/webhook/v4) | Standard Webhooks HMAC-SHA256 signing and verification with timestamp validation and secret rotation. |
+| Webhook | [`webhook`](https://pkg.go.dev/github.com/go-fries/fries/webhook/v4)<br>[`webhook/sender`](https://pkg.go.dev/github.com/go-fries/fries/webhook/sender/v4) | Standard Webhooks signing, verification, secret rotation, and single-attempt HTTP delivery. |
 | X | [`x/pagination`](https://pkg.go.dev/github.com/go-fries/fries/x/pagination/v4)<br>[`x/prints`](https://pkg.go.dev/github.com/go-fries/fries/x/prints/v4)<br>[`x/container`](https://pkg.go.dev/github.com/go-fries/fries/x/container/v4) | Experimental pagination, terminal output, and dependency container utilities without compatibility guarantees. |
 
 ## Contributing

--- a/codecov.yml
+++ b/codecov.yml
@@ -97,6 +97,7 @@ fixes:
   - github.com/go-fries/fries/support/v4::support/
   - github.com/go-fries/fries/timezone/v4::timezone/
   - github.com/go-fries/fries/udp/v4::udp/
+  - github.com/go-fries/fries/webhook/v4::webhook/
   - github.com/go-fries/fries/x/container/v4::x/container/
   - github.com/go-fries/fries/x/pagination/v4::x/pagination/
   - github.com/go-fries/fries/x/prints/v4::x/prints/

--- a/codecov.yml
+++ b/codecov.yml
@@ -98,6 +98,7 @@ fixes:
   - github.com/go-fries/fries/timezone/v4::timezone/
   - github.com/go-fries/fries/udp/v4::udp/
   - github.com/go-fries/fries/webhook/v4::webhook/
+  - github.com/go-fries/fries/webhook/sender/v4::webhook/sender/
   - github.com/go-fries/fries/x/container/v4::x/container/
   - github.com/go-fries/fries/x/pagination/v4::x/pagination/
   - github.com/go-fries/fries/x/prints/v4::x/prints/

--- a/versions.yaml
+++ b/versions.yaml
@@ -162,6 +162,9 @@ module-sets:
       # UDP
       - github.com/go-fries/fries/udp/v4
 
+      # Webhook
+      - github.com/go-fries/fries/webhook/v4
+
       # X (Extra)
       - github.com/go-fries/fries/x/pagination/v4
       - github.com/go-fries/fries/x/prints/v4

--- a/versions.yaml
+++ b/versions.yaml
@@ -164,6 +164,7 @@ module-sets:
 
       # Webhook
       - github.com/go-fries/fries/webhook/v4
+      - github.com/go-fries/fries/webhook/sender/v4
 
       # X (Extra)
       - github.com/go-fries/fries/x/pagination/v4

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,219 @@
+# Webhook
+
+`webhook` signs and verifies HTTP webhook messages using the
+[Standard Webhooks](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md)
+HMAC-SHA256 scheme. It protects the message ID, timestamp, and exact payload
+bytes without binding applications to a particular HTTP framework.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/webhook/v4
+```
+
+## Secret
+
+Create a Secret from raw key bytes:
+
+```go
+// Example only. Load a random key from a secret manager in production.
+secret, err := webhook.NewSecret(
+	[]byte("0123456789abcdef0123456789abcdef"),
+)
+```
+
+The key must contain between 24 and 64 bytes. `NewSecret` copies the key and
+does not retain the caller's slice.
+
+Standard Webhooks secrets can also be loaded from configuration:
+
+```go
+secret, err := webhook.ParseSecret(os.Getenv("WEBHOOK_SECRET"))
+```
+
+The encoded value uses `whsec_<base64>` format. Generate and store signing
+keys with a cryptographically secure secret-management process. Use a
+different key for each receiving endpoint.
+
+## Sign a message
+
+Create and reuse one Signer:
+
+```go
+signer, err := webhook.NewSigner(secret)
+if err != nil {
+	return err
+}
+
+payload := []byte(`{"type":"order.created","data":{"id":"123"}}`)
+
+headers, err := signer.Sign("msg_123", payload)
+if err != nil {
+	return err
+}
+
+request, err := http.NewRequestWithContext(
+	ctx,
+	http.MethodPost,
+	endpoint,
+	bytes.NewReader(payload),
+)
+if err != nil {
+	return err
+}
+request.Header = headers.Clone()
+request.Header.Set("Content-Type", "application/json")
+```
+
+`Sign` returns `Webhook-Id`, `Webhook-Timestamp`, and `Webhook-Signature`.
+The message ID must contain only visible ASCII characters other than `.`.
+
+Sign the same payload bytes that will be sent. Formatting or marshaling the
+payload again after signing can invalidate the signature.
+
+## Verify a request
+
+Create and reuse one Verifier:
+
+```go
+verifier, err := webhook.NewVerifier(secret)
+if err != nil {
+	return err
+}
+```
+
+Read a bounded raw request body before decoding JSON:
+
+```go
+body, err := io.ReadAll(http.MaxBytesReader(w, request.Body, 1<<20))
+if err != nil {
+	http.Error(w, "invalid body", http.StatusBadRequest)
+	return
+}
+
+metadata, err := verifier.Verify(request.Header, body)
+if err != nil {
+	http.Error(w, "invalid webhook", http.StatusUnauthorized)
+	return
+}
+
+var event struct {
+	Type string `json:"type"`
+}
+if err := json.Unmarshal(body, &event); err != nil {
+	http.Error(w, "invalid payload", http.StatusBadRequest)
+	return
+}
+```
+
+Use the exact bytes read from the request. Do not decode and re-encode the
+payload before verification.
+
+The default timestamp tolerance is five minutes. Configure a different
+positive tolerance when required:
+
+```go
+verifier, err := webhook.NewVerifier(
+	secret,
+	webhook.WithTolerance(10*time.Minute),
+)
+```
+
+Requests older than the tolerance or too far in the future are rejected.
+Timestamp validation limits old replays, but it does not prevent a valid
+request from being delivered more than once within that window.
+
+## Prevent duplicate processing
+
+Use the authenticated message ID as part of a business idempotency key:
+
+```go
+metadata, err := verifier.Verify(request.Header, body)
+if err != nil {
+	return err
+}
+
+err = executor.Do(
+	request.Context(),
+	"webhook:orders:"+metadata.ID,
+	func(ctx context.Context) error {
+		return handleOrderEvent(ctx, body)
+	},
+)
+```
+
+Choose an idempotency TTL based on the business redelivery period. It does not
+need to equal the webhook timestamp tolerance.
+
+## Rotate secrets
+
+During a rotation, producers can sign with both the current and previous
+secrets:
+
+```go
+signer, err := webhook.NewSigner(
+	current,
+	webhook.WithAdditionalSigningSecrets(previous),
+)
+```
+
+Consumers can accept both:
+
+```go
+verifier, err := webhook.NewVerifier(
+	current,
+	webhook.WithAdditionalVerificationSecrets(previous),
+)
+```
+
+Remove the previous secret after deployments and outstanding deliveries have
+passed the agreed transition period.
+
+## Reliable delivery
+
+This package does not send HTTP requests, persist delivery records, or retry
+failed requests. For durable delivery, put the stable message ID and payload
+in a queue and sign them immediately before each HTTP attempt:
+
+```go
+func deliver(
+	ctx context.Context,
+	endpoint string,
+	messageID string,
+	payload []byte,
+) error {
+	headers, err := signer.Sign(messageID, payload)
+	if err != nil {
+		return err
+	}
+	return send(ctx, endpoint, headers, payload)
+}
+```
+
+Signing immediately before the request ensures a delayed or retried delivery
+receives a current timestamp.
+
+## Compatibility and boundaries
+
+The package implements the Standard Webhooks symmetric `v1` signature format:
+
+```text
+Webhook-Id: msg_123
+Webhook-Timestamp: 1700000000
+Webhook-Signature: v1,<base64-hmac-sha256>
+```
+
+GitHub, Stripe, Slack, and other providers use their own header and signature
+formats. Their deliveries cannot be verified directly with this package.
+
+`webhook` does not:
+
+- decode or define the payload schema;
+- guarantee exactly-once processing;
+- dispatch application events;
+- send, persist, or retry deliveries;
+- log payloads, secrets, or signatures;
+- provide framework middleware or provider-specific adapters.
+
+Signer and Verifier are safe for concurrent use and start no background
+goroutines.

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -171,27 +171,17 @@ passed the agreed transition period.
 
 ## Reliable delivery
 
-This package does not send HTTP requests, persist delivery records, or retry
-failed requests. For durable delivery, put the stable message ID and payload
-in a queue and sign them immediately before each HTTP attempt:
+Use `webhook/sender` when an application needs a standardized single HTTP
+delivery:
 
-```go
-func deliver(
-	ctx context.Context,
-	endpoint string,
-	messageID string,
-	payload []byte,
-) error {
-	headers, err := signer.Sign(messageID, payload)
-	if err != nil {
-		return err
-	}
-	return send(ctx, endpoint, headers, payload)
-}
+```bash
+go get github.com/go-fries/fries/webhook/sender/v4
 ```
 
-Signing immediately before the request ensures a delayed or retried delivery
-receives a current timestamp.
+The sender binds an endpoint to a Signer, applies safe HTTP defaults, signs
+immediately before each request, and returns the HTTP result. It does not
+persist or automatically retry deliveries. For durable delivery, invoke the
+sender from a queue handler using a stable message ID.
 
 ## Compatibility and boundaries
 
@@ -211,7 +201,7 @@ formats. Their deliveries cannot be verified directly with this package.
 - decode or define the payload schema;
 - guarantee exactly-once processing;
 - dispatch application events;
-- send, persist, or retry deliveries;
+- persist or retry deliveries;
 - log payloads, secrets, or signatures;
 - provide framework middleware or provider-specific adapters.
 

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -65,7 +65,7 @@ request.Header = headers.Clone()
 request.Header.Set("Content-Type", "application/json")
 ```
 
-`Sign` returns `Webhook-Id`, `Webhook-Timestamp`, and `Webhook-Signature`.
+`Sign` returns `webhook-id`, `webhook-timestamp`, and `webhook-signature`.
 The message ID must contain only visible ASCII characters other than `.`.
 
 Sign the same payload bytes that will be sent. Formatting or marshaling the
@@ -198,9 +198,9 @@ receives a current timestamp.
 The package implements the Standard Webhooks symmetric `v1` signature format:
 
 ```text
-Webhook-Id: msg_123
-Webhook-Timestamp: 1700000000
-Webhook-Signature: v1,<base64-hmac-sha256>
+webhook-id: msg_123
+webhook-timestamp: 1700000000
+webhook-signature: v1,<base64-hmac-sha256>
 ```
 
 GitHub, Stripe, Slack, and other providers use their own header and signature

--- a/webhook/config.go
+++ b/webhook/config.go
@@ -1,0 +1,131 @@
+package webhook
+
+import (
+	"fmt"
+	"time"
+)
+
+const defaultTolerance = 5 * time.Minute
+
+type signerConfig struct {
+	secrets [][]byte
+}
+
+// SignerOption configures a [Signer].
+type SignerOption interface {
+	applySigner(*signerConfig) error
+}
+
+type signerOptionFunc func(*signerConfig) error
+
+func (f signerOptionFunc) applySigner(c *signerConfig) error {
+	return f(c)
+}
+
+// WithAdditionalSigningSecrets adds secrets whose signatures are emitted
+// after the primary signature. This supports zero-downtime secret rotation.
+func WithAdditionalSigningSecrets(secrets ...Secret) SignerOption {
+	return signerOptionFunc(func(c *signerConfig) error {
+		for _, secret := range secrets {
+			if err := validateSecret(secret); err != nil {
+				return err
+			}
+			c.secrets = append(c.secrets, bytesClone(secret.key))
+		}
+		return nil
+	})
+}
+
+func newSignerConfig(
+	secret Secret,
+	options ...SignerOption,
+) (signerConfig, error) {
+	if err := validateSecret(secret); err != nil {
+		return signerConfig{}, err
+	}
+
+	c := signerConfig{
+		secrets: [][]byte{bytesClone(secret.key)},
+	}
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option.applySigner(&c); err != nil {
+			return signerConfig{}, err
+		}
+	}
+	return c, nil
+}
+
+type verifierConfig struct {
+	secrets   [][]byte
+	tolerance time.Duration
+}
+
+// VerifierOption configures a [Verifier].
+type VerifierOption interface {
+	applyVerifier(*verifierConfig) error
+}
+
+type verifierOptionFunc func(*verifierConfig) error
+
+func (f verifierOptionFunc) applyVerifier(c *verifierConfig) error {
+	return f(c)
+}
+
+// WithTolerance sets the maximum allowed difference between the message
+// timestamp and the current time.
+//
+// The tolerance must be positive.
+func WithTolerance(tolerance time.Duration) VerifierOption {
+	return verifierOptionFunc(func(c *verifierConfig) error {
+		if tolerance <= 0 {
+			return fmt.Errorf(
+				"%w: must be greater than zero",
+				ErrInvalidTolerance,
+			)
+		}
+		c.tolerance = tolerance
+		return nil
+	})
+}
+
+// WithAdditionalVerificationSecrets adds secrets accepted in addition to the
+// primary secret. This supports zero-downtime secret rotation.
+func WithAdditionalVerificationSecrets(
+	secrets ...Secret,
+) VerifierOption {
+	return verifierOptionFunc(func(c *verifierConfig) error {
+		for _, secret := range secrets {
+			if err := validateSecret(secret); err != nil {
+				return err
+			}
+			c.secrets = append(c.secrets, bytesClone(secret.key))
+		}
+		return nil
+	})
+}
+
+func newVerifierConfig(
+	secret Secret,
+	options ...VerifierOption,
+) (verifierConfig, error) {
+	if err := validateSecret(secret); err != nil {
+		return verifierConfig{}, err
+	}
+
+	c := verifierConfig{
+		secrets:   [][]byte{bytesClone(secret.key)},
+		tolerance: defaultTolerance,
+	}
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option.applyVerifier(&c); err != nil {
+			return verifierConfig{}, err
+		}
+	}
+	return c, nil
+}

--- a/webhook/config_test.go
+++ b/webhook/config_test.go
@@ -1,0 +1,107 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSignerConfiguration(t *testing.T) {
+	t.Parallel()
+
+	primary := mustSecret(t, 0)
+	additional := mustSecret(t, 1)
+
+	signer, err := NewSigner(
+		primary,
+		nil,
+		WithAdditionalSigningSecrets(additional),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, signer.secrets, 2)
+	assert.Equal(t, primary.key, signer.secrets[0])
+	assert.Equal(t, additional.key, signer.secrets[1])
+
+	primary.key[0] = 9
+	additional.key[0] = 9
+	assert.Equal(t, byte(0), signer.secrets[0][0])
+	assert.Equal(t, byte(1), signer.secrets[1][0])
+}
+
+func TestNewSignerRejectsInvalidSecret(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewSigner(Secret{})
+	assert.ErrorIs(t, err, ErrInvalidSecret)
+
+	_, err = NewSigner(
+		mustSecret(t, 0),
+		WithAdditionalSigningSecrets(Secret{}),
+	)
+	assert.ErrorIs(t, err, ErrInvalidSecret)
+}
+
+func TestNewVerifierConfiguration(t *testing.T) {
+	t.Parallel()
+
+	primary := mustSecret(t, 0)
+	additional := mustSecret(t, 1)
+
+	verifier, err := NewVerifier(
+		primary,
+		nil,
+		WithTolerance(time.Minute),
+		WithAdditionalVerificationSecrets(additional),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Minute, verifier.tolerance)
+	require.Len(t, verifier.secrets, 2)
+	assert.Equal(t, primary.key, verifier.secrets[0])
+	assert.Equal(t, additional.key, verifier.secrets[1])
+
+	primary.key[0] = 9
+	additional.key[0] = 9
+	assert.Equal(t, byte(0), verifier.secrets[0][0])
+	assert.Equal(t, byte(1), verifier.secrets[1][0])
+}
+
+func TestNewVerifierRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewVerifier(Secret{})
+	assert.ErrorIs(t, err, ErrInvalidSecret)
+
+	_, err = NewVerifier(
+		mustSecret(t, 0),
+		WithAdditionalVerificationSecrets(Secret{}),
+	)
+	assert.ErrorIs(t, err, ErrInvalidSecret)
+
+	for _, tolerance := range []time.Duration{0, -time.Second} {
+		_, err = NewVerifier(
+			mustSecret(t, 0),
+			WithTolerance(tolerance),
+		)
+		assert.ErrorIs(t, err, ErrInvalidTolerance)
+	}
+}
+
+func mustSecret(t testing.TB, value byte) Secret {
+	t.Helper()
+
+	secret, err := NewSecret(bytesOf(value, 32))
+	require.NoError(t, err)
+	return secret
+}
+
+func bytesOf(value byte, length int) []byte {
+	result := make([]byte, length)
+	for index := range result {
+		result[index] = value
+	}
+	return result
+}

--- a/webhook/doc.go
+++ b/webhook/doc.go
@@ -1,0 +1,8 @@
+// Package webhook signs and verifies HTTP webhook messages using the
+// Standard Webhooks HMAC-SHA256 scheme.
+//
+// A [Signer] protects the message ID, timestamp, and exact payload bytes. A
+// [Verifier] authenticates those values and enforces a timestamp tolerance.
+// The package does not send requests, retry deliveries, decode payloads, or
+// prevent duplicate business execution.
+package webhook

--- a/webhook/errors.go
+++ b/webhook/errors.go
@@ -1,0 +1,27 @@
+package webhook
+
+import "errors"
+
+var (
+	// ErrInvalidSecret indicates that a signing secret is malformed or does
+	// not meet the required security length.
+	ErrInvalidSecret = errors.New("webhook: invalid secret")
+	// ErrInvalidTolerance indicates that a verification tolerance is not
+	// positive.
+	ErrInvalidTolerance = errors.New("webhook: invalid tolerance")
+	// ErrInvalidMessageID indicates that a message ID cannot be signed or
+	// verified.
+	ErrInvalidMessageID = errors.New("webhook: invalid message id")
+	// ErrMissingHeader indicates that a required Webhook header is absent.
+	ErrMissingHeader = errors.New("webhook: missing required header")
+	// ErrInvalidTimestamp indicates that Webhook-Timestamp is malformed.
+	ErrInvalidTimestamp = errors.New("webhook: invalid timestamp")
+	// ErrTimestampOutsideTolerance indicates that the message timestamp is too
+	// old or too far in the future.
+	ErrTimestampOutsideTolerance = errors.New(
+		"webhook: timestamp outside tolerance",
+	)
+	// ErrInvalidSignature indicates that no supported signature matches the
+	// message.
+	ErrInvalidSignature = errors.New("webhook: invalid signature")
+)

--- a/webhook/errors.go
+++ b/webhook/errors.go
@@ -14,7 +14,7 @@ var (
 	ErrInvalidMessageID = errors.New("webhook: invalid message id")
 	// ErrMissingHeader indicates that a required Webhook header is absent.
 	ErrMissingHeader = errors.New("webhook: missing required header")
-	// ErrInvalidTimestamp indicates that Webhook-Timestamp is malformed.
+	// ErrInvalidTimestamp indicates that webhook-timestamp is malformed.
 	ErrInvalidTimestamp = errors.New("webhook: invalid timestamp")
 	// ErrTimestampOutsideTolerance indicates that the message timestamp is too
 	// old or too far in the future.

--- a/webhook/example_test.go
+++ b/webhook/example_test.go
@@ -1,0 +1,37 @@
+package webhook_test
+
+import (
+	"fmt"
+
+	"github.com/go-fries/fries/webhook/v4"
+)
+
+func Example() {
+	secret, err := webhook.NewSecret(
+		[]byte("01234567890123456789012345678901"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	signer, err := webhook.NewSigner(secret)
+	if err != nil {
+		panic(err)
+	}
+	verifier, err := webhook.NewVerifier(secret)
+	if err != nil {
+		panic(err)
+	}
+
+	payload := []byte(`{"type":"order.created"}`)
+	headers, err := signer.Sign("msg_123", payload)
+	if err != nil {
+		panic(err)
+	}
+
+	metadata, err := verifier.Verify(headers, payload)
+	fmt.Println(metadata.ID, err)
+
+	// Output:
+	// msg_123 <nil>
+}

--- a/webhook/go.mod
+++ b/webhook/go.mod
@@ -1,0 +1,11 @@
+module github.com/go-fries/fries/webhook/v4
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/webhook/go.sum
+++ b/webhook/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/webhook/secret.go
+++ b/webhook/secret.go
@@ -1,0 +1,76 @@
+package webhook
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+const (
+	secretPrefix    = "whsec_"
+	minSecretLength = 24
+	maxSecretLength = 64
+)
+
+// Secret contains an HMAC signing key. Its zero value is invalid.
+//
+// Secret intentionally provides no string or marshaling method that could
+// expose its key material.
+type Secret struct {
+	key []byte
+}
+
+// NewSecret creates a Secret from raw key bytes.
+//
+// The key must contain between 24 and 64 bytes. NewSecret copies key and does
+// not retain the caller's slice.
+func NewSecret(key []byte) (Secret, error) {
+	if err := validateSecretLength(len(key)); err != nil {
+		return Secret{}, err
+	}
+
+	return Secret{key: bytesClone(key)}, nil
+}
+
+// ParseSecret parses a Standard Webhooks secret in whsec_<base64> format.
+func ParseSecret(value string) (Secret, error) {
+	encoded, ok := strings.CutPrefix(value, secretPrefix)
+	if !ok || encoded == "" {
+		return Secret{}, fmt.Errorf(
+			"%w: expected %s<base64>",
+			ErrInvalidSecret,
+			secretPrefix,
+		)
+	}
+
+	key, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return Secret{}, fmt.Errorf(
+			"%w: decode base64: %v",
+			ErrInvalidSecret,
+			err,
+		)
+	}
+
+	return NewSecret(key)
+}
+
+func validateSecret(secret Secret) error {
+	return validateSecretLength(len(secret.key))
+}
+
+func validateSecretLength(length int) error {
+	if length < minSecretLength || length > maxSecretLength {
+		return fmt.Errorf(
+			"%w: key length must be between %d and %d bytes",
+			ErrInvalidSecret,
+			minSecretLength,
+			maxSecretLength,
+		)
+	}
+	return nil
+}
+
+func bytesClone(value []byte) []byte {
+	return append([]byte(nil), value...)
+}

--- a/webhook/secret_test.go
+++ b/webhook/secret_test.go
@@ -1,0 +1,100 @@
+package webhook
+
+import (
+	"encoding/base64"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSecret(t *testing.T) {
+	t.Parallel()
+
+	for _, length := range []int{24, 32, 64} {
+		t.Run(strconv.Itoa(length), func(t *testing.T) {
+			t.Parallel()
+
+			key := make([]byte, length)
+			secret, err := NewSecret(key)
+
+			require.NoError(t, err)
+			assert.Len(t, secret.key, length)
+		})
+	}
+}
+
+func TestNewSecretRejectsInvalidLength(t *testing.T) {
+	t.Parallel()
+
+	for _, length := range []int{0, 23, 65} {
+		t.Run(strconv.Itoa(length), func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewSecret(make([]byte, length))
+
+			assert.ErrorIs(t, err, ErrInvalidSecret)
+		})
+	}
+}
+
+func TestNewSecretCopiesKey(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("01234567890123456789012345678901")
+	secret, err := NewSecret(key)
+	require.NoError(t, err)
+
+	key[0] = 'x'
+
+	assert.Equal(t, byte('0'), secret.key[0])
+}
+
+func TestParseSecret(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("01234567890123456789012345678901")
+	value := secretPrefix + base64.StdEncoding.EncodeToString(key)
+
+	secret, err := ParseSecret(value)
+
+	require.NoError(t, err)
+	assert.Equal(t, key, secret.key)
+}
+
+func TestParseSecretRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"empty":          "",
+		"missing prefix": base64.StdEncoding.EncodeToString(make([]byte, 32)),
+		"empty key":      secretPrefix,
+		"invalid base64": secretPrefix + "***",
+		"short key": secretPrefix +
+			base64.StdEncoding.EncodeToString(make([]byte, 23)),
+	}
+
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseSecret(value)
+
+			assert.ErrorIs(t, err, ErrInvalidSecret)
+		})
+	}
+}
+
+func FuzzParseSecret(f *testing.F) {
+	f.Add("whsec_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		secret, err := ParseSecret(value)
+		if err == nil {
+			assert.GreaterOrEqual(t, len(secret.key), minSecretLength)
+			assert.LessOrEqual(t, len(secret.key), maxSecretLength)
+		}
+	})
+}

--- a/webhook/sender/README.md
+++ b/webhook/sender/README.md
@@ -1,0 +1,170 @@
+# Webhook Sender
+
+`webhook/sender` performs one signed HTTP POST delivery to a configured
+endpoint. It combines `webhook.Signer` with safe HTTP defaults while leaving
+durable retries and delivery settlement to the application or queue.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/webhook/v4
+go get github.com/go-fries/fries/webhook/sender/v4
+```
+
+## Usage
+
+Bind one endpoint to its signing secret:
+
+```go
+secret, err := webhook.ParseSecret(os.Getenv("WEBHOOK_SECRET"))
+if err != nil {
+	return err
+}
+signer, err := webhook.NewSigner(secret)
+if err != nil {
+	return err
+}
+outbound, err := sender.New(
+	"https://customer.example.com/webhooks",
+	signer,
+)
+if err != nil {
+	return err
+}
+```
+
+Send one message:
+
+```go
+result, err := outbound.Send(ctx, sender.Message{
+	ID:      event.ID,
+	Payload: payload,
+	Header: http.Header{
+		"content-type": {"application/json"},
+	},
+})
+if err != nil {
+	return err
+}
+if !result.Successful() {
+	return fmt.Errorf("webhook returned HTTP %d", result.StatusCode)
+}
+```
+
+The message ID should remain stable across retries. Sender generates a current
+timestamp and signature immediately before every HTTP attempt.
+
+## HTTP behavior
+
+Sender:
+
+- performs exactly one HTTP POST per `Send` call;
+- requires HTTPS by default;
+- never follows redirects;
+- uses a 30-second total request timeout by default;
+- defaults Content-Type to `application/json`;
+- overwrites all Standard Webhooks signature headers;
+- drains at most 64 KiB of the response body and closes it;
+- returns response status, headers, and a parsed `Retry-After` delay.
+
+Configure a custom HTTP client and timeout when required:
+
+```go
+outbound, err := sender.New(
+	endpoint,
+	signer,
+	sender.WithHTTPClient(client),
+	sender.WithTimeout(20*time.Second),
+)
+```
+
+The supplied client is copied. Sender disables redirects on the copy and does
+not modify the original client. A positive client timeout is preserved unless
+`WithTimeout` overrides it; a client without a timeout receives the 30-second
+default.
+
+HTTP can be enabled explicitly for trusted development or private-network
+environments:
+
+```go
+outbound, err := sender.New(
+	"http://localhost:8080/webhook",
+	signer,
+	sender.WithInsecureHTTP(),
+)
+```
+
+## Result and retries
+
+Transport failures, Context cancellation, and request construction failures
+are returned as errors. An HTTP response is returned as a `Result`, including
+4xx and 5xx responses:
+
+```go
+result, err := outbound.Send(ctx, message)
+if err != nil {
+	return err
+}
+
+switch {
+case result.Successful():
+	return nil
+case result.StatusCode == http.StatusGone:
+	return queue.DeadLetter("webhook endpoint is gone")
+case result.RetryAfter > 0:
+	return queue.RetryAfter(result.RetryAfter)
+case result.StatusCode == http.StatusTooManyRequests:
+	return errors.New("webhook rate limited")
+case result.StatusCode >= 500:
+	return errors.New("webhook server error")
+default:
+	return queue.DeadLetter("webhook rejected")
+}
+```
+
+`webhook/sender` does not depend on `queue`; the example shows how an
+application may map delivery results to its own queue policy.
+
+Do not assume a transport error means the endpoint did not process the
+request. A connection may fail after the receiver committed the operation.
+Retries can therefore deliver the same message more than once, and receivers
+should use `webhook-id` as an idempotency key.
+
+## Endpoint security
+
+Sender rejects malformed endpoints, URL credentials, fragments, unsupported
+schemes, and HTTP unless it is explicitly enabled. It also supports
+application-specific validation:
+
+```go
+outbound, err := sender.New(
+	endpoint,
+	signer,
+	sender.WithEndpointValidator(func(
+		ctx context.Context,
+		endpoint *url.URL,
+	) error {
+		if !allowedHosts[endpoint.Hostname()] {
+			return ErrEndpointNotAllowed
+		}
+		return nil
+	}),
+)
+```
+
+URL validation alone is not complete SSRF protection. When customers control
+endpoints, use an outbound proxy or network policy that prevents access to
+loopback addresses, private networks, link-local addresses, and cloud metadata
+services. DNS must be checked at connection time to protect against rebinding.
+
+## Boundaries
+
+Sender does not:
+
+- persist messages or delivery attempts;
+- automatically retry failures;
+- decide whether a status code is retryable;
+- manage endpoint lifecycle or disable failed endpoints;
+- retain or expose response bodies;
+- provide complete SSRF protection;
+- guarantee exactly-once delivery.

--- a/webhook/sender/README.md
+++ b/webhook/sender/README.md
@@ -46,6 +46,8 @@ result, err := outbound.Send(ctx, sender.Message{
 if err != nil {
 	return err
 }
+defer result.Body.Close()
+
 if !result.Successful() {
 	return fmt.Errorf("webhook returned HTTP %d", result.StatusCode)
 }
@@ -64,8 +66,24 @@ Sender:
 - uses a 30-second total request timeout by default;
 - defaults Content-Type to `application/json`;
 - overwrites all Standard Webhooks signature headers;
-- drains at most 64 KiB of the response body and closes it;
-- returns response status, headers, and a parsed `Retry-After` delay.
+- returns the underlying `http.Response` and a parsed `Retry-After` delay.
+
+The returned `sender.Response` embeds `*http.Response`, so standard response
+fields and methods remain available:
+
+```go
+response, err := outbound.Send(ctx, message)
+if err != nil {
+	return err
+}
+defer response.Body.Close()
+
+cookies := response.Cookies()
+location, err := response.Location()
+```
+
+The caller owns the response Body and must close it. Apply an appropriate size
+limit before reading responses from endpoints that are not fully trusted.
 
 Configure a custom HTTP client and timeout when required:
 
@@ -94,10 +112,10 @@ outbound, err := sender.New(
 )
 ```
 
-## Result and retries
+## Response and retries
 
-Transport failures, Context cancellation, and request construction failures
-are returned as errors. An HTTP response is returned as a `Result`, including
+Transport failures, context cancellation, and request construction failures
+are returned as errors. An HTTP response is returned as a `Response`, including
 4xx and 5xx responses:
 
 ```go
@@ -105,6 +123,7 @@ result, err := outbound.Send(ctx, message)
 if err != nil {
 	return err
 }
+defer result.Body.Close()
 
 switch {
 case result.Successful():

--- a/webhook/sender/config.go
+++ b/webhook/sender/config.go
@@ -1,0 +1,105 @@
+package sender
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const defaultTimeout = 30 * time.Second
+
+type config struct {
+	client     *http.Client
+	timeout    time.Duration
+	allowHTTP  bool
+	validators []EndpointValidator
+}
+
+// Option configures a [Sender].
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+
+// WithHTTPClient sets the HTTP client used for delivery. The Sender copies the
+// client and disables redirects without modifying the supplied value.
+//
+// A nil client leaves the current client unchanged.
+func WithHTTPClient(client *http.Client) Option {
+	return optionFunc(func(c *config) {
+		if client != nil {
+			c.client = client
+		}
+	})
+}
+
+// WithTimeout sets the total HTTP request timeout. Non-positive values are
+// ignored.
+func WithTimeout(timeout time.Duration) Option {
+	return optionFunc(func(c *config) {
+		if timeout > 0 {
+			c.timeout = timeout
+		}
+	})
+}
+
+// WithInsecureHTTP allows an endpoint to use HTTP instead of HTTPS.
+//
+// Use this only for trusted development or private-network endpoints whose
+// transport security is provided elsewhere.
+func WithInsecureHTTP() Option {
+	return optionFunc(func(c *config) {
+		c.allowHTTP = true
+	})
+}
+
+// EndpointValidator validates an endpoint immediately before each delivery.
+//
+// A validator may enforce an application-specific hostname allowlist or other
+// outbound policy. It must be safe for concurrent use.
+type EndpointValidator func(context.Context, *url.URL) error
+
+// WithEndpointValidator adds an endpoint validator. Nil validators are
+// ignored.
+func WithEndpointValidator(validator EndpointValidator) Option {
+	return optionFunc(func(c *config) {
+		if validator != nil {
+			c.validators = append(c.validators, validator)
+		}
+	})
+}
+
+func newConfig(options ...Option) config {
+	c := config{
+		client: &http.Client{},
+	}
+	for _, option := range options {
+		if option != nil {
+			option.apply(&c)
+		}
+	}
+	return c
+}
+
+func (c config) newHTTPClient() *http.Client {
+	client := *c.client
+	switch {
+	case c.timeout > 0:
+		client.Timeout = c.timeout
+	case client.Timeout <= 0:
+		client.Timeout = defaultTimeout
+	}
+	client.CheckRedirect = func(
+		_ *http.Request,
+		_ []*http.Request,
+	) error {
+		return http.ErrUseLastResponse
+	}
+	return &client
+}

--- a/webhook/sender/config_test.go
+++ b/webhook/sender/config_test.go
@@ -1,0 +1,52 @@
+package sender
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfig(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Timeout: time.Second}
+	validator := EndpointValidator(func(context.Context, *url.URL) error {
+		return nil
+	})
+	c := newConfig(
+		nil,
+		WithHTTPClient(nil),
+		WithTimeout(0),
+		WithEndpointValidator(nil),
+		WithHTTPClient(client),
+		WithTimeout(time.Minute),
+		WithEndpointValidator(validator),
+		WithInsecureHTTP(),
+	)
+
+	assert.Same(t, client, c.client)
+	assert.Equal(t, time.Minute, c.timeout)
+	assert.True(t, c.allowHTTP)
+	assert.Len(t, c.validators, 1)
+
+	actual := c.newHTTPClient()
+	assert.NotSame(t, client, actual)
+	assert.Equal(t, time.Minute, actual.Timeout)
+	assert.NotNil(t, actual.CheckRedirect)
+	assert.Equal(
+		t,
+		http.ErrUseLastResponse,
+		actual.CheckRedirect(nil, nil),
+	)
+	assert.Nil(t, client.CheckRedirect)
+
+	preserved := newConfig(WithHTTPClient(client)).newHTTPClient()
+	assert.Equal(t, time.Second, preserved.Timeout)
+
+	defaulted := newConfig().newHTTPClient()
+	assert.Equal(t, defaultTimeout, defaulted.Timeout)
+}

--- a/webhook/sender/doc.go
+++ b/webhook/sender/doc.go
@@ -1,0 +1,6 @@
+// Package sender delivers signed webhook messages over HTTP.
+//
+// A [Sender] binds one endpoint to one webhook Signer and performs one HTTP
+// request per [Sender.Send] call. It does not persist messages, retry failed
+// deliveries, or classify non-success responses as errors.
+package sender

--- a/webhook/sender/errors.go
+++ b/webhook/sender/errors.go
@@ -1,0 +1,16 @@
+package sender
+
+import "errors"
+
+var (
+	// ErrInvalidContext indicates that a required context is nil.
+	ErrInvalidContext = errors.New("webhook/sender: invalid context")
+	// ErrInvalidEndpoint indicates that an endpoint URL is malformed or
+	// unsupported.
+	ErrInvalidEndpoint = errors.New("webhook/sender: invalid endpoint")
+	// ErrInsecureEndpoint indicates that an HTTP endpoint was supplied without
+	// explicitly enabling insecure HTTP.
+	ErrInsecureEndpoint = errors.New("webhook/sender: insecure endpoint")
+	// ErrNilSigner indicates that a nil webhook Signer was supplied to [New].
+	ErrNilSigner = errors.New("webhook/sender: nil signer")
+)

--- a/webhook/sender/example_test.go
+++ b/webhook/sender/example_test.go
@@ -44,6 +44,12 @@ func ExampleSender_Send() {
 		ID:      "msg_123",
 		Payload: []byte(`{"type":"order.created"}`),
 	})
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = result.Body.Close()
+	}()
 	fmt.Println(result.StatusCode, err)
 
 	// Output:

--- a/webhook/sender/example_test.go
+++ b/webhook/sender/example_test.go
@@ -1,0 +1,59 @@
+package sender_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-fries/fries/webhook/sender/v4"
+	"github.com/go-fries/fries/webhook/v4"
+)
+
+func ExampleSender_Send() {
+	secret, err := webhook.NewSecret(
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+	if err != nil {
+		panic(err)
+	}
+	signer, err := webhook.NewSigner(secret)
+	if err != nil {
+		panic(err)
+	}
+	client := &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+	}
+	value, err := sender.New(
+		"https://customer.example.com/webhooks",
+		signer,
+		sender.WithHTTPClient(client),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	result, err := value.Send(context.Background(), sender.Message{
+		ID:      "msg_123",
+		Payload: []byte(`{"type":"order.created"}`),
+	})
+	fmt.Println(result.StatusCode, err)
+
+	// Output:
+	// 204 <nil>
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	return f(request)
+}

--- a/webhook/sender/go.mod
+++ b/webhook/sender/go.mod
@@ -1,0 +1,16 @@
+module github.com/go-fries/fries/webhook/sender/v4
+
+go 1.25.0
+
+require (
+	github.com/go-fries/fries/webhook/v4 v4.0.0
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace github.com/go-fries/fries/webhook/v4 => ../

--- a/webhook/sender/go.sum
+++ b/webhook/sender/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/webhook/sender/sender.go
+++ b/webhook/sender/sender.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -14,8 +13,6 @@ import (
 
 	"github.com/go-fries/fries/webhook/v4"
 )
-
-const maxResponseBodyDrain = 64 << 10
 
 // Message contains one outbound webhook message.
 type Message struct {
@@ -30,20 +27,22 @@ type Message struct {
 	Header http.Header
 }
 
-// Result describes an HTTP response received from a webhook endpoint.
-type Result struct {
-	// StatusCode is the response HTTP status code.
-	StatusCode int
-	// Header is a copy of the response headers.
-	Header http.Header
+// Response contains an HTTP response received from a webhook endpoint.
+//
+// Callers must close Body when Response is non-nil.
+type Response struct {
+	*http.Response
+
 	// RetryAfter is the delay requested by a valid Retry-After header. It is
 	// zero when the header is absent, invalid, or already elapsed.
 	RetryAfter time.Duration
 }
 
 // Successful reports whether StatusCode is between 200 and 299.
-func (r Result) Successful() bool {
-	return r.StatusCode >= http.StatusOK &&
+func (r *Response) Successful() bool {
+	return r != nil &&
+		r.Response != nil &&
+		r.StatusCode >= http.StatusOK &&
 		r.StatusCode < http.StatusMultipleChoices
 }
 
@@ -92,20 +91,21 @@ func New(
 // Send signs message and performs one HTTP POST request.
 //
 // Transport failures are returned as errors. HTTP responses, including 4xx
-// and 5xx responses, are returned as Result values with a nil error. Send does
-// not retain or modify message. A nil ctx returns [ErrInvalidContext].
+// and 5xx responses, are returned as Response values with a nil error. The
+// caller must close Response.Body. Send does not retain or modify message. A
+// nil ctx returns [ErrInvalidContext].
 func (s *Sender) Send(
 	ctx context.Context,
 	message Message,
-) (Result, error) {
+) (*Response, error) {
 	if ctx == nil {
-		return Result{}, ErrInvalidContext
+		return nil, ErrInvalidContext
 	}
 
 	for _, validator := range s.validators {
 		endpoint := s.endpoint
 		if err := validator(ctx, &endpoint); err != nil {
-			return Result{}, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"%w: endpoint validator: %w",
 				ErrInvalidEndpoint,
 				err,
@@ -115,7 +115,7 @@ func (s *Sender) Send(
 
 	signatureHeaders, err := s.signer.Sign(message.ID, message.Payload)
 	if err != nil {
-		return Result{}, err
+		return nil, err
 	}
 
 	request, err := http.NewRequestWithContext(
@@ -125,7 +125,7 @@ func (s *Sender) Send(
 		bytes.NewReader(message.Payload),
 	)
 	if err != nil {
-		return Result{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"webhook/sender: create request: %w",
 			err,
 		)
@@ -140,25 +140,18 @@ func (s *Sender) Send(
 		request.Header[name] = append([]string(nil), values...)
 	}
 
+	//nolint:bodyclose // Response ownership is transferred to the caller.
 	response, err := s.client.Do(request)
 	if err != nil {
-		return Result{}, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"webhook/sender: send request: %w",
 			err,
 		)
 	}
-	if response.Body != nil {
-		defer func() {
-			_ = response.Body.Close()
-		}()
-		drainResponseBody(response.Body)
-	}
 
-	headers := cloneHeader(response.Header)
-	return Result{
-		StatusCode: response.StatusCode,
-		Header:     headers,
-		RetryAfter: parseRetryAfter(headers.Get("retry-after"), s.now()),
+	return &Response{
+		Response:   response,
+		RetryAfter: parseRetryAfter(response.Header.Get("retry-after"), s.now()),
 	}, nil
 }
 
@@ -197,13 +190,6 @@ func cloneHeader(source http.Header) http.Header {
 		target[canonicalName] = append(target[canonicalName], values...)
 	}
 	return target
-}
-
-func drainResponseBody(body io.Reader) {
-	if body == nil {
-		return
-	}
-	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxResponseBodyDrain))
 }
 
 func parseRetryAfter(value string, now time.Time) time.Duration {

--- a/webhook/sender/sender.go
+++ b/webhook/sender/sender.go
@@ -130,6 +130,10 @@ func (s *Sender) Send(
 			err,
 		)
 	}
+	// Prevent net/http from replaying a POST after a possible delivery. In
+	// particular, Transport treats requests with an idempotency header and a
+	// GetBody function as replayable.
+	request.GetBody = nil
 
 	request.Header = cloneHeader(message.Header)
 	if request.Header.Get("content-type") == "" {
@@ -166,6 +170,11 @@ func parseEndpoint(value string, allowHTTP bool) (*url.URL, error) {
 		endpoint.Fragment != "" ||
 		endpoint.Opaque != "" {
 		return nil, ErrInvalidEndpoint
+	}
+	if port := endpoint.Port(); port != "" {
+		if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+			return nil, ErrInvalidEndpoint
+		}
 	}
 
 	scheme := strings.ToLower(endpoint.Scheme)

--- a/webhook/sender/sender.go
+++ b/webhook/sender/sender.go
@@ -1,0 +1,232 @@
+package sender
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-fries/fries/webhook/v4"
+)
+
+const maxResponseBodyDrain = 64 << 10
+
+// Message contains one outbound webhook message.
+type Message struct {
+	// ID is the stable message ID used across delivery attempts.
+	ID string
+	// Payload contains the exact bytes to sign and send. The caller must not
+	// modify Payload until Send returns.
+	Payload []byte
+	// Header contains additional request headers. Sender clones Header and
+	// overwrites the Standard Webhooks signature headers. The caller must not
+	// modify Header until Send returns.
+	Header http.Header
+}
+
+// Result describes an HTTP response received from a webhook endpoint.
+type Result struct {
+	// StatusCode is the response HTTP status code.
+	StatusCode int
+	// Header is a copy of the response headers.
+	Header http.Header
+	// RetryAfter is the delay requested by a valid Retry-After header. It is
+	// zero when the header is absent, invalid, or already elapsed.
+	RetryAfter time.Duration
+}
+
+// Successful reports whether StatusCode is between 200 and 299.
+func (r Result) Successful() bool {
+	return r.StatusCode >= http.StatusOK &&
+		r.StatusCode < http.StatusMultipleChoices
+}
+
+// Sender performs signed HTTP webhook deliveries to one endpoint.
+//
+// A Sender is safe for concurrent use. Endpoint validators must also be safe
+// for concurrent use.
+type Sender struct {
+	endpoint   url.URL
+	signer     *webhook.Signer
+	client     *http.Client
+	validators []EndpointValidator
+	now        func() time.Time
+}
+
+// New creates a Sender bound to endpoint and signer.
+//
+// HTTPS is required unless [WithInsecureHTTP] is supplied. Redirects are never
+// followed. A nil signer returns [ErrNilSigner]. Invalid and insecure
+// endpoints return [ErrInvalidEndpoint] and [ErrInsecureEndpoint],
+// respectively.
+func New(
+	endpoint string,
+	signer *webhook.Signer,
+	options ...Option,
+) (*Sender, error) {
+	if signer == nil {
+		return nil, ErrNilSigner
+	}
+
+	c := newConfig(options...)
+	parsed, err := parseEndpoint(endpoint, c.allowHTTP)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Sender{
+		endpoint:   *parsed,
+		signer:     signer,
+		client:     c.newHTTPClient(),
+		validators: append([]EndpointValidator(nil), c.validators...),
+		now:        time.Now,
+	}, nil
+}
+
+// Send signs message and performs one HTTP POST request.
+//
+// Transport failures are returned as errors. HTTP responses, including 4xx
+// and 5xx responses, are returned as Result values with a nil error. Send does
+// not retain or modify message. A nil ctx returns [ErrInvalidContext].
+func (s *Sender) Send(
+	ctx context.Context,
+	message Message,
+) (Result, error) {
+	if ctx == nil {
+		return Result{}, ErrInvalidContext
+	}
+
+	for _, validator := range s.validators {
+		endpoint := s.endpoint
+		if err := validator(ctx, &endpoint); err != nil {
+			return Result{}, fmt.Errorf(
+				"%w: endpoint validator: %w",
+				ErrInvalidEndpoint,
+				err,
+			)
+		}
+	}
+
+	signatureHeaders, err := s.signer.Sign(message.ID, message.Payload)
+	if err != nil {
+		return Result{}, err
+	}
+
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		s.endpoint.String(),
+		bytes.NewReader(message.Payload),
+	)
+	if err != nil {
+		return Result{}, fmt.Errorf(
+			"webhook/sender: create request: %w",
+			err,
+		)
+	}
+
+	request.Header = cloneHeader(message.Header)
+	if request.Header.Get("content-type") == "" {
+		request.Header.Set("content-type", "application/json")
+	}
+	for name, values := range signatureHeaders {
+		request.Header.Del(name)
+		request.Header[name] = append([]string(nil), values...)
+	}
+
+	response, err := s.client.Do(request)
+	if err != nil {
+		return Result{}, fmt.Errorf(
+			"webhook/sender: send request: %w",
+			err,
+		)
+	}
+	if response.Body != nil {
+		defer func() {
+			_ = response.Body.Close()
+		}()
+		drainResponseBody(response.Body)
+	}
+
+	headers := cloneHeader(response.Header)
+	return Result{
+		StatusCode: response.StatusCode,
+		Header:     headers,
+		RetryAfter: parseRetryAfter(headers.Get("retry-after"), s.now()),
+	}, nil
+}
+
+func parseEndpoint(value string, allowHTTP bool) (*url.URL, error) {
+	endpoint, err := url.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidEndpoint, err)
+	}
+	if !endpoint.IsAbs() ||
+		endpoint.Hostname() == "" ||
+		endpoint.User != nil ||
+		endpoint.Fragment != "" ||
+		endpoint.Opaque != "" {
+		return nil, ErrInvalidEndpoint
+	}
+
+	scheme := strings.ToLower(endpoint.Scheme)
+	endpoint.Scheme = scheme
+	switch scheme {
+	case "https":
+		return endpoint, nil
+	case "http":
+		if !allowHTTP {
+			return nil, ErrInsecureEndpoint
+		}
+		return endpoint, nil
+	default:
+		return nil, ErrInvalidEndpoint
+	}
+}
+
+func cloneHeader(source http.Header) http.Header {
+	target := make(http.Header, len(source))
+	for name, values := range source {
+		canonicalName := http.CanonicalHeaderKey(name)
+		target[canonicalName] = append(target[canonicalName], values...)
+	}
+	return target
+}
+
+func drainResponseBody(body io.Reader) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxResponseBodyDrain))
+}
+
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		if seconds <= 0 || seconds > math.MaxInt64/int64(time.Second) {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	date, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	delay := date.Sub(now)
+	if delay <= 0 {
+		return 0
+	}
+	return delay
+}

--- a/webhook/sender/sender_test.go
+++ b/webhook/sender/sender_test.go
@@ -43,14 +43,18 @@ func TestSenderSend(t *testing.T) {
 			assert.Len(t, request.Header.Values(webhook.HeaderTimestamp), 1)
 			assert.Len(t, request.Header.Values(webhook.HeaderSignature), 1)
 
-			return newResponse(
+			response := newResponse(
 				http.StatusCreated,
 				http.Header{
-					"retry-after": {"12"},
-					"x-result":    {"received"},
+					"Retry-After": {"12"},
+					"X-Result":    {"received"},
+					"Set-Cookie":  {"session=active; Path=/"},
+					"Location":    {"/deliveries/msg_123"},
 				},
 				"accepted",
-			), nil
+			)
+			response.Request = request
+			return response, nil
 		}),
 	}
 
@@ -72,10 +76,23 @@ func TestSenderSend(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer func() {
+		require.NoError(t, result.Body.Close())
+	}()
 	assert.Equal(t, http.StatusCreated, result.StatusCode)
 	assert.True(t, result.Successful())
 	assert.Equal(t, 12*time.Second, result.RetryAfter)
 	assert.Equal(t, "received", result.Header.Get("x-result"))
+	require.Len(t, result.Cookies(), 1)
+	assert.Equal(t, "session", result.Cookies()[0].Name)
+	location, err := result.Location()
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"https://example.com/deliveries/msg_123",
+		location.String(),
+	)
 }
 
 func TestSenderUsesDefaultContentType(t *testing.T) {
@@ -98,14 +115,18 @@ func TestSenderUsesDefaultContentType(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer func() {
+		require.NoError(t, result.Body.Close())
+	}()
 	assert.True(t, result.Successful())
 }
 
-func TestSenderReturnsNonSuccessfulResponse(t *testing.T) {
+func TestSenderReturnsNonSuccessfulResponseBody(t *testing.T) {
 	t.Parallel()
 
 	body := &recordingBody{
-		Reader: strings.NewReader(strings.Repeat("x", maxResponseBodyDrain+1)),
+		Reader: strings.NewReader("unavailable"),
 	}
 	client := &http.Client{
 		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
@@ -123,10 +144,18 @@ func TestSenderReturnsNonSuccessfulResponse(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	require.NotNil(t, result)
 	assert.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
 	assert.False(t, result.Successful())
+	assert.False(t, body.closed)
+	assert.Zero(t, body.read)
+
+	content, err := io.ReadAll(result.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "unavailable", string(content))
+	require.NoError(t, result.Body.Close())
 	assert.True(t, body.closed)
-	assert.Equal(t, int64(maxResponseBodyDrain), body.read)
+	assert.Equal(t, int64(len("unavailable")), body.read)
 }
 
 func TestSenderDoesNotFollowRedirects(t *testing.T) {
@@ -151,6 +180,10 @@ func TestSenderDoesNotFollowRedirects(t *testing.T) {
 	result, err := value.Send(t.Context(), Message{ID: "msg_redirect"})
 
 	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer func() {
+		require.NoError(t, result.Body.Close())
+	}()
 	assert.Equal(t, http.StatusTemporaryRedirect, result.StatusCode)
 	assert.Equal(t, int32(1), calls.Load())
 }
@@ -207,9 +240,13 @@ func TestSenderRunsSuccessfulEndpointValidator(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = value.Send(t.Context(), Message{ID: "msg_allowed"})
+	response, err := value.Send(t.Context(), Message{ID: "msg_allowed"})
 
 	require.NoError(t, err)
+	require.NotNil(t, response)
+	defer func() {
+		require.NoError(t, response.Body.Close())
+	}()
 	assert.True(t, validated.Load())
 }
 
@@ -223,9 +260,10 @@ func TestSenderRejectsNilContext(t *testing.T) {
 	require.NoError(t, err)
 
 	var ctx context.Context
-	_, err = value.Send(ctx, Message{ID: "msg_nil_context"})
+	response, err := value.Send(ctx, Message{ID: "msg_nil_context"})
 
 	assert.ErrorIs(t, err, ErrInvalidContext)
+	assert.Nil(t, response)
 }
 
 func TestSenderReturnsSigningError(t *testing.T) {
@@ -237,9 +275,10 @@ func TestSenderReturnsSigningError(t *testing.T) {
 	value, err := New("https://example.com", signer)
 	require.NoError(t, err)
 
-	_, err = value.Send(t.Context(), Message{})
+	response, err := value.Send(t.Context(), Message{})
 
 	assert.ErrorIs(t, err, webhook.ErrInvalidMessageID)
+	assert.Nil(t, response)
 }
 
 func TestSenderReturnsTransportError(t *testing.T) {
@@ -253,9 +292,10 @@ func TestSenderReturnsTransportError(t *testing.T) {
 	}
 	value := newTestSender(t, mustSecret(t), client)
 
-	_, err := value.Send(t.Context(), Message{ID: "msg_failed"})
+	response, err := value.Send(t.Context(), Message{ID: "msg_failed"})
 
 	assert.ErrorIs(t, err, sentinel)
+	assert.Nil(t, response)
 }
 
 func TestSenderReturnsContextError(t *testing.T) {
@@ -265,9 +305,10 @@ func TestSenderReturnsContextError(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	_, err := value.Send(ctx, Message{ID: "msg_canceled"})
+	response, err := value.Send(ctx, Message{ID: "msg_canceled"})
 
 	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, response)
 }
 
 func TestSenderConcurrentUse(t *testing.T) {
@@ -287,8 +328,10 @@ func TestSenderConcurrentUse(t *testing.T) {
 			result, err := value.Send(t.Context(), Message{
 				ID: "msg_concurrent",
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			require.NotNil(t, result)
 			assert.True(t, result.Successful())
+			require.NoError(t, result.Body.Close())
 		})
 	}
 	wait.Wait()
@@ -416,17 +459,11 @@ func TestParseRetryAfter(t *testing.T) {
 	}
 }
 
-func TestDrainResponseBody(t *testing.T) {
+func TestResponseSuccessful(t *testing.T) {
 	t.Parallel()
 
-	body := &recordingBody{
-		Reader: strings.NewReader(strings.Repeat("x", maxResponseBodyDrain+1)),
-	}
-
-	drainResponseBody(body)
-	drainResponseBody(nil)
-
-	assert.Equal(t, int64(maxResponseBodyDrain), body.read)
+	assert.False(t, (*Response)(nil).Successful())
+	assert.False(t, (&Response{}).Successful())
 }
 
 type recordingBody struct {

--- a/webhook/sender/sender_test.go
+++ b/webhook/sender/sender_test.go
@@ -1,0 +1,498 @@
+package sender
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-fries/fries/webhook/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSenderSend(t *testing.T) {
+	t.Parallel()
+
+	secret := mustSecret(t)
+	verifier, err := webhook.NewVerifier(secret)
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			body, readErr := io.ReadAll(request.Body)
+			require.NoError(t, readErr)
+
+			metadata, verifyErr := verifier.Verify(request.Header, body)
+			require.NoError(t, verifyErr)
+			assert.Equal(t, "msg_123", metadata.ID)
+			assert.Equal(t, `{"type":"order.created"}`, string(body))
+			assert.Equal(
+				t,
+				"application/cloudevents+json",
+				request.Header.Get("content-type"),
+			)
+			assert.Equal(t, "custom", request.Header.Get("x-custom"))
+			assert.Len(t, request.Header.Values(webhook.HeaderID), 1)
+			assert.Len(t, request.Header.Values(webhook.HeaderTimestamp), 1)
+			assert.Len(t, request.Header.Values(webhook.HeaderSignature), 1)
+
+			return newResponse(
+				http.StatusCreated,
+				http.Header{
+					"retry-after": {"12"},
+					"x-result":    {"received"},
+				},
+				"accepted",
+			), nil
+		}),
+	}
+
+	value := newTestSender(t, secret, client)
+	result, err := value.Send(t.Context(), Message{
+		ID:      "msg_123",
+		Payload: []byte(`{"type":"order.created"}`),
+		Header: http.Header{
+			"content-type":            {"application/cloudevents+json"},
+			"x-custom":                {"custom"},
+			webhook.HeaderID:          {"forged"},
+			webhook.HeaderTimestamp:   {"0"},
+			webhook.HeaderSignature:   {"v1,forged"},
+			"WEBHOOK-SIGNATURE":       {"v1,also-forged"},
+			"Webhook-Id":              {"also-forged"},
+			"Webhook-Timestamp":       {"0"},
+			"Webhook-Other-Extension": {"preserved"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, result.StatusCode)
+	assert.True(t, result.Successful())
+	assert.Equal(t, 12*time.Second, result.RetryAfter)
+	assert.Equal(t, "received", result.Header.Get("x-result"))
+}
+
+func TestSenderUsesDefaultContentType(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			assert.Equal(
+				t,
+				"application/json",
+				request.Header.Get("content-type"),
+			)
+			return newResponse(http.StatusNoContent, nil, ""), nil
+		}),
+	}
+	value := newTestSender(t, mustSecret(t), client)
+
+	result, err := value.Send(t.Context(), Message{
+		ID: "msg_default_content_type",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.Successful())
+}
+
+func TestSenderReturnsNonSuccessfulResponse(t *testing.T) {
+	t.Parallel()
+
+	body := &recordingBody{
+		Reader: strings.NewReader(strings.Repeat("x", maxResponseBodyDrain+1)),
+	}
+	client := &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		}),
+	}
+	value := newTestSender(t, mustSecret(t), client)
+
+	result, err := value.Send(t.Context(), Message{
+		ID: "msg_unavailable",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, result.StatusCode)
+	assert.False(t, result.Successful())
+	assert.True(t, body.closed)
+	assert.Equal(t, int64(maxResponseBodyDrain), body.read)
+}
+
+func TestSenderDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	client := &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusTemporaryRedirect,
+				Header: http.Header{
+					"location": {"https://other.example.com/target"},
+				},
+				Body:    io.NopCloser(strings.NewReader("redirect")),
+				Request: request,
+			}, nil
+		}),
+	}
+	value := newTestSender(t, mustSecret(t), client)
+
+	result, err := value.Send(t.Context(), Message{ID: "msg_redirect"})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTemporaryRedirect, result.StatusCode)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestSenderValidatesEndpointBeforeDelivery(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("endpoint denied")
+	secret := mustSecret(t)
+	signer, err := webhook.NewSigner(secret)
+	require.NoError(t, err)
+	value, err := New(
+		"https://example.com/webhook",
+		signer,
+		WithEndpointValidator(func(
+			ctx context.Context,
+			endpoint *url.URL,
+		) error {
+			assert.NoError(t, ctx.Err())
+			assert.Equal(t, "example.com", endpoint.Hostname())
+			endpoint.Host = "modified.example.com"
+			return sentinel
+		}),
+	)
+	require.NoError(t, err)
+
+	_, err = value.Send(t.Context(), Message{ID: "msg_denied"})
+
+	assert.ErrorIs(t, err, ErrInvalidEndpoint)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, "example.com", value.endpoint.Hostname())
+}
+
+func TestSenderRunsSuccessfulEndpointValidator(t *testing.T) {
+	t.Parallel()
+
+	var validated atomic.Bool
+	client := &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return newResponse(http.StatusNoContent, nil, ""), nil
+		}),
+	}
+	secret := mustSecret(t)
+	signer, err := webhook.NewSigner(secret)
+	require.NoError(t, err)
+	value, err := New(
+		"https://example.com/webhook",
+		signer,
+		WithHTTPClient(client),
+		WithEndpointValidator(func(context.Context, *url.URL) error {
+			validated.Store(true)
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+
+	_, err = value.Send(t.Context(), Message{ID: "msg_allowed"})
+
+	require.NoError(t, err)
+	assert.True(t, validated.Load())
+}
+
+func TestSenderRejectsNilContext(t *testing.T) {
+	t.Parallel()
+
+	secret := mustSecret(t)
+	signer, err := webhook.NewSigner(secret)
+	require.NoError(t, err)
+	value, err := New("https://example.com", signer)
+	require.NoError(t, err)
+
+	var ctx context.Context
+	_, err = value.Send(ctx, Message{ID: "msg_nil_context"})
+
+	assert.ErrorIs(t, err, ErrInvalidContext)
+}
+
+func TestSenderReturnsSigningError(t *testing.T) {
+	t.Parallel()
+
+	secret := mustSecret(t)
+	signer, err := webhook.NewSigner(secret)
+	require.NoError(t, err)
+	value, err := New("https://example.com", signer)
+	require.NoError(t, err)
+
+	_, err = value.Send(t.Context(), Message{})
+
+	assert.ErrorIs(t, err, webhook.ErrInvalidMessageID)
+}
+
+func TestSenderReturnsTransportError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("connection failed")
+	client := &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, sentinel
+		}),
+	}
+	value := newTestSender(t, mustSecret(t), client)
+
+	_, err := value.Send(t.Context(), Message{ID: "msg_failed"})
+
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestSenderReturnsContextError(t *testing.T) {
+	t.Parallel()
+
+	value := newTestSender(t, mustSecret(t), &http.Client{})
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := value.Send(ctx, Message{ID: "msg_canceled"})
+
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSenderConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	client := &http.Client{
+		Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return newResponse(http.StatusNoContent, nil, ""), nil
+		}),
+	}
+	value := newTestSender(t, mustSecret(t), client)
+	var wait sync.WaitGroup
+	for range 25 {
+		wait.Go(func() {
+			result, err := value.Send(t.Context(), Message{
+				ID: "msg_concurrent",
+			})
+			assert.NoError(t, err)
+			assert.True(t, result.Successful())
+		})
+	}
+	wait.Wait()
+	assert.Equal(t, int32(25), calls.Load())
+}
+
+func TestNewRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	secret := mustSecret(t)
+	signer, err := webhook.NewSigner(secret)
+	require.NoError(t, err)
+
+	_, err = New("https://example.com", nil)
+	assert.ErrorIs(t, err, ErrNilSigner)
+
+	tests := map[string]struct {
+		endpoint string
+		options  []Option
+		wantErr  error
+	}{
+		"empty": {
+			wantErr: ErrInvalidEndpoint,
+		},
+		"malformed": {
+			endpoint: "https://[::1",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"relative": {
+			endpoint: "/webhook",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"missing host": {
+			endpoint: "https:///webhook",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"userinfo": {
+			endpoint: "https://user:password@example.com/webhook",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"fragment": {
+			endpoint: "https://example.com/webhook#fragment",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"opaque": {
+			endpoint: "https:opaque",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"unsupported scheme": {
+			endpoint: "ftp://example.com/webhook",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"insecure HTTP": {
+			endpoint: "http://example.com/webhook",
+			wantErr:  ErrInsecureEndpoint,
+		},
+		"allowed HTTP": {
+			endpoint: "http://example.com/webhook",
+			options:  []Option{WithInsecureHTTP()},
+		},
+		"uppercase HTTPS": {
+			endpoint: "HTTPS://example.com/webhook",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			value, newErr := New(test.endpoint, signer, test.options...)
+
+			assert.ErrorIs(t, newErr, test.wantErr)
+			if test.wantErr == nil {
+				assert.NotNil(t, value)
+				assert.Equal(
+					t,
+					strings.ToLower(value.endpoint.Scheme),
+					value.endpoint.Scheme,
+				)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.July, 30, 10, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		value string
+		want  time.Duration
+	}{
+		"empty": {},
+		"seconds": {
+			value: "15",
+			want:  15 * time.Second,
+		},
+		"trimmed seconds": {
+			value: " 15 ",
+			want:  15 * time.Second,
+		},
+		"zero seconds": {
+			value: "0",
+		},
+		"negative seconds": {
+			value: "-1",
+		},
+		"overflow": {
+			value: "9223372036854775807",
+		},
+		"future date": {
+			value: now.Add(time.Minute).Format(http.TimeFormat),
+			want:  time.Minute,
+		},
+		"past date": {
+			value: now.Add(-time.Minute).Format(http.TimeFormat),
+		},
+		"invalid": {
+			value: "later",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, parseRetryAfter(test.value, now))
+		})
+	}
+}
+
+func TestDrainResponseBody(t *testing.T) {
+	t.Parallel()
+
+	body := &recordingBody{
+		Reader: strings.NewReader(strings.Repeat("x", maxResponseBodyDrain+1)),
+	}
+
+	drainResponseBody(body)
+	drainResponseBody(nil)
+
+	assert.Equal(t, int64(maxResponseBodyDrain), body.read)
+}
+
+type recordingBody struct {
+	*strings.Reader
+	closed bool
+	read   int64
+}
+
+func (b *recordingBody) Read(payload []byte) (int, error) {
+	count, err := b.Reader.Read(payload)
+	b.read += int64(count)
+	return count, err
+}
+
+func (b *recordingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	return f(request)
+}
+
+func newResponse(
+	statusCode int,
+	header http.Header,
+	body string,
+) *http.Response {
+	if header == nil {
+		header = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func newTestSender(
+	t testing.TB,
+	secret webhook.Secret,
+	client *http.Client,
+) *Sender {
+	t.Helper()
+
+	signer, err := webhook.NewSigner(secret)
+	require.NoError(t, err)
+	value, err := New(
+		"https://example.com/webhook",
+		signer,
+		WithHTTPClient(client),
+	)
+	require.NoError(t, err)
+	return value
+}
+
+func mustSecret(t testing.TB) webhook.Secret {
+	t.Helper()
+
+	secret, err := webhook.NewSecret(
+		[]byte("0123456789abcdef0123456789abcdef"),
+	)
+	require.NoError(t, err)
+	return secret
+}

--- a/webhook/sender/sender_test.go
+++ b/webhook/sender/sender_test.go
@@ -39,6 +39,12 @@ func TestSenderSend(t *testing.T) {
 				request.Header.Get("content-type"),
 			)
 			assert.Equal(t, "custom", request.Header.Get("x-custom"))
+			assert.Equal(
+				t,
+				"delivery_attempt",
+				request.Header.Get("idempotency-key"),
+			)
+			assert.Nil(t, request.GetBody)
 			assert.Len(t, request.Header.Values(webhook.HeaderID), 1)
 			assert.Len(t, request.Header.Values(webhook.HeaderTimestamp), 1)
 			assert.Len(t, request.Header.Values(webhook.HeaderSignature), 1)
@@ -65,6 +71,7 @@ func TestSenderSend(t *testing.T) {
 		Header: http.Header{
 			"content-type":            {"application/cloudevents+json"},
 			"x-custom":                {"custom"},
+			"idempotency-key":         {"delivery_attempt"},
 			webhook.HeaderID:          {"forged"},
 			webhook.HeaderTimestamp:   {"0"},
 			webhook.HeaderSignature:   {"v1,forged"},
@@ -394,6 +401,17 @@ func TestNewRejectsInvalidConfiguration(t *testing.T) {
 		},
 		"uppercase HTTPS": {
 			endpoint: "HTTPS://example.com/webhook",
+		},
+		"maximum port": {
+			endpoint: "https://example.com:65535/webhook",
+		},
+		"port above maximum": {
+			endpoint: "https://example.com:65536/webhook",
+			wantErr:  ErrInvalidEndpoint,
+		},
+		"large port": {
+			endpoint: "https://example.com:99999/webhook",
+			wantErr:  ErrInvalidEndpoint,
 		},
 	}
 

--- a/webhook/sender/version.go
+++ b/webhook/sender/version.go
@@ -1,0 +1,6 @@
+package sender
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0"
+}

--- a/webhook/sender/version_test.go
+++ b/webhook/sender/version_test.go
@@ -1,0 +1,20 @@
+package sender_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/webhook/sender/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := sender.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}

--- a/webhook/signer.go
+++ b/webhook/signer.go
@@ -1,0 +1,102 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// HeaderID contains the unique webhook message ID.
+	HeaderID = "Webhook-Id"
+	// HeaderTimestamp contains the message creation time as Unix seconds.
+	HeaderTimestamp = "Webhook-Timestamp"
+	// HeaderSignature contains one or more versioned message signatures.
+	HeaderSignature = "Webhook-Signature"
+
+	signatureVersion = "v1"
+)
+
+// Signer creates Standard Webhooks HMAC-SHA256 signatures.
+//
+// A Signer is safe for concurrent use.
+type Signer struct {
+	secrets [][]byte
+	now     func() time.Time
+}
+
+// NewSigner creates a Signer with secret as its primary signing secret.
+func NewSigner(secret Secret, options ...SignerOption) (*Signer, error) {
+	c, err := newSignerConfig(secret, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Signer{
+		secrets: c.secrets,
+		now:     time.Now,
+	}, nil
+}
+
+// Sign signs messageID, the current Unix timestamp, and the exact payload
+// bytes. It returns complete Webhook headers ready to add to an HTTP request.
+//
+// Sign returns [ErrInvalidMessageID] unless messageID contains only visible
+// ASCII characters other than a full stop.
+func (s *Signer) Sign(
+	messageID string,
+	payload []byte,
+) (http.Header, error) {
+	if !validMessageID(messageID) {
+		return nil, ErrInvalidMessageID
+	}
+
+	timestamp := strconv.FormatInt(s.now().Unix(), 10)
+	signatures := make([]string, 0, len(s.secrets))
+	for _, secret := range s.secrets {
+		digest := signDigest(secret, messageID, timestamp, payload)
+		signatures = append(
+			signatures,
+			signatureVersion+","+base64.StdEncoding.EncodeToString(digest),
+		)
+	}
+
+	headers := make(http.Header, 3)
+	headers.Set(HeaderID, messageID)
+	headers.Set(HeaderTimestamp, timestamp)
+	headers.Set(HeaderSignature, strings.Join(signatures, " "))
+	return headers, nil
+}
+
+func signDigest(
+	secret []byte,
+	messageID string,
+	timestamp string,
+	payload []byte,
+) []byte {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = io.WriteString(mac, messageID)
+	_, _ = mac.Write([]byte{'.'})
+	_, _ = io.WriteString(mac, timestamp)
+	_, _ = mac.Write([]byte{'.'})
+	_, _ = mac.Write(payload)
+	return mac.Sum(nil)
+}
+
+func validMessageID(messageID string) bool {
+	if messageID == "" {
+		return false
+	}
+	for i := range len(messageID) {
+		value := messageID[i]
+		if value < '!' || value > '~' || value == '.' {
+			return false
+		}
+	}
+	return true
+}

--- a/webhook/signer.go
+++ b/webhook/signer.go
@@ -13,11 +13,11 @@ import (
 
 const (
 	// HeaderID contains the unique webhook message ID.
-	HeaderID = "Webhook-Id"
+	HeaderID = "webhook-id"
 	// HeaderTimestamp contains the message creation time as Unix seconds.
-	HeaderTimestamp = "Webhook-Timestamp"
+	HeaderTimestamp = "webhook-timestamp"
 	// HeaderSignature contains one or more versioned message signatures.
-	HeaderSignature = "Webhook-Signature"
+	HeaderSignature = "webhook-signature"
 
 	signatureVersion = "v1"
 )

--- a/webhook/signer_test.go
+++ b/webhook/signer_test.go
@@ -1,0 +1,97 @@
+package webhook
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testTime = time.Unix(1_700_000_000, 0).UTC()
+
+func TestSignerSign(t *testing.T) {
+	t.Parallel()
+
+	key := make([]byte, 32)
+	for index := range key {
+		key[index] = byte(index)
+	}
+	secret, err := NewSecret(key)
+	require.NoError(t, err)
+	signer, err := NewSigner(secret)
+	require.NoError(t, err)
+	signer.now = func() time.Time { return testTime }
+
+	headers, err := signer.Sign(
+		"msg_test",
+		[]byte(`{"type":"example.created"}`),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg_test", headers.Get(HeaderID))
+	assert.Equal(t, "1700000000", headers.Get(HeaderTimestamp))
+	assert.Equal(
+		t,
+		"v1,+Ic57Le4o6523vOytAQ+1WEe0iMI81lYzLep8kBQTq8=",
+		headers.Get(HeaderSignature),
+	)
+}
+
+func TestSignerSignWithAdditionalSecrets(t *testing.T) {
+	t.Parallel()
+
+	signer, err := NewSigner(
+		mustSecret(t, 0),
+		WithAdditionalSigningSecrets(mustSecret(t, 1)),
+	)
+	require.NoError(t, err)
+	signer.now = func() time.Time { return testTime }
+
+	headers, err := signer.Sign("msg_rotation", []byte("payload"))
+
+	require.NoError(t, err)
+	signatures := strings.Fields(headers.Get(HeaderSignature))
+	require.Len(t, signatures, 2)
+	assert.NotEqual(t, signatures[0], signatures[1])
+	assert.True(t, strings.HasPrefix(signatures[0], "v1,"))
+	assert.True(t, strings.HasPrefix(signatures[1], "v1,"))
+}
+
+func TestSignerSignRejectsInvalidMessageID(t *testing.T) {
+	t.Parallel()
+
+	signer, err := NewSigner(mustSecret(t, 0))
+	require.NoError(t, err)
+
+	for _, messageID := range []string{
+		"",
+		"msg.with.dot",
+		"msg with space",
+		"msg\nheader",
+		"消息",
+	} {
+		_, err = signer.Sign(messageID, nil)
+		assert.ErrorIs(t, err, ErrInvalidMessageID)
+	}
+}
+
+func TestSignerConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	signer, err := NewSigner(mustSecret(t, 0))
+	require.NoError(t, err)
+	signer.now = func() time.Time { return testTime }
+
+	var wait sync.WaitGroup
+	for range 50 {
+		wait.Go(func() {
+			headers, signErr := signer.Sign("msg_concurrent", []byte("payload"))
+			assert.NoError(t, signErr)
+			assert.NotEmpty(t, headers.Get(HeaderSignature))
+		})
+	}
+	wait.Wait()
+}

--- a/webhook/verifier.go
+++ b/webhook/verifier.go
@@ -1,0 +1,175 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	maxSignatureHeaderBytes = 16 << 10
+	maxSignatureCount       = 32
+)
+
+// Metadata contains authenticated webhook message metadata.
+type Metadata struct {
+	// ID is the signed webhook message ID.
+	ID string
+	// Timestamp is the signed message timestamp.
+	Timestamp time.Time
+}
+
+// Verifier authenticates Standard Webhooks HMAC-SHA256 signatures.
+//
+// A Verifier is safe for concurrent use.
+type Verifier struct {
+	secrets   [][]byte
+	tolerance time.Duration
+	now       func() time.Time
+}
+
+// NewVerifier creates a Verifier with secret as its primary verification
+// secret.
+func NewVerifier(
+	secret Secret,
+	options ...VerifierOption,
+) (*Verifier, error) {
+	c, err := newVerifierConfig(secret, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Verifier{
+		secrets:   c.secrets,
+		tolerance: c.tolerance,
+		now:       time.Now,
+	}, nil
+}
+
+// Verify authenticates the Webhook headers and exact payload bytes.
+//
+// On success, Metadata contains the signed message ID and timestamp. Verify
+// does not decode payload or prevent the same valid message from being
+// processed more than once.
+func (v *Verifier) Verify(
+	headers http.Header,
+	payload []byte,
+) (Metadata, error) {
+	messageID, err := requiredSingleHeader(
+		headers,
+		HeaderID,
+		ErrInvalidMessageID,
+	)
+	if err != nil {
+		return Metadata{}, err
+	}
+	if !validMessageID(messageID) {
+		return Metadata{}, ErrInvalidMessageID
+	}
+
+	timestampValue, err := requiredSingleHeader(
+		headers,
+		HeaderTimestamp,
+		ErrInvalidTimestamp,
+	)
+	if err != nil {
+		return Metadata{}, err
+	}
+	unixTimestamp, err := strconv.ParseInt(timestampValue, 10, 64)
+	if err != nil || unixTimestamp < 0 {
+		return Metadata{}, ErrInvalidTimestamp
+	}
+
+	timestamp := time.Unix(unixTimestamp, 0).UTC()
+	difference := v.now().Sub(timestamp)
+	if difference > v.tolerance || difference < -v.tolerance {
+		return Metadata{}, ErrTimestampOutsideTolerance
+	}
+
+	signatures, err := parseSignatures(headers)
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	matched := false
+	for _, secret := range v.secrets {
+		expected := signDigest(
+			secret,
+			messageID,
+			timestampValue,
+			payload,
+		)
+		for _, signature := range signatures {
+			equal := hmac.Equal(expected, signature)
+			matched = equal || matched
+		}
+	}
+	if !matched {
+		return Metadata{}, ErrInvalidSignature
+	}
+
+	return Metadata{
+		ID:        messageID,
+		Timestamp: timestamp,
+	}, nil
+}
+
+func requiredSingleHeader(
+	headers http.Header,
+	name string,
+	invalidError error,
+) (string, error) {
+	values := headers.Values(name)
+	if len(values) == 0 || len(values) == 1 && values[0] == "" {
+		return "", fmt.Errorf("%w: %s", ErrMissingHeader, name)
+	}
+	if len(values) != 1 {
+		return "", fmt.Errorf("%w: duplicate %s", invalidError, name)
+	}
+	return values[0], nil
+}
+
+func parseSignatures(headers http.Header) ([][]byte, error) {
+	values := headers.Values(HeaderSignature)
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrMissingHeader, HeaderSignature)
+	}
+
+	totalBytes := 0
+	tokenCount := 0
+	signatures := make([][]byte, 0, len(values))
+	for _, value := range values {
+		totalBytes += len(value)
+		if totalBytes > maxSignatureHeaderBytes {
+			return nil, ErrInvalidSignature
+		}
+
+		for token := range strings.FieldsSeq(value) {
+			tokenCount++
+			if tokenCount > maxSignatureCount {
+				return nil, ErrInvalidSignature
+			}
+
+			version, encoded, ok := strings.Cut(token, ",")
+			if !ok || version != signatureVersion {
+				continue
+			}
+			signature, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil || len(signature) != hmacSignatureSize {
+				continue
+			}
+			signatures = append(signatures, signature)
+		}
+	}
+
+	if len(signatures) == 0 {
+		return nil, ErrInvalidSignature
+	}
+	return signatures, nil
+}
+
+const hmacSignatureSize = 32

--- a/webhook/verifier_test.go
+++ b/webhook/verifier_test.go
@@ -1,0 +1,407 @@
+package webhook
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifierVerify(t *testing.T) {
+	t.Parallel()
+
+	signer, verifier := newTestPair(t)
+	payload := []byte(`{"type":"example.created"}`)
+	headers, err := signer.Sign("msg_test", payload)
+	require.NoError(t, err)
+
+	metadata, err := verifier.Verify(headers, payload)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg_test", metadata.ID)
+	assert.Equal(t, testTime, metadata.Timestamp)
+}
+
+func TestVerifierSupportsMultipleHeadersAndVersions(t *testing.T) {
+	t.Parallel()
+
+	signer, verifier := newTestPair(t)
+	payload := []byte("payload")
+	headers, err := signer.Sign("msg_multiple", payload)
+	require.NoError(t, err)
+	validSignature := headers.Get(HeaderSignature)
+	headers.Set(HeaderSignature, "v2,unknown")
+	headers.Add(HeaderSignature, "invalid")
+	headers.Add(HeaderSignature, validSignature)
+
+	metadata, err := verifier.Verify(headers, payload)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg_multiple", metadata.ID)
+}
+
+func TestVerifierSupportsSecretRotation(t *testing.T) {
+	t.Parallel()
+
+	current := mustSecret(t, 0)
+	previous := mustSecret(t, 1)
+	signer, err := NewSigner(previous)
+	require.NoError(t, err)
+	signer.now = func() time.Time { return testTime }
+	verifier, err := NewVerifier(
+		current,
+		WithAdditionalVerificationSecrets(previous),
+	)
+	require.NoError(t, err)
+	verifier.now = func() time.Time { return testTime }
+	headers, err := signer.Sign("msg_rotation", []byte("payload"))
+	require.NoError(t, err)
+
+	_, err = verifier.Verify(headers, []byte("payload"))
+
+	assert.NoError(t, err)
+}
+
+func TestVerifierTimestampTolerance(t *testing.T) {
+	t.Parallel()
+
+	secret := mustSecret(t, 0)
+	signer, err := NewSigner(secret)
+	require.NoError(t, err)
+	verifier, err := NewVerifier(secret, WithTolerance(time.Minute))
+	require.NoError(t, err)
+	verifier.now = func() time.Time { return testTime }
+
+	tests := map[string]struct {
+		signedAt time.Time
+		wantErr  error
+	}{
+		"past boundary": {
+			signedAt: testTime.Add(-time.Minute),
+		},
+		"future boundary": {
+			signedAt: testTime.Add(time.Minute),
+		},
+		"too old": {
+			signedAt: testTime.Add(-time.Minute - time.Second),
+			wantErr:  ErrTimestampOutsideTolerance,
+		},
+		"too far in future": {
+			signedAt: testTime.Add(time.Minute + time.Second),
+			wantErr:  ErrTimestampOutsideTolerance,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			signer.now = func() time.Time { return test.signedAt }
+			headers, signErr := signer.Sign("msg_time", nil)
+			require.NoError(t, signErr)
+
+			_, verifyErr := verifier.Verify(headers, nil)
+
+			assert.ErrorIs(t, verifyErr, test.wantErr)
+		})
+	}
+}
+
+func TestVerifierRejectsInvalidHeaders(t *testing.T) {
+	t.Parallel()
+
+	_, verifier := newTestPair(t)
+	valid := validHeaders(t)
+
+	tests := map[string]struct {
+		mutate  func(http.Header)
+		wantErr error
+	}{
+		"missing id": {
+			mutate:  func(headers http.Header) { headers.Del(HeaderID) },
+			wantErr: ErrMissingHeader,
+		},
+		"empty id": {
+			mutate:  func(headers http.Header) { headers.Set(HeaderID, "") },
+			wantErr: ErrMissingHeader,
+		},
+		"duplicate id": {
+			mutate: func(headers http.Header) {
+				headers.Add(HeaderID, "msg_other")
+			},
+			wantErr: ErrInvalidMessageID,
+		},
+		"invalid id": {
+			mutate: func(headers http.Header) {
+				headers.Set(HeaderID, "msg.invalid")
+			},
+			wantErr: ErrInvalidMessageID,
+		},
+		"missing timestamp": {
+			mutate: func(headers http.Header) {
+				headers.Del(HeaderTimestamp)
+			},
+			wantErr: ErrMissingHeader,
+		},
+		"duplicate timestamp": {
+			mutate: func(headers http.Header) {
+				headers.Add(HeaderTimestamp, "1700000001")
+			},
+			wantErr: ErrInvalidTimestamp,
+		},
+		"invalid timestamp": {
+			mutate: func(headers http.Header) {
+				headers.Set(HeaderTimestamp, "not-a-time")
+			},
+			wantErr: ErrInvalidTimestamp,
+		},
+		"negative timestamp": {
+			mutate: func(headers http.Header) {
+				headers.Set(HeaderTimestamp, "-1")
+			},
+			wantErr: ErrInvalidTimestamp,
+		},
+		"missing signature": {
+			mutate: func(headers http.Header) {
+				headers.Del(HeaderSignature)
+			},
+			wantErr: ErrMissingHeader,
+		},
+		"invalid signature": {
+			mutate: func(headers http.Header) {
+				headers.Set(HeaderSignature, "v1,invalid")
+			},
+			wantErr: ErrInvalidSignature,
+		},
+		"unknown signature version": {
+			mutate: func(headers http.Header) {
+				headers.Set(HeaderSignature, "v2,unknown")
+			},
+			wantErr: ErrInvalidSignature,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			headers := valid.Clone()
+			test.mutate(headers)
+
+			_, err := verifier.Verify(headers, []byte("payload"))
+
+			assert.ErrorIs(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestVerifierRejectsTampering(t *testing.T) {
+	t.Parallel()
+
+	signer, verifier := newTestPair(t)
+	payload := []byte("payload")
+	headers, err := signer.Sign("msg_tampering", payload)
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		headers http.Header
+		payload []byte
+	}{
+		"message id": {
+			headers: func() http.Header {
+				modified := headers.Clone()
+				modified.Set(HeaderID, "msg_other")
+				return modified
+			}(),
+			payload: payload,
+		},
+		"timestamp": {
+			headers: func() http.Header {
+				modified := headers.Clone()
+				modified.Set(HeaderTimestamp, "1700000001")
+				return modified
+			}(),
+			payload: payload,
+		},
+		"payload": {
+			headers: headers,
+			payload: []byte("modified"),
+		},
+		"signature": {
+			headers: func() http.Header {
+				modified := headers.Clone()
+				modified.Set(
+					HeaderSignature,
+					"v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+				)
+				return modified
+			}(),
+			payload: payload,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, verifyErr := verifier.Verify(test.headers, test.payload)
+
+			assert.ErrorIs(t, verifyErr, ErrInvalidSignature)
+		})
+	}
+}
+
+func TestVerifierLimitsSignatureParsing(t *testing.T) {
+	t.Parallel()
+
+	_, verifier := newTestPair(t)
+	headers := validHeaders(t)
+
+	headers.Set(
+		HeaderSignature,
+		strings.Repeat("v2,unknown ", maxSignatureCount+1),
+	)
+	_, err := verifier.Verify(headers, []byte("payload"))
+	assert.ErrorIs(t, err, ErrInvalidSignature)
+
+	headers.Set(
+		HeaderSignature,
+		strings.Repeat("x", maxSignatureHeaderBytes+1),
+	)
+	_, err = verifier.Verify(headers, []byte("payload"))
+	assert.ErrorIs(t, err, ErrInvalidSignature)
+}
+
+func TestVerifierConcurrentUse(t *testing.T) {
+	t.Parallel()
+
+	signer, verifier := newTestPair(t)
+	payload := []byte("payload")
+	headers, err := signer.Sign("msg_concurrent", payload)
+	require.NoError(t, err)
+
+	var wait sync.WaitGroup
+	for range 50 {
+		wait.Go(func() {
+			metadata, verifyErr := verifier.Verify(headers, payload)
+			assert.NoError(t, verifyErr)
+			assert.Equal(t, "msg_concurrent", metadata.ID)
+		})
+	}
+	wait.Wait()
+}
+
+func FuzzSignAndVerify(f *testing.F) {
+	f.Add("msg_example", []byte(`{"type":"example.created"}`))
+	f.Add("", []byte(nil))
+
+	secret, err := NewSecret(bytesOf(0, 32))
+	require.NoError(f, err)
+	signer, err := NewSigner(secret)
+	require.NoError(f, err)
+	verifier, err := NewVerifier(secret)
+	require.NoError(f, err)
+	signer.now = func() time.Time { return testTime }
+	verifier.now = func() time.Time { return testTime }
+
+	f.Fuzz(func(t *testing.T, messageID string, payload []byte) {
+		headers, signErr := signer.Sign(messageID, payload)
+		if signErr != nil {
+			require.ErrorIs(t, signErr, ErrInvalidMessageID)
+			return
+		}
+
+		metadata, verifyErr := verifier.Verify(headers, payload)
+		require.NoError(t, verifyErr)
+		assert.Equal(t, messageID, metadata.ID)
+	})
+}
+
+func FuzzVerifierHeaders(f *testing.F) {
+	f.Add("msg_example", "1700000000", "v1,invalid", []byte("payload"))
+	f.Add("", "", "", []byte(nil))
+
+	verifier, err := NewVerifier(mustSecret(f, 0))
+	require.NoError(f, err)
+	verifier.now = func() time.Time { return testTime }
+
+	f.Fuzz(func(
+		t *testing.T,
+		messageID string,
+		timestamp string,
+		signature string,
+		payload []byte,
+	) {
+		headers := make(http.Header)
+		headers.Set(HeaderID, messageID)
+		headers.Set(HeaderTimestamp, timestamp)
+		headers.Set(HeaderSignature, signature)
+
+		_, _ = verifier.Verify(headers, payload)
+	})
+}
+
+func BenchmarkVerifierVerify(b *testing.B) {
+	current := mustSecret(b, 0)
+	previous := mustSecret(b, 1)
+	payload := []byte(`{"type":"example.created","data":{"id":"123"}}`)
+
+	benchmarks := map[string]struct {
+		signerOptions   []SignerOption
+		verifierOptions []VerifierOption
+	}{
+		"single secret": {},
+		"rotation": {
+			signerOptions: []SignerOption{
+				WithAdditionalSigningSecrets(previous),
+			},
+			verifierOptions: []VerifierOption{
+				WithAdditionalVerificationSecrets(previous),
+			},
+		},
+	}
+
+	for name, benchmark := range benchmarks {
+		b.Run(name, func(b *testing.B) {
+			signer, err := NewSigner(current, benchmark.signerOptions...)
+			require.NoError(b, err)
+			verifier, err := NewVerifier(
+				current,
+				benchmark.verifierOptions...,
+			)
+			require.NoError(b, err)
+			signer.now = func() time.Time { return testTime }
+			verifier.now = func() time.Time { return testTime }
+			headers, err := signer.Sign("msg_benchmark", payload)
+			require.NoError(b, err)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				_, err = verifier.Verify(headers, payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func newTestPair(t testing.TB) (*Signer, *Verifier) {
+	t.Helper()
+
+	secret := mustSecret(t, 0)
+	signer, err := NewSigner(secret)
+	require.NoError(t, err)
+	verifier, err := NewVerifier(secret)
+	require.NoError(t, err)
+	signer.now = func() time.Time { return testTime }
+	verifier.now = func() time.Time { return testTime }
+	return signer, verifier
+}
+
+func validHeaders(t testing.TB) http.Header {
+	t.Helper()
+
+	signer, _ := newTestPair(t)
+	headers, err := signer.Sign("msg_valid", []byte("payload"))
+	require.NoError(t, err)
+	return headers
+}

--- a/webhook/version.go
+++ b/webhook/version.go
@@ -1,0 +1,6 @@
+package webhook
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.0.0"
+}

--- a/webhook/version_test.go
+++ b/webhook/version_test.go
@@ -1,0 +1,20 @@
+package webhook_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/webhook/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	v := webhook.Version()
+	assert.NotNil(t, versionRegex.FindStringSubmatch(v), "version is not semver: %s", v)
+}


### PR DESCRIPTION
## Summary

Add framework-neutral Webhook signing, verification, and single-attempt HTTP delivery as two independently versioned modules.

## Changes

- Add `webhook` with Standard Webhooks-compatible HMAC-SHA256 signing and verification
- Sign the message ID, Unix timestamp, and exact payload bytes using the `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers
- Support `whsec_` secrets, timestamp tolerance, multiple signatures, and multiple verification secrets for zero-downtime secret rotation
- Add `webhook/sender` for one signed HTTP POST per `Send` call
- Require HTTPS by default, disable redirects, apply a total request timeout, and support application-defined endpoint validation
- Return a `sender.Response` that embeds `*http.Response` and includes parsed `Retry-After` information
- Add package documentation, usage examples, version metadata, module registration, and focused test coverage

## Motivation

- Applications repeatedly need a consistent way to sign and verify internal or public Webhook messages
- Keeping cryptographic verification separate from business dispatch, idempotency, queues, and reliable delivery produces clearer ownership boundaries
- A small HTTP sender removes repetitive request setup without embedding retry or settlement policy into the transport layer

## Usage

Create a signer and verifier from the same secret:

```go
secret, err := webhook.ParseSecret(os.Getenv("WEBHOOK_SECRET"))
if err != nil {
	return err
}

signer, err := webhook.NewSigner(secret)
if err != nil {
	return err
}

headers, err := signer.Sign(messageID, payload)
if err != nil {
	return err
}

verifier, err := webhook.NewVerifier(secret)
if err != nil {
	return err
}

metadata, err := verifier.Verify(headers, payload)
```

Perform one signed HTTP delivery:

```go
outbound, err := sender.New(endpoint, signer)
if err != nil {
	return err
}

response, err := outbound.Send(ctx, sender.Message{
	ID:      messageID,
	Payload: payload,
})
if err != nil {
	return err
}
defer response.Body.Close()

if !response.Successful() {
	return fmt.Errorf("webhook returned HTTP %d", response.StatusCode)
}
```

## Compatibility and adoption

- This is an additive change; no existing package or public API is changed
- Install `github.com/go-fries/fries/webhook/v4` for signing and verification
- Install `github.com/go-fries/fries/webhook/sender/v4` only when HTTP delivery is needed
- The core protocol targets Standard Webhooks and does not directly support vendor-specific GitHub, Stripe, or Slack signature formats
- Sender performs exactly one request and does not persist messages, retry failures, classify retryable status codes, or provide exactly-once delivery
- Callers own and must close `sender.Response.Body`
- Receivers should combine verified message IDs with an idempotency mechanism when duplicate processing matters
- URL validation alone is not complete SSRF protection; user-controlled endpoints still require an appropriate outbound network policy or proxy

## Testing

- `make test/webhook`
- `make lint/webhook`
- `make build/webhook`
- `go test -race -cover ./...` in `webhook` — 100.0% statement coverage
- `make test/webhook/sender`
- `make lint/webhook/sender`
- `make build/webhook/sender`
- `go test -race -cover ./...` in `webhook/sender` — 98.9% statement coverage
