### PR TITLE
chore(go)!: support Go 1.26 and 1.27

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.25.x, 1.26.x ]
+        go-version: [ 1.26.x, 1.27.x ]
         platform: [ ubuntu-latest ]
         mysql-version: [ 'mysql:latest', 'mysql:5.7' ]
     runs-on: ${{ matrix.platform }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,11 +67,6 @@ linters:
         - '-ST1021' # https://staticcheck.dev/docs/checks#ST1021
         - '-ST1022' # https://staticcheck.dev/docs/checks#ST1022
   exclusions:
-    rules:
-      - linters:
-          - modernize
-        path: ^ptr/
-        text: "newexpr:"
     paths:
       - .gocache
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,7 @@ linters:
       replace-allow-list:
         - github.com/flc1125/go-cron/v4
       toolchain-forbidden: true
-      go-version-pattern: '^1\.25\.0$'
+      go-version-pattern: '^1\.26\.0$'
     nolintlint:
       require-specific: true
     usetesting:
@@ -67,6 +67,11 @@ linters:
         - '-ST1021' # https://staticcheck.dev/docs/checks#ST1021
         - '-ST1022' # https://staticcheck.dev/docs/checks#ST1022
   exclusions:
+    rules:
+      - linters:
+          - modernize
+        path: ^ptr/
+        text: "newexpr:"
     paths:
       - .gocache
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,7 +4,7 @@
 
 **Fries** (formerly `go-kratos-ecosystem/components`) is a modular collection of Go libraries and components designed to build robust applications. It follows a toolkit approach where developers can pick and choose specific packages (like `event`, `cache`, `filesystem`) or use the `lifecycle` package to coordinate application startup and shutdown with a Service Provider pattern.
 
-*   **Language:** Go (>= 1.25.0)
+*   **Language:** Go (>= 1.26.0)
 *   **Architecture:** Modular, Component-based, Service Provider (DI) pattern.
 *   **Key Pattern:** The `lifecycle.Runner` manages application lifecycle via `Bootstrap` and `Shutdown` methods defined in `Provider` interfaces.
 
@@ -26,7 +26,7 @@ This project uses a `Makefile` to manage the build, test, and lint workflows acr
 
 ### Prerequisites
 
-*   Go >= 1.25.0
+*   Go >= 1.26.0
 *   `make`
 
 ### Common Commands

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,7 @@ test/%: DIR=$*
 test/%:
 	@echo "$(GO) test -timeout $(TIMEOUT)s $(ARGS) $(DIR)/..." \
 		&& cd $(DIR) \
-		&& $(GO) list ./... \
-		| xargs $(GO) test -timeout $(TIMEOUT)s $(ARGS)
+		&& $(GO) test -timeout $(TIMEOUT)s $(ARGS) ./...
 
 
 COVERAGE_MODE    = atomic
@@ -82,8 +81,7 @@ test-coverage: $(GOCOVMERGE)
 	for dir in $(ALL_COVERAGE_MOD_DIRS); do \
 	  echo "$(GO) test -v -race -coverpkg=github.com/go-fries/fries/... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" $${dir}/..."; \
 	  (cd "$${dir}" && \
-	    $(GO) list ./... \
-	    | xargs $(GO) test -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" && \
+	    $(GO) test -coverpkg=./... -covermode=$(COVERAGE_MODE) -coverprofile="$(COVERAGE_PROFILE)" ./... && \
 	  $(GO) tool cover -html=coverage.out -o coverage.html); \
 	done; \
 	$(GOCOVMERGE) $$(find . -name coverage.out) > coverage.txt
@@ -109,7 +107,7 @@ go-mod-tidy/%: DIR=$*
 go-mod-tidy/%:
 	@echo "$(GO) mod tidy in $(DIR)" \
 		&& cd $(DIR) \
-		&& $(GO) mod tidy -compat=1.22.0
+		&& $(GO) mod tidy -compat=1.26.0
 
 .PHONY: go-fix
 go-fix: $(ROOT_GO_MOD_DIRS:%=go-fix/%)
@@ -168,7 +166,7 @@ check-clean-work-tree:
 	fi
 
 # Upgrade Go version in all go.mod files to the version specified in the GO_VERSION env var
-# Example: make upgrade-go-version GO_VERSION=1.25.0
+# Example: make upgrade-go-version GO_VERSION=1.26.0
 .PHONY: upgrade-go-version
 upgrade-go-version: $(ALL_GO_MOD_DIRS:%=upgrade-go-version/%)
 upgrade-go-version/%: DIR=$*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Fries Components
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.25.0-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.26.0-blue)
 [![Package Version](https://badgen.net/github/release/go-fries/fries/stable)](https://github.com/go-fries/fries/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/go-fries/fries/v4)](https://pkg.go.dev/github.com/go-fries/fries/v4)
 [![codecov](https://codecov.io/gh/go-fries/fries/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/go-fries/fries)

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cache/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/locker/v4 => ../locker
 

--- a/cache/redis/go.mod
+++ b/cache/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cache/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/cache/v4 => ../

--- a/capability/go.mod
+++ b/capability/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/capability/v4
 
-go 1.25.0
+go 1.26.0

--- a/chi/go.mod
+++ b/chi/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/chi/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-chi/chi/v5 v5.3.2

--- a/chi/server_test.go
+++ b/chi/server_test.go
@@ -17,8 +17,7 @@ func TestServerDoesNotExposeMux(t *testing.T) {
 	serverType := reflect.TypeFor[Server]()
 	muxType := reflect.TypeFor[*chi.Mux]()
 
-	for i := range serverType.NumField() {
-		field := serverType.Field(i)
+	for field := range serverType.Fields() {
 		assert.False(t, field.Anonymous && field.Type == muxType)
 	}
 }

--- a/cloudevents/eventdispatcher/go.mod
+++ b/cloudevents/eventdispatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cloudevents/eventdispatcher/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2

--- a/cloudevents/protocol/amqp091/go.mod
+++ b/cloudevents/protocol/amqp091/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/cloudevents/protocol/amqp091/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2

--- a/codec/go.mod
+++ b/codec/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/codec/json/go.mod
+++ b/codec/json/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/json/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/codec/v4 => ../
 

--- a/codec/msgpack/go.mod
+++ b/codec/msgpack/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/msgpack/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/codec/v4 => ../
 

--- a/codec/proto/go.mod
+++ b/codec/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/proto/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/codec/v4 => ../
 

--- a/codec/sonic/go.mod
+++ b/codec/sonic/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/sonic/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/codec/v4 => ../
 

--- a/codec/xml/go.mod
+++ b/codec/xml/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/xml/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/codec/v4 => ../
 

--- a/codec/yaml/go.mod
+++ b/codec/yaml/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/codec/yaml/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/codec/v4 => ../
 

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/config/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/constraints/go.mod
+++ b/constraints/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-fries/fries/constraints/v4
 
-go 1.25.0
+go 1.26.0

--- a/crontab/go.mod
+++ b/crontab/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/crontab/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/flc1125/go-cron/v4 v4.11.0

--- a/eino/components/embedding/cached/cacher/gorm/go.mod
+++ b/eino/components/embedding/cached/cacher/gorm/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/cacher/gorm/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/eino/components/embedding/cached/v4 => ../../
 

--- a/eino/components/embedding/cached/cacher/redis/go.mod
+++ b/eino/components/embedding/cached/cacher/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/cacher/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/sonic/v4 => ./../../../../../../codec/sonic

--- a/eino/components/embedding/cached/example/go.mod
+++ b/eino/components/embedding/cached/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/example/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/sonic/v4 => ../../../../../codec/sonic

--- a/eino/components/embedding/cached/go.mod
+++ b/eino/components/embedding/cached/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/eino/components/embedding/cached/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cloudwego/eino v0.9.15

--- a/encrypter/go.mod
+++ b/encrypter/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/encrypter/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/ent/go.mod
+++ b/ent/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ent/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/ent/multidriver/go.mod
+++ b/ent/multidriver/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ent/multidriver/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	entgo.io/ent v0.14.6

--- a/env/go.mod
+++ b/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/env/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/errors/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-kratos/kratos/v3 v3.0.0

--- a/event/go.mod
+++ b/event/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/event/middleware/recovery/go.mod
+++ b/event/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/event/middleware/recovery/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/event/v4 => ../../
 

--- a/filesystem/go.mod
+++ b/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/filesystem/local/go.mod
+++ b/filesystem/local/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/local/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/filesystem/v4 => ../
 

--- a/filesystem/oss/filesystem.go
+++ b/filesystem/oss/filesystem.go
@@ -79,8 +79,8 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 		return nil, err
 	}
 	result, err := s.client.GetObject(ctx, &aliyunoss.GetObjectRequest{
-		Bucket: aliyunoss.Ptr(s.bucket),
-		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
+		Bucket: new(s.bucket),
+		Key:    new(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
 		return nil, wrapPathError("open", path, err)
@@ -104,14 +104,14 @@ func (s *Filesystem) Put(
 		return wrapPathError("put", path, err)
 	}
 	request := &aliyunoss.PutObjectRequest{
-		Bucket:        aliyunoss.Ptr(s.bucket),
-		Key:           aliyunoss.Ptr(s.prefixer.Prefix(path)),
+		Bucket:        new(s.bucket),
+		Key:           new(s.prefixer.Prefix(path)),
 		Body:          src,
-		ContentLength: aliyunoss.Ptr(contentLength),
+		ContentLength: new(contentLength),
 		Metadata:      cloneMetadata(options.Metadata),
 	}
 	if options.ContentType != "" {
-		request.ContentType = aliyunoss.Ptr(options.ContentType)
+		request.ContentType = new(options.ContentType)
 	}
 	_, err = s.client.PutObject(ctx, request)
 	if err != nil {
@@ -126,8 +126,8 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 		return err
 	}
 	_, err := s.client.DeleteObject(ctx, &aliyunoss.DeleteObjectRequest{
-		Bucket: aliyunoss.Ptr(s.bucket),
-		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
+		Bucket: new(s.bucket),
+		Key:    new(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
 		return wrapPathError("delete", path, err)
@@ -148,8 +148,8 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 		return filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, nil
 	}
 	result, err := s.client.HeadObject(ctx, &aliyunoss.HeadObjectRequest{
-		Bucket: aliyunoss.Ptr(s.bucket),
-		Key:    aliyunoss.Ptr(s.prefixer.Prefix(path)),
+		Bucket: new(s.bucket),
+		Key:    new(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
 		if isNotFound(err) {
@@ -179,8 +179,8 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 
 func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error) {
 	result, err := s.client.ListObjectsV2(ctx, &aliyunoss.ListObjectsV2Request{
-		Bucket:  aliyunoss.Ptr(s.bucket),
-		Prefix:  aliyunoss.Ptr(directoryPrefix(s.prefixer.Prefix(path))),
+		Bucket:  new(s.bucket),
+		Prefix:  new(directoryPrefix(s.prefixer.Prefix(path))),
 		MaxKeys: 1,
 	})
 	if err != nil {
@@ -200,14 +200,14 @@ func (s *Filesystem) ListFiles(
 		return filesystem.ListPage{}, err
 	}
 	request := &aliyunoss.ListObjectsV2Request{
-		Bucket: aliyunoss.Ptr(s.bucket),
-		Prefix: aliyunoss.Ptr(directoryPrefix(s.prefixer.Prefix(path))),
+		Bucket: new(s.bucket),
+		Prefix: new(directoryPrefix(s.prefixer.Prefix(path))),
 	}
 	if !options.Recursive {
-		request.Delimiter = aliyunoss.Ptr("/")
+		request.Delimiter = new("/")
 	}
 	if options.Cursor != "" {
-		request.ContinuationToken = aliyunoss.Ptr(options.Cursor)
+		request.ContinuationToken = new(options.Cursor)
 	}
 	request.MaxKeys = int32(options.Limit)
 
@@ -231,10 +231,10 @@ func (s *Filesystem) Copy(ctx context.Context, src, dst string) error {
 		return err
 	}
 	_, err := s.client.CopyObject(ctx, &aliyunoss.CopyObjectRequest{
-		Bucket:       aliyunoss.Ptr(s.bucket),
-		Key:          aliyunoss.Ptr(s.prefixer.Prefix(dst)),
-		SourceBucket: aliyunoss.Ptr(s.bucket),
-		SourceKey:    aliyunoss.Ptr(s.prefixer.Prefix(src)),
+		Bucket:       new(s.bucket),
+		Key:          new(s.prefixer.Prefix(dst)),
+		SourceBucket: new(s.bucket),
+		SourceKey:    new(s.prefixer.Prefix(src)),
 	})
 	if err != nil {
 		return wrapPathError("copy", src, err)

--- a/filesystem/oss/filesystem_test.go
+++ b/filesystem/oss/filesystem_test.go
@@ -19,14 +19,14 @@ func TestFilesystemList(t *testing.T) {
 		listResult: &aliyunoss.ListObjectsV2Result{
 			Contents: []aliyunoss.ObjectProperties{
 				{
-					Key:          aliyunoss.Ptr("root/dir/file.txt"),
+					Key:          new("root/dir/file.txt"),
 					Size:         7,
 					LastModified: &modified,
 				},
-				{Key: aliyunoss.Ptr("root/dir/marker/")},
+				{Key: new("root/dir/marker/")},
 			},
-			CommonPrefixes:        []aliyunoss.CommonPrefix{{Prefix: aliyunoss.Ptr("root/dir/nested/")}},
-			NextContinuationToken: aliyunoss.Ptr("next"),
+			CommonPrefixes:        []aliyunoss.CommonPrefix{{Prefix: new("root/dir/nested/")}},
+			NextContinuationToken: new("next"),
 		},
 	}
 	storage := newFilesystem(client, "bucket", WithRoot("root"))
@@ -97,7 +97,7 @@ func TestFilesystemStatVirtualDirectory(t *testing.T) {
 	client := &fakeClient{
 		headErr: &aliyunoss.ServiceError{StatusCode: 404, Code: "NoSuchKey"},
 		listResult: &aliyunoss.ListObjectsV2Result{
-			Contents: []aliyunoss.ObjectProperties{{Key: aliyunoss.Ptr("root/images/file.jpg")}},
+			Contents: []aliyunoss.ObjectProperties{{Key: new("root/images/file.jpg")}},
 		},
 	}
 	storage := newFilesystem(client, "bucket", WithRoot("root"))

--- a/filesystem/oss/go.mod
+++ b/filesystem/oss/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/oss/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/filesystem/v4 => ../
 

--- a/filesystem/s3/filesystem.go
+++ b/filesystem/s3/filesystem.go
@@ -82,8 +82,8 @@ func (s *Filesystem) Open(ctx context.Context, path string) (io.ReadCloser, erro
 		return nil, err
 	}
 	output, err := s.client.GetObject(ctx, &awss3.GetObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path)),
+		Bucket: new(s.bucket),
+		Key:    new(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
 		return nil, wrapPathError("open", path, err)
@@ -107,14 +107,14 @@ func (s *Filesystem) Put(
 		return wrapPathError("put", path, err)
 	}
 	input := &awss3.PutObjectInput{
-		Bucket:        ptr(s.bucket),
-		Key:           ptr(s.prefixer.Prefix(path)),
+		Bucket:        new(s.bucket),
+		Key:           new(s.prefixer.Prefix(path)),
 		Body:          src,
-		ContentLength: ptr(contentLength),
+		ContentLength: new(contentLength),
 		Metadata:      cloneMetadata(options.Metadata),
 	}
 	if options.ContentType != "" {
-		input.ContentType = ptr(options.ContentType)
+		input.ContentType = new(options.ContentType)
 	}
 	_, err = s.client.PutObject(ctx, input)
 	if err != nil {
@@ -129,8 +129,8 @@ func (s *Filesystem) Delete(ctx context.Context, path string) error {
 		return err
 	}
 	_, err := s.client.DeleteObject(ctx, &awss3.DeleteObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path)),
+		Bucket: new(s.bucket),
+		Key:    new(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
 		return wrapPathError("delete", path, err)
@@ -151,8 +151,8 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 		return filesystem.Entry{Path: ".", Kind: filesystem.EntryKindDirectory}, nil
 	}
 	output, err := s.client.HeadObject(ctx, &awss3.HeadObjectInput{
-		Bucket: ptr(s.bucket),
-		Key:    ptr(s.prefixer.Prefix(path)),
+		Bucket: new(s.bucket),
+		Key:    new(s.prefixer.Prefix(path)),
 	})
 	if err != nil {
 		if isNotFound(err) {
@@ -184,9 +184,9 @@ func (s *Filesystem) Stat(ctx context.Context, path string) (filesystem.Entry, e
 
 func (s *Filesystem) hasChildren(ctx context.Context, path string) (bool, error) {
 	output, err := s.client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
-		Bucket:  ptr(s.bucket),
-		Prefix:  ptr(directoryPrefix(s.prefixer.Prefix(path))),
-		MaxKeys: ptr(int32(1)),
+		Bucket:  new(s.bucket),
+		Prefix:  new(directoryPrefix(s.prefixer.Prefix(path))),
+		MaxKeys: new(int32(1)),
 	})
 	if err != nil {
 		return false, err
@@ -205,16 +205,16 @@ func (s *Filesystem) ListFiles(
 		return filesystem.ListPage{}, err
 	}
 	input := &awss3.ListObjectsV2Input{
-		Bucket: ptr(s.bucket),
-		Prefix: ptr(directoryPrefix(s.prefixer.Prefix(path))),
+		Bucket: new(s.bucket),
+		Prefix: new(directoryPrefix(s.prefixer.Prefix(path))),
 	}
 	if !options.Recursive {
-		input.Delimiter = ptr("/")
+		input.Delimiter = new("/")
 	}
 	if options.Cursor != "" {
-		input.ContinuationToken = ptr(options.Cursor)
+		input.ContinuationToken = new(options.Cursor)
 	}
-	input.MaxKeys = ptr(int32(options.Limit))
+	input.MaxKeys = new(int32(options.Limit))
 
 	output, err := s.client.ListObjectsV2(ctx, input)
 	if err != nil {
@@ -238,9 +238,9 @@ func (s *Filesystem) Copy(ctx context.Context, src, dst string) error {
 	}
 	copySource := url.PathEscape(s.bucket + "/" + s.prefixer.Prefix(src))
 	_, err := s.client.CopyObject(ctx, &awss3.CopyObjectInput{
-		Bucket:     ptr(s.bucket),
-		CopySource: ptr(copySource),
-		Key:        ptr(s.prefixer.Prefix(dst)),
+		Bucket:     new(s.bucket),
+		CopySource: new(copySource),
+		Key:        new(s.prefixer.Prefix(dst)),
 	})
 	if err != nil {
 		return wrapPathError("copy", src, err)
@@ -301,16 +301,13 @@ func wrapPathError(op, path string, err error) error {
 }
 
 func isNotFound(err error) bool {
-	var notFound *types.NotFound
-	if errors.As(err, &notFound) {
+	if _, ok := errors.AsType[*types.NotFound](err); ok {
 		return true
 	}
-	var noSuchKey *types.NoSuchKey
-	if errors.As(err, &noSuchKey) {
+	if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
 		return true
 	}
-	var apiError smithy.APIError
-	if errors.As(err, &apiError) {
+	if apiError, ok := errors.AsType[smithy.APIError](err); ok {
 		switch apiError.ErrorCode() {
 		case "NotFound", "NoSuchKey", "404":
 			return true
@@ -328,8 +325,4 @@ func dereference(value *string) string {
 		return ""
 	}
 	return *value
-}
-
-func ptr[T any](value T) *T {
-	return &value
 }

--- a/filesystem/s3/filesystem_test.go
+++ b/filesystem/s3/filesystem_test.go
@@ -20,14 +20,14 @@ func TestFilesystemList(t *testing.T) {
 		listOutput: &awss3.ListObjectsV2Output{
 			Contents: []types.Object{
 				{
-					Key:          ptr("root/dir/file.txt"),
-					Size:         ptr(int64(7)),
+					Key:          new("root/dir/file.txt"),
+					Size:         new(int64(7)),
 					LastModified: &modified,
 				},
-				{Key: ptr("root/dir/marker/")},
+				{Key: new("root/dir/marker/")},
 			},
-			CommonPrefixes:        []types.CommonPrefix{{Prefix: ptr("root/dir/nested/")}},
-			NextContinuationToken: ptr("next"),
+			CommonPrefixes:        []types.CommonPrefix{{Prefix: new("root/dir/nested/")}},
+			NextContinuationToken: new("next"),
 		},
 	}
 	storage := newFilesystem(client, "bucket", WithRoot("root"))
@@ -97,7 +97,7 @@ func TestFilesystemStatVirtualDirectory(t *testing.T) {
 	client := &fakeClient{
 		headErr: &types.NoSuchKey{},
 		listOutput: &awss3.ListObjectsV2Output{
-			Contents: []types.Object{{Key: ptr("root/images/file.jpg")}},
+			Contents: []types.Object{{Key: new("root/images/file.jpg")}},
 		},
 	}
 	storage := newFilesystem(client, "bucket", WithRoot("root"))

--- a/filesystem/s3/go.mod
+++ b/filesystem/s3/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/filesystem/s3/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/filesystem/v4 => ../
 

--- a/gin/go.mod
+++ b/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gin/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/gin/server_test.go
+++ b/gin/server_test.go
@@ -34,8 +34,7 @@ func TestServerDoesNotExposeEngine(t *testing.T) {
 	serverType := reflect.TypeFor[Server]()
 	engineType := reflect.TypeFor[*gin.Engine]()
 
-	for i := range serverType.NumField() {
-		field := serverType.Field(i)
+	for field := range serverType.Fields() {
 		assert.False(t, field.Anonymous && field.Type == engineType)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/gomod_test.go
+++ b/gomod_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var expectedVersion = "go 1.25.0"
+var expectedVersion = "go 1.26.0"
 
 func TestAllGoModVersions(t *testing.T) {
 	var modFiles []string

--- a/gorm/logger/multi/go.mod
+++ b/gorm/logger/multi/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/logger/multi/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/gorm/logger/otel/go.mod
+++ b/gorm/logger/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/logger/otel/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/gorm/scope/go.mod
+++ b/gorm/scope/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/gorm/scope/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/hashing/go.mod
+++ b/hashing/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hashing/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/hashing/md5/go.mod
+++ b/hashing/md5/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hashing/md5/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/hashing/v4 => ../
 

--- a/health/go.mod
+++ b/health/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/health/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/http/response/config_test.go
+++ b/http/response/config_test.go
@@ -28,12 +28,12 @@ func TestNewConfig(t *testing.T) {
 		{
 			name:     "sets code",
 			options:  []Option{WithCode(200)},
-			wantCode: intPointer(200),
+			wantCode: new(200),
 		},
 		{
 			name:     "keeps zero code",
 			options:  []Option{WithCode(0)},
-			wantCode: intPointer(0),
+			wantCode: new(0),
 		},
 		{
 			name:     "replaces data",
@@ -79,8 +79,4 @@ func TestWithCodeDoesNotSharePointers(t *testing.T) {
 
 	assert.Equal(t, 500, *first.code)
 	assert.Equal(t, 200, *second.code)
-}
-
-func intPointer(value int) *int {
-	return &value
 }

--- a/http/response/go.mod
+++ b/http/response/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/http/response/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/http/response/response_test.go
+++ b/http/response/response_test.go
@@ -65,14 +65,14 @@ func TestFromError(t *testing.T) {
 			name:       "applies options to success",
 			options:    []response.Option{response.WithCode(0), response.WithData("result")},
 			wantStatus: true,
-			wantCode:   intPointer(0),
+			wantCode:   new(0),
 			wantData:   "result",
 		},
 		{
 			name:        "applies options to failure",
 			err:         errors.New("invalid request"),
 			options:     []response.Option{response.WithCode(10422), response.WithData("details")},
-			wantCode:    intPointer(10422),
+			wantCode:    new(10422),
 			wantMessage: "invalid request",
 			wantData:    "details",
 		},
@@ -166,8 +166,4 @@ func TestBodyJSON(t *testing.T) {
 			assert.JSONEq(t, tt.want, string(payload))
 		})
 	}
-}
-
-func intPointer(value int) *int {
-	return &value
 }

--- a/http/server/go.mod
+++ b/http/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/http/server/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/capability/v4 => ../../capability
 

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -16,8 +16,7 @@ func TestServerDoesNotExposeHTTPServer(t *testing.T) {
 	serverType := reflect.TypeFor[Server]()
 	httpServerType := reflect.TypeFor[*http.Server]()
 
-	for i := range serverType.NumField() {
-		field := serverType.Field(i)
+	for field := range serverType.Fields() {
 		assert.False(t, field.Anonymous && field.Type == httpServerType)
 	}
 }

--- a/hyperf/jet/go.mod
+++ b/hyperf/jet/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/hyperf/jet/middleware/logger/go.mod
+++ b/hyperf/jet/middleware/logger/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/logger/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 

--- a/hyperf/jet/middleware/otel/go.mod
+++ b/hyperf/jet/middleware/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/otel/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 

--- a/hyperf/jet/middleware/otel/internal/semconv/attribute.go
+++ b/hyperf/jet/middleware/otel/internal/semconv/attribute.go
@@ -50,13 +50,11 @@ func ServerPort(port int) attribute.KeyValue {
 
 // ErrorAttributes returns semantic-convention attributes derived from err.
 func ErrorAttributes(err error) []attribute.KeyValue {
-	var rpcErr *jet.RPCResponseError
-	if errors.As(err, &rpcErr) {
+	if rpcErr, ok := errors.AsType[*jet.RPCResponseError](err); ok {
 		return RPCErrorAttributes(rpcErr.Code)
 	}
 
-	var httpErr *jet.HTTPTransporterServerError
-	if errors.As(err, &httpErr) {
+	if httpErr, ok := errors.AsType[*jet.HTTPTransporterServerError](err); ok {
 		statusCode := strconv.Itoa(httpErr.StatusCode)
 		return []attribute.KeyValue{
 			HTTPResponseStatusCode(httpErr.StatusCode),

--- a/hyperf/jet/middleware/recovery/go.mod
+++ b/hyperf/jet/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/recovery/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 

--- a/hyperf/jet/middleware/retry/go.mod
+++ b/hyperf/jet/middleware/retry/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/retry/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4 => ../timeout

--- a/hyperf/jet/middleware/timeout/go.mod
+++ b/hyperf/jet/middleware/timeout/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/hyperf/jet/middleware/timeout/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/hyperf/jet/v4 => ../../
 

--- a/idempotency/go.mod
+++ b/idempotency/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/idempotency/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-fries/fries/codec/json/v4 v4.0.0

--- a/idempotency/memory/go.mod
+++ b/idempotency/memory/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/idempotency/memory/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-fries/fries/idempotency/v4 v4.0.0

--- a/idempotency/redis/go.mod
+++ b/idempotency/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/idempotency/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-fries/fries/idempotency/v4 v4.0.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/internal/tools/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/bufbuild/buf v1.65.0

--- a/jsonrpc/go.mod
+++ b/jsonrpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/jsonrpc/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v4 => ../codec/json

--- a/kratos/middleware/cors/go.mod
+++ b/kratos/middleware/cors/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/cors/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/go-kratos/kratos/v3 v3.0.0
 

--- a/kratos/middleware/otel/go.mod
+++ b/kratos/middleware/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/otel/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-kratos/kratos/v3 v3.0.0

--- a/kratos/middleware/protovalidate/go.mod
+++ b/kratos/middleware/protovalidate/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/kratos/middleware/protovalidate/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.12-20260709200747-435963d16310.1

--- a/lifecycle/go.mod
+++ b/lifecycle/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/lifecycle/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/locker/go.mod
+++ b/locker/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/locker/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/locker/redis/go.mod
+++ b/locker/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/locker/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/locker/v4 => ../
 

--- a/log/slog/go.mod
+++ b/log/slog/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/log/slog/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/log/slog/multi/go.mod
+++ b/log/slog/multi/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/log/slog/multi/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/log/slog/syslog/go.mod
+++ b/log/slog/syslog/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/log/slog/syslog/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/mysql/canal/go.mod
+++ b/mysql/canal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-mysql-org/go-mysql v1.13.0

--- a/mysql/canal/positioner/redis/go.mod
+++ b/mysql/canal/positioner/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/positioner/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/json/v4 => ./../../../../codec/json

--- a/mysql/canal/server/go.mod
+++ b/mysql/canal/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/mysql/canal/server/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/mysql/canal/v4 => ../
 

--- a/otel/otlp/go.mod
+++ b/otel/otlp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/otel/otlp/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/lifecycle/v4 => ../../lifecycle
 

--- a/parallel/go.mod
+++ b/parallel/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/parallel/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/poll/go.mod
+++ b/poll/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/poll/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/ptr/example_test.go
+++ b/ptr/example_test.go
@@ -14,7 +14,7 @@ func ExamplePtr() {
 }
 
 func ExampleValue() {
-	name, ok := ptr.Value(ptr.Ptr("fries"))
+	name, ok := ptr.Value(new("fries"))
 
 	fmt.Println(name, ok)
 	// Output: fries true

--- a/ptr/go.mod
+++ b/ptr/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ptr/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/ptr/ptr.go
+++ b/ptr/ptr.go
@@ -1,8 +1,10 @@
 package ptr
 
 // Ptr returns a pointer to value.
+//
+// Deprecated: use new(value) instead.
 func Ptr[T any](value T) *T {
-	return &value
+	return new(value)
 }
 
 // Value returns the value pointed to by value and reports whether value is non-nil.

--- a/ptr/ptr_test.go
+++ b/ptr/ptr_test.go
@@ -54,13 +54,13 @@ func TestPtr(t *testing.T) {
 
 func TestValue(t *testing.T) {
 	t.Run("value", func(t *testing.T) {
-		got, ok := ptr.Value(ptr.Ptr("foo"))
+		got, ok := ptr.Value(new("foo"))
 		assert.True(t, ok)
 		assert.Equal(t, "foo", got)
 	})
 
 	t.Run("zero value", func(t *testing.T) {
-		got, ok := ptr.Value(ptr.Ptr(""))
+		got, ok := ptr.Value(new(""))
 		assert.True(t, ok)
 		assert.Empty(t, got)
 	})
@@ -72,7 +72,7 @@ func TestValue(t *testing.T) {
 	})
 
 	t.Run("pointer containing nil", func(t *testing.T) {
-		got, ok := ptr.Value(ptr.Ptr[*int](nil))
+		got, ok := ptr.Value(new((*int)(nil)))
 		assert.True(t, ok)
 		assert.Nil(t, got)
 	})
@@ -80,11 +80,11 @@ func TestValue(t *testing.T) {
 
 func TestOr(t *testing.T) {
 	t.Run("value", func(t *testing.T) {
-		assert.Equal(t, "foo", ptr.Or(ptr.Ptr("foo"), "fallback"))
+		assert.Equal(t, "foo", ptr.Or(new("foo"), "fallback"))
 	})
 
 	t.Run("zero value", func(t *testing.T) {
-		assert.Empty(t, ptr.Or(ptr.Ptr(""), "fallback"))
+		assert.Empty(t, ptr.Or(new(""), "fallback"))
 	})
 
 	t.Run("nil pointer", func(t *testing.T) {
@@ -92,7 +92,7 @@ func TestOr(t *testing.T) {
 	})
 
 	t.Run("pointer containing nil", func(t *testing.T) {
-		fallback := ptr.Ptr(10)
-		assert.Nil(t, ptr.Or(ptr.Ptr[*int](nil), fallback))
+		fallback := new(10)
+		assert.Nil(t, ptr.Or(new((*int)(nil)), fallback))
 	})
 }

--- a/queue/adapter/memory/go.mod
+++ b/queue/adapter/memory/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/adapter/memory/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../../../codec

--- a/queue/adapter/rabbitmq/go.mod
+++ b/queue/adapter/rabbitmq/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/adapter/rabbitmq/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../../../codec

--- a/queue/adapter/redis/go.mod
+++ b/queue/adapter/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/adapter/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../../../codec

--- a/queue/examples/tasker/go.mod
+++ b/queue/examples/tasker/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/examples/tasker/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../../../codec

--- a/queue/go.mod
+++ b/queue/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../codec

--- a/queue/kratos/server/go.mod
+++ b/queue/kratos/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/kratos/server/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../../../codec

--- a/queue/middleware/recovery/go.mod
+++ b/queue/middleware/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/queue/middleware/recovery/v4
 
-go 1.25.0
+go 1.26.0
 
 replace (
 	github.com/go-fries/fries/codec/v4 => ../../../codec

--- a/ratelimit/go.mod
+++ b/ratelimit/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ratelimit/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/ratelimit/memory/go.mod
+++ b/ratelimit/memory/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ratelimit/memory/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-fries/fries/ratelimit/v4 v4.0.0

--- a/ratelimit/redis/go.mod
+++ b/ratelimit/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/ratelimit/redis/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-fries/fries/ratelimit/v4 v4.0.0

--- a/recovery/go.mod
+++ b/recovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/recovery/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "gomodTidy"
   ],
   "constraints": {
-    "go": "1.25.0"
+    "go": "1.26.0"
   },
   "packageRules": [
     {

--- a/retry/go.mod
+++ b/retry/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/retry/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -150,13 +150,11 @@ type errorInfo struct {
 func inspectError(err error) errorInfo {
 	info := errorInfo{cause: err}
 
-	var permanentErr *permanentError
-	if errors.As(err, &permanentErr) {
+	if _, ok := errors.AsType[*permanentError](err); ok {
 		info.permanent = true
 	}
 
-	var afterErr *afterError
-	if errors.As(err, &afterErr) {
+	if afterErr, ok := errors.AsType[*afterError](err); ok {
 		info.override = true
 		info.overrideDelay = afterErr.delay
 	}

--- a/signal/go.mod
+++ b/signal/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/signal/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/slices/go.mod
+++ b/slices/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/slices/v4
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/go-fries/fries/constraints/v4 => ../constraints
 

--- a/strings/go.mod
+++ b/strings/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/strings/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/support/go.mod
+++ b/support/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/support/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/timezone/go.mod
+++ b/timezone/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/timezone/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/udp/go.mod
+++ b/udp/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/udp/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-kratos/kratos/v3 v3.0.0

--- a/webhook/go.mod
+++ b/webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/webhook/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/webhook/sender/go.mod
+++ b/webhook/sender/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/webhook/sender/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-fries/fries/webhook/v4 v4.0.0

--- a/x/container/go.mod
+++ b/x/container/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/container/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/x/pagination/go.mod
+++ b/x/pagination/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/pagination/v4
 
-go 1.25.0
+go 1.26.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/x/prints/go.mod
+++ b/x/prints/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-fries/fries/x/prints/v4
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/cheggaaa/pb/v3 v3.2.0


### PR DESCRIPTION
## Summary
Raise the minimum supported Go version to 1.26 and validate forward compatibility with Go 1.27. Adopt Go 1.26 standard-library APIs while preserving the deprecated `ptr.Ptr` compatibility helper.

## Changes
- Update all 91 modules and repository tooling and documentation to Go 1.26.0.
- Test CI with Go 1.26.x and Go 1.27.x while continuing to forbid `toolchain` directives.
- Update `go mod tidy` compatibility to Go 1.26.0.
- Make the Makefile test and coverage targets propagate package and test failures.
- Modernize affected code with `new(expr)`, `errors.AsType`, and `reflect.Type.Fields`.
- Deprecate `ptr.Ptr` in favor of `new(value)` without removing the public API.

## Motivation
- Align the supported toolchains with Go 1.26 and validate the next release in CI.
- Ensure repository validation cannot report success when package discovery or tests fail.

## Breaking Changes
- Consumers now need Go 1.26 or newer to build repository modules.
- Older Go toolchains cannot load the updated `go.mod` files.

## Before and After
| Area | Before | After |
| --- | --- | --- |
| Minimum Go version | Go 1.25 | Go 1.26 |
| CI toolchains | Go 1.25.x and 1.26.x | Go 1.26.x and 1.27.x |
| Pointer construction | `ptr.Ptr(value)` | `new(value)`; `ptr.Ptr` remains deprecated |

## Migration
1. Upgrade local and CI Go toolchains to Go 1.26 or newer.
2. Replace `ptr.Ptr(value)` with `new(value)` where practical. Existing `ptr.Ptr` calls still compile but are deprecated.

## Testing
- `GOTOOLCHAIN=go1.26.0 make go-mod-tidy`
- `GOTOOLCHAIN=go1.26.0 make lint`
- `make build` with Go 1.26.0 and Go 1.27.0
- Root-module tests with Go 1.26.0 and Go 1.27.0
- Changed-component tests with both versions for `chi`, `gin`, `http/server`, `http/response`, `filesystem/oss`, `filesystem/s3`, `hyperf/jet/middleware/otel`, `retry`, and `ptr`

The full service-backed suite was not run locally because Redis and MySQL were unavailable. CI provisions both services and runs repository coverage on both configured Go versions.

## Notes
- No `toolchain` directives were added.
- No `go.sum` files changed.