### PR TITLE
fix(jsonrpc): validate IDs and expand test coverage

### DIFF
--- a/jsonrpc/client_test.go
+++ b/jsonrpc/client_test.go
@@ -1,0 +1,197 @@
+package jsonrpc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type transportFunc func(context.Context, string, *Request) (*Response, error)
+
+func (f transportFunc) Send(ctx context.Context, namespace string, request *Request) (*Response, error) {
+	return f(ctx, namespace, request)
+}
+
+type codecStub struct {
+	marshal   func(any) ([]byte, error)
+	unmarshal func([]byte, any) error
+}
+
+func (c *codecStub) Marshal(value any) ([]byte, error) {
+	return c.marshal(value)
+}
+
+func (c *codecStub) Unmarshal(data []byte, value any) error {
+	return c.unmarshal(data, value)
+}
+
+type staticIDGenerator struct {
+	id *ID
+}
+
+func (g staticIDGenerator) Generate() *ID {
+	return g.id
+}
+
+func TestNewClientOptions(t *testing.T) {
+	transport := transportFunc(func(context.Context, string, *Request) (*Response, error) {
+		return &Response{}, nil
+	})
+	customCodec := &codecStub{
+		marshal: func(any) ([]byte, error) { return nil, nil },
+		unmarshal: func([]byte, any) error {
+			return nil
+		},
+	}
+	idGenerator := staticIDGenerator{id: NewID("fixed-id")}
+	middleware := func(next Handler) Handler { return next }
+
+	clientWithOptions := NewClient(
+		transport,
+		WithMiddlewares(middleware),
+		WithIDGenerator(idGenerator),
+		WithCodec(customCodec),
+	).(*client)
+
+	assert.Same(t, customCodec, clientWithOptions.codec)
+	assert.Equal(t, idGenerator, clientWithOptions.idGenerator)
+	assert.Len(t, clientWithOptions.middlewares, 1)
+
+	clientWithOptions.Use(middleware)
+	assert.Len(t, clientWithOptions.middlewares, 2)
+
+	namespaced := clientWithOptions.Namespace("users").(*client)
+	assert.Equal(t, "users", namespaced.namespace)
+	assert.Empty(t, clientWithOptions.namespace)
+	assert.NotNil(t, namespaced.transport)
+
+	clientWithDefaults := NewClient(transport).(*client)
+	assert.Equal(t, DefaultCodec, clientWithDefaults.codec)
+	assert.Equal(t, DefaultIDGenerator, clientWithDefaults.idGenerator)
+	assert.Empty(t, clientWithDefaults.middlewares)
+}
+
+func TestClientInvoke(t *testing.T) {
+	id := NewID("fixed-id")
+	var calls []string
+	middleware := func(name string) Middleware {
+		return func(next Handler) Handler {
+			return func(ctx context.Context, namespace string, req *Request) (*Response, error) {
+				calls = append(calls, name+":before")
+				resp, err := next(ctx, namespace, req)
+				calls = append(calls, name+":after")
+				return resp, err
+			}
+		}
+	}
+	transport := transportFunc(func(_ context.Context, namespace string, request *Request) (*Response, error) {
+		calls = append(calls, "transport")
+		assert.Equal(t, "users", namespace)
+		assert.Equal(t, ProtocolVersion, request.JSONRPC)
+		assert.Equal(t, "find", request.Method)
+		assert.Same(t, id, request.ID)
+		assert.JSONEq(t, `[123,"active"]`, string(request.Params))
+		return &Response{
+			JSONRPC: ProtocolVersion,
+			Result:  json.RawMessage(`{"name":"Alice"}`),
+			ID:      id,
+		}, nil
+	})
+	client := NewClient(
+		transport,
+		WithIDGenerator(staticIDGenerator{id: id}),
+		WithMiddlewares(middleware("client")),
+	).Namespace("users")
+	ctx := ContextWithMiddlewares(t.Context(), middleware("context"))
+	var result struct {
+		Name string `json:"name"`
+	}
+
+	resp, err := client.Invoke(ctx, &result, "find", 123, "active")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Alice", result.Name)
+	assert.Equal(t, []string{
+		"client:before",
+		"context:before",
+		"transport",
+		"context:after",
+		"client:after",
+	}, calls)
+}
+
+func TestClientInvokeErrors(t *testing.T) {
+	sentinel := errors.New("sentinel")
+
+	t.Run("marshal", func(t *testing.T) {
+		transportCalled := false
+		client := NewClient(
+			transportFunc(func(context.Context, string, *Request) (*Response, error) {
+				transportCalled = true
+				return nil, nil
+			}),
+			WithCodec(&codecStub{
+				marshal: func(any) ([]byte, error) { return nil, sentinel },
+				unmarshal: func([]byte, any) error {
+					return nil
+				},
+			}),
+		)
+
+		resp, err := client.Invoke(t.Context(), nil, "method")
+
+		assert.Nil(t, resp)
+		assert.ErrorIs(t, err, sentinel)
+		assert.False(t, transportCalled)
+	})
+
+	t.Run("transport", func(t *testing.T) {
+		wantResp := &Response{}
+		client := NewClient(transportFunc(func(context.Context, string, *Request) (*Response, error) {
+			return wantResp, sentinel
+		}))
+
+		resp, err := client.Invoke(t.Context(), nil, "method")
+
+		assert.Same(t, wantResp, resp)
+		assert.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("rpc response", func(t *testing.T) {
+		rpcErr := &Error{Code: -32601, Message: "method not found"}
+		wantResp := &Response{Error: rpcErr}
+		client := NewClient(transportFunc(func(context.Context, string, *Request) (*Response, error) {
+			return wantResp, nil
+		}))
+
+		resp, err := client.Invoke(t.Context(), nil, "method")
+
+		assert.Same(t, wantResp, resp)
+		assert.Same(t, rpcErr, err)
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		wantResp := &Response{Result: json.RawMessage(`"result"`)}
+		client := NewClient(
+			transportFunc(func(context.Context, string, *Request) (*Response, error) {
+				return wantResp, nil
+			}),
+			WithCodec(&codecStub{
+				marshal: func(any) ([]byte, error) { return []byte("[]"), nil },
+				unmarshal: func([]byte, any) error {
+					return sentinel
+				},
+			}),
+		)
+
+		resp, err := client.Invoke(t.Context(), nil, "method")
+
+		assert.Same(t, wantResp, resp)
+		assert.ErrorIs(t, err, sentinel)
+	})
+}

--- a/jsonrpc/id.go
+++ b/jsonrpc/id.go
@@ -82,23 +82,17 @@ func NewID(v any) *ID {
 }
 
 func (i *ID) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		i.isNil = true
-		return nil
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return fmt.Errorf("jsonrpc: unmarshal id: %w", err)
 	}
 
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		i.str = &s
-		return nil
+	id := NewID(value)
+	if id == nil {
+		return fmt.Errorf("jsonrpc: invalid id type %T: expected string, number, or null", value)
 	}
 
-	var n float64
-	if err := json.Unmarshal(data, &n); err == nil {
-		i.num = &n
-		return nil
-	}
-
+	*i = *id
 	return nil
 }
 

--- a/jsonrpc/id_test.go
+++ b/jsonrpc/id_test.go
@@ -42,6 +42,7 @@ func TestNewID(t *testing.T) {
 	}
 
 	assert.Nil(t, NewID(true))
+	assert.Equal(t, "null", (&ID{}).String())
 }
 
 func TestIDJSON(t *testing.T) {
@@ -75,7 +76,6 @@ func TestIDJSON(t *testing.T) {
 			{name: "nil", data: "null", want: "null"},
 			{name: "string", data: `"request-id"`, want: "request-id"},
 			{name: "number", data: "12.5", want: "12.5"},
-			{name: "unsupported value", data: "true", want: "null"},
 		}
 
 		for _, tt := range tests {
@@ -86,6 +86,41 @@ func TestIDJSON(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("reject invalid values without changing the ID", func(t *testing.T) {
+		tests := []struct {
+			name string
+			data string
+		}{
+			{name: "boolean", data: "true"},
+			{name: "array", data: "[]"},
+			{name: "object", data: "{}"},
+			{name: "malformed JSON", data: "{"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				id := NewID("existing-id")
+				err := id.UnmarshalJSON([]byte(tt.data))
+
+				require.Error(t, err)
+				assert.Equal(t, "existing-id", id.String())
+			})
+		}
+	})
+}
+
+func TestIDUnmarshalJSONReplacesPreviousValue(t *testing.T) {
+	id := NewID("first-id")
+
+	require.NoError(t, id.UnmarshalJSON([]byte("42")))
+	assert.Equal(t, "42", id.String())
+
+	require.NoError(t, id.UnmarshalJSON([]byte("null")))
+	assert.Equal(t, "null", id.String())
+
+	require.NoError(t, id.UnmarshalJSON([]byte(`"last-id"`)))
+	assert.Equal(t, "last-id", id.String())
 }
 
 func TestUUIDGenerator(t *testing.T) {

--- a/jsonrpc/id_test.go
+++ b/jsonrpc/id_test.go
@@ -1,0 +1,98 @@
+package jsonrpc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewID(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "nil", value: nil, want: "null"},
+		{name: "string", value: "request-id", want: "request-id"},
+		{name: "int", value: int(1), want: "1"},
+		{name: "int8", value: int8(2), want: "2"},
+		{name: "int16", value: int16(3), want: "3"},
+		{name: "int32", value: int32(4), want: "4"},
+		{name: "int64", value: int64(5), want: "5"},
+		{name: "uint", value: uint(6), want: "6"},
+		{name: "uint8", value: uint8(7), want: "7"},
+		{name: "uint16", value: uint16(8), want: "8"},
+		{name: "uint32", value: uint32(9), want: "9"},
+		{name: "uint64", value: uint64(10), want: "10"},
+		{name: "uintptr", value: uintptr(11), want: "11"},
+		{name: "float32", value: float32(12.5), want: "12.5"},
+		{name: "float64", value: 13.5, want: "13.5"},
+		{name: "complex64", value: complex64(complex(14.5, 1)), want: "14.5"},
+		{name: "complex128", value: complex(15.5, 1), want: "15.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := NewID(tt.value)
+			require.NotNil(t, id)
+			assert.Equal(t, tt.want, id.String())
+		})
+	}
+
+	assert.Nil(t, NewID(true))
+}
+
+func TestIDJSON(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
+		tests := []struct {
+			name string
+			id   ID
+			want string
+		}{
+			{name: "nil", id: *NewID(nil), want: "null"},
+			{name: "string", id: *NewID("request-id"), want: `"request-id"`},
+			{name: "number", id: *NewID(12.5), want: "12.5"},
+			{name: "zero value", id: ID{}, want: "null"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := tt.id.MarshalJSON()
+				require.NoError(t, err)
+				assert.JSONEq(t, tt.want, string(got))
+			})
+		}
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		tests := []struct {
+			name string
+			data string
+			want string
+		}{
+			{name: "nil", data: "null", want: "null"},
+			{name: "string", data: `"request-id"`, want: "request-id"},
+			{name: "number", data: "12.5", want: "12.5"},
+			{name: "unsupported value", data: "true", want: "null"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var id ID
+				require.NoError(t, id.UnmarshalJSON([]byte(tt.data)))
+				assert.Equal(t, tt.want, id.String())
+			})
+		}
+	})
+}
+
+func TestUUIDGenerator(t *testing.T) {
+	generator := NewUUIDGenerator()
+	id := generator.Generate()
+
+	require.NotNil(t, id)
+	_, err := uuid.Parse(id.String())
+	require.NoError(t, err)
+}

--- a/jsonrpc/middleware_test.go
+++ b/jsonrpc/middleware_test.go
@@ -1,0 +1,52 @@
+package jsonrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChain(t *testing.T) {
+	var calls []string
+	middleware := func(name string) Middleware {
+		return func(next Handler) Handler {
+			return func(ctx context.Context, namespace string, req *Request) (*Response, error) {
+				calls = append(calls, name+":before")
+				resp, err := next(ctx, namespace, req)
+				calls = append(calls, name+":after")
+				return resp, err
+			}
+		}
+	}
+	final := func(context.Context, string, *Request) (*Response, error) {
+		calls = append(calls, "handler")
+		return &Response{}, nil
+	}
+
+	resp, err := chain(middleware("first"), middleware("second"))(final)(t.Context(), "", &Request{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, []string{
+		"first:before",
+		"second:before",
+		"handler",
+		"second:after",
+		"first:after",
+	}, calls)
+}
+
+func TestMiddlewaresFromContext(t *testing.T) {
+	middleware := func(next Handler) Handler { return next }
+
+	ctx := ContextWithMiddlewares(t.Context(), middleware)
+	middlewares := middlewaresFromContext(ctx)
+	require.Len(t, middlewares, 1)
+	assert.NotNil(t, middlewares[0])
+	assert.Nil(t, middlewaresFromContext(t.Context()))
+
+	invalidCtx := context.WithValue(t.Context(), middlewareContextKey{}, "not middleware")
+	assert.Nil(t, middlewaresFromContext(invalidCtx))
+}

--- a/jsonrpc/transport_test.go
+++ b/jsonrpc/transport_test.go
@@ -1,0 +1,132 @@
+package jsonrpc
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestNewHTTPTransport(t *testing.T) {
+	customClient := &http.Client{}
+	transport := NewHTTPTransport(
+		"https://example.com/",
+		WithHTTPTransportUserAgent("fries-test"),
+		WithHTTPTransportClient(customClient),
+	)
+
+	assert.Equal(t, "https://example.com", transport.addr)
+	assert.Equal(t, "fries-test", transport.userAgent)
+	assert.Same(t, customClient, transport.httpClient)
+
+	defaultTransport := NewHTTPTransport("https://example.com")
+	assert.Same(t, http.DefaultClient, defaultTransport.httpClient)
+}
+
+func TestHTTPTransportSend(t *testing.T) {
+	requests := make(chan *http.Request, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests <- request.Clone(request.Context())
+
+		var rpcRequest Request
+		if err := json.NewDecoder(request.Body).Decode(&rpcRequest); err != nil {
+			t.Errorf("decode request: %v", err)
+			return
+		}
+		assert.Equal(t, "method", rpcRequest.Method)
+
+		writer.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(writer, `{"jsonrpc":"2.0","result":"ok","id":"request-id"}`)
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	transport := NewHTTPTransport(
+		server.URL+"/",
+		WithHTTPTransportClient(server.Client()),
+		WithHTTPTransportUserAgent("fries-test"),
+	)
+	request := &Request{
+		JSONRPC: ProtocolVersion,
+		Method:  "method",
+		Params:  json.RawMessage(`[]`),
+		ID:      NewID("request-id"),
+	}
+
+	resp, err := transport.Send(t.Context(), "", request)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.JSONEq(t, `"ok"`, string(resp.Result))
+	received := <-requests
+	assert.Equal(t, "/", received.URL.Path)
+	assert.Equal(t, http.MethodPost, received.Method)
+	assert.Equal(t, "application/json", received.Header.Get("Content-Type"))
+	assert.Equal(t, "fries-test", received.Header.Get("User-Agent"))
+
+	_, err = transport.Send(t.Context(), "/users", request)
+	require.NoError(t, err)
+	received = <-requests
+	assert.Equal(t, "/users", received.URL.Path)
+}
+
+func TestHTTPTransportSendErrors(t *testing.T) {
+	sentinel := errors.New("sentinel")
+
+	t.Run("encode request", func(t *testing.T) {
+		transport := NewHTTPTransport("https://example.com")
+		resp, err := transport.Send(t.Context(), "", &Request{Params: json.RawMessage(`{`)})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+	})
+
+	t.Run("create request", func(t *testing.T) {
+		transport := NewHTTPTransport("://invalid")
+		resp, err := transport.Send(t.Context(), "", &Request{})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+	})
+
+	t.Run("send request", func(t *testing.T) {
+		transport := NewHTTPTransport("https://example.com", WithHTTPTransportClient(&http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, sentinel
+			}),
+		}))
+
+		resp, err := transport.Send(t.Context(), "", &Request{})
+
+		assert.Nil(t, resp)
+		assert.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("decode response", func(t *testing.T) {
+		transport := NewHTTPTransport("https://example.com", WithHTTPTransportClient(&http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("not-json")),
+				}, nil
+			}),
+		}))
+
+		resp, err := transport.Send(t.Context(), "", &Request{})
+
+		assert.Nil(t, resp)
+		require.Error(t, err)
+	})
+}

--- a/jsonrpc/types_test.go
+++ b/jsonrpc/types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProtocolVersion(t *testing.T) {
@@ -19,4 +20,13 @@ func TestRequestUsesProtocolVersion(t *testing.T) {
 	}
 
 	assert.Equal(t, ProtocolVersion, req.JSONRPC)
+}
+
+func TestError(t *testing.T) {
+	err := &Error{Code: -32601, Message: "method not found"}
+
+	assert.Equal(t, "code: -32601, message: method not found", err.Error())
+	unwrapped := err.Unwrap()
+	require.Error(t, unwrapped)
+	assert.Equal(t, "method not found", unwrapped.Error())
 }


### PR DESCRIPTION
## Summary
Add comprehensive unit coverage for the JSON-RPC module and enforce spec-compliant ID decoding.

## Changes
- cover client invocation, middleware ordering, ID handling, and HTTP transport success and failure paths
- reject boolean, array, object, and malformed JSON-RPC IDs during unmarshalling
- preserve the existing ID when decoding fails and replace prior state after successful decoding

## Motivation
- invalid JSON-RPC IDs were silently accepted and could leave stale ID state when an `ID` value was reused
- the module previously had minimal unit coverage despite containing client and transport behavior

## Testing
- `go test -race -coverprofile=coverage.out ./...` (100.0% statement coverage)
- `make lint/jsonrpc`