### PR TITLE
test(cors): add middleware unit coverage

### DIFF
--- a/kratos/middleware/cors/cors_test.go
+++ b/kratos/middleware/cors/cors_test.go
@@ -1,0 +1,247 @@
+package cors
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kratos/kratos/v3/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type headerCarrier http.Header
+
+func (h headerCarrier) Get(key string) string {
+	return http.Header(h).Get(key)
+}
+
+func (h headerCarrier) Set(key, value string) {
+	http.Header(h).Set(key, value)
+}
+
+func (h headerCarrier) Add(key, value string) {
+	http.Header(h).Add(key, value)
+}
+
+func (h headerCarrier) Keys() []string {
+	keys := make([]string, 0, len(h))
+	for key := range h {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func (h headerCarrier) Values(key string) []string {
+	return http.Header(h).Values(key)
+}
+
+type mockTransport struct {
+	kind        transport.Kind
+	requestHead headerCarrier
+	replyHead   headerCarrier
+}
+
+func newMockTransport(kind transport.Kind) *mockTransport {
+	return &mockTransport{
+		kind:        kind,
+		requestHead: headerCarrier{},
+		replyHead:   headerCarrier{},
+	}
+}
+
+func (m *mockTransport) Kind() transport.Kind {
+	return m.kind
+}
+
+func (m *mockTransport) Endpoint() string {
+	return ""
+}
+
+func (m *mockTransport) Operation() string {
+	return ""
+}
+
+func (m *mockTransport) RequestHeader() transport.Header {
+	return m.requestHead
+}
+
+func (m *mockTransport) ReplyHeader() transport.Header {
+	return m.replyHead
+}
+
+type mockHTTPTransport struct {
+	*mockTransport
+	request *http.Request
+}
+
+func (m *mockHTTPTransport) Request() *http.Request {
+	return m.request
+}
+
+func (m *mockHTTPTransport) PathTemplate() string {
+	return ""
+}
+
+func TestOptions(t *testing.T) {
+	op := newOptions()
+	assert.Equal(t, []string{"*"}, op.paths)
+	assert.Equal(t, []string{"*"}, op.allowedMethods)
+	assert.Equal(t, []string{"*"}, op.allowedHeaders)
+	assert.Equal(t, []string{"*"}, op.allowedOrigins)
+
+	options := []Option{
+		Path("/api/*"),
+		AppendPath("/health"),
+		AllowedMethods(http.MethodGet),
+		AppendAllowedMethods(http.MethodPost),
+		AllowedHeaders("Content-Type"),
+		AppendAllowedHeaders("Authorization"),
+		AllowedOrigins("https://example.com"),
+		AppendAllowedOrigins("https://api.example.com"),
+	}
+	for _, option := range options {
+		option(op)
+	}
+
+	assert.Equal(t, []string{"/api/*", "/health"}, op.paths)
+	assert.Equal(t, []string{http.MethodGet, http.MethodPost}, op.allowedMethods)
+	assert.Equal(t, []string{"Content-Type", "Authorization"}, op.allowedHeaders)
+	assert.Equal(t, []string{"https://example.com", "https://api.example.com"}, op.allowedOrigins)
+}
+
+func TestIsPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		want    bool
+	}{
+		{name: "all paths", pattern: "*", value: "/api/users", want: true},
+		{name: "exact", pattern: "/api/users", value: "/api/users", want: true},
+		{name: "leading slash", pattern: "api/users", value: "/api/users", want: true},
+		{name: "wildcard", pattern: "/api/*", value: "/api/users/1", want: true},
+		{name: "mismatch", pattern: "/api/*", value: "/admin/users", want: false},
+		{name: "invalid expression", pattern: "[", value: "/api/users", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPath(tt.pattern, tt.value))
+		})
+	}
+}
+
+func TestCorsPassesThroughWithoutHTTPRequest(t *testing.T) {
+	sentinel := errors.New("handler error")
+	request := &struct{}{}
+	wantReply := &struct{}{}
+	tests := []struct {
+		name string
+		ctx  func() context.Context
+	}{
+		{
+			name: "missing transport",
+			ctx:  t.Context,
+		},
+		{
+			name: "non HTTP transport",
+			ctx: func() context.Context {
+				return transport.NewServerContext(t.Context(), newMockTransport(transport.KindGRPC))
+			},
+		},
+		{
+			name: "missing HTTP request",
+			ctx: func() context.Context {
+				return transport.NewServerContext(t.Context(), newMockTransport(transport.KindHTTP))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			handler := func(_ context.Context, gotRequest any) (any, error) {
+				called = true
+				assert.Same(t, request, gotRequest)
+				return wantReply, sentinel
+			}
+
+			reply, err := Cors()(handler)(tt.ctx(), request)
+
+			assert.True(t, called)
+			assert.Same(t, wantReply, reply)
+			assert.ErrorIs(t, err, sentinel)
+		})
+	}
+}
+
+func TestCorsAddsHeadersForMatchingPath(t *testing.T) {
+	httpRequest := httptest.NewRequest(http.MethodOptions, "https://service.example.com/api/users", nil)
+	tr := &mockHTTPTransport{
+		mockTransport: newMockTransport(transport.KindHTTP),
+		request:       httpRequest,
+	}
+	ctx := transport.NewServerContext(t.Context(), tr)
+	request := &struct{}{}
+	handler := func(_ context.Context, gotRequest any) (any, error) {
+		assert.Same(t, request, gotRequest)
+		return gotRequest, nil
+	}
+	middleware := Cors(
+		Path("/api/*", "*"),
+		AllowedMethods(http.MethodGet, http.MethodPost),
+		AllowedHeaders("Content-Type", "Authorization"),
+		AllowedOrigins("https://client.example.com"),
+	)
+
+	reply, err := middleware(handler)(ctx, request)
+
+	require.NoError(t, err)
+	assert.Same(t, request, reply)
+	assert.Equal(t, []string{"true"}, tr.replyHead.Values("Access-Control-Allow-Credentials"))
+	assert.Equal(t, []string{"GET, POST"}, tr.replyHead.Values("Access-Control-Allow-Methods"))
+	assert.Equal(t, []string{"Content-Type, Authorization"}, tr.replyHead.Values("Access-Control-Allow-Headers"))
+	assert.Equal(t, []string{"https://client.example.com"}, tr.replyHead.Values("Access-Control-Allow-Origin"))
+}
+
+func TestCorsUsesDefaults(t *testing.T) {
+	httpRequest := httptest.NewRequest(http.MethodGet, "https://service.example.com/health", nil)
+	tr := &mockHTTPTransport{
+		mockTransport: newMockTransport(transport.KindHTTP),
+		request:       httpRequest,
+	}
+	ctx := transport.NewServerContext(t.Context(), tr)
+	handler := func(_ context.Context, request any) (any, error) {
+		return request, nil
+	}
+
+	_, err := Cors()(handler)(ctx, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "*", tr.replyHead.Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "*", tr.replyHead.Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "*", tr.replyHead.Get("Access-Control-Allow-Origin"))
+}
+
+func TestCorsDoesNotAddHeadersForUnmatchedPath(t *testing.T) {
+	httpRequest := httptest.NewRequest(http.MethodGet, "https://service.example.com/admin/users", nil)
+	tr := &mockHTTPTransport{
+		mockTransport: newMockTransport(transport.KindHTTP),
+		request:       httpRequest,
+	}
+	ctx := transport.NewServerContext(t.Context(), tr)
+	handlerCalled := false
+	handler := func(_ context.Context, request any) (any, error) {
+		handlerCalled = true
+		return request, nil
+	}
+
+	_, err := Cors(Path("/api/*"))(handler)(ctx, nil)
+
+	require.NoError(t, err)
+	assert.True(t, handlerCalled)
+	assert.Empty(t, tr.replyHead)
+}

--- a/kratos/middleware/cors/go.mod
+++ b/kratos/middleware/cors/go.mod
@@ -2,7 +2,10 @@ module github.com/go-fries/fries/kratos/middleware/cors/v4
 
 go 1.26.0
 
-require github.com/go-kratos/kratos/v3 v3.0.0
+require (
+	github.com/go-kratos/kratos/v3 v3.0.0
+	github.com/stretchr/testify v1.12.1
+)
 
 require (
 	github.com/go-playground/form/v4 v4.3.0 // indirect
@@ -10,6 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect

--- a/kratos/middleware/cors/go.sum
+++ b/kratos/middleware/cors/go.sum
@@ -27,6 +27,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
@@ -39,6 +41,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=
 golang.org/x/net v0.58.0/go.mod h1:YwCddHnFlT7eLQqVprV19OnhLGtc5xOKgE0RyqgfWAU=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=


### PR DESCRIPTION
## Summary
Add isolated unit coverage for the Kratos CORS middleware without requiring a running server or external services.

## Changes
- verify default, replacement, and append behavior for all middleware options
- cover exact, wildcard, mismatched, and invalid path patterns
- test HTTP header application and pass-through behavior for missing or non-HTTP transports
- verify handler replies and errors are preserved

## Motivation
- the CORS module previously had no unit tests despite controlling response security headers

## Testing
- `go test -race -coverprofile=coverage.out ./...` (100.0% statement coverage)
- `make lint/kratos/middleware/cors`