### PR TITLE
fix(jet): preserve JSON-RPC error data

### DIFF
--- a/hyperf/jet/formatter.go
+++ b/hyperf/jet/formatter.go
@@ -1,6 +1,7 @@
 package jet
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -71,7 +72,65 @@ type JSONRPCFormatterRequest struct {
 type JSONRPCFormatterResponseError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
-	Data    error
+	Data    error  `json:"data,omitempty"`
+}
+
+type jsonRPCFormatterResponseErrorWire struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+type jsonRPCErrorData struct {
+	raw json.RawMessage
+}
+
+func (e jsonRPCErrorData) Error() string {
+	var message string
+	if err := json.Unmarshal(e.raw, &message); err == nil {
+		return message
+	}
+	return string(e.raw)
+}
+
+func (e jsonRPCErrorData) MarshalJSON() ([]byte, error) {
+	return e.raw, nil
+}
+
+func (e JSONRPCFormatterResponseError) MarshalJSON() ([]byte, error) {
+	var data json.RawMessage
+	if e.Data != nil {
+		var err error
+		if _, ok := e.Data.(json.Marshaler); ok {
+			data, err = json.Marshal(e.Data)
+		} else {
+			data, err = json.Marshal(e.Data.Error())
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return json.Marshal(jsonRPCFormatterResponseErrorWire{
+		Code:    e.Code,
+		Message: e.Message,
+		Data:    data,
+	})
+}
+
+func (e *JSONRPCFormatterResponseError) UnmarshalJSON(data []byte) error {
+	var decoded jsonRPCFormatterResponseErrorWire
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	e.Code = decoded.Code
+	e.Message = decoded.Message
+	e.Data = nil
+	if len(decoded.Data) > 0 && !bytes.Equal(bytes.TrimSpace(decoded.Data), []byte("null")) {
+		e.Data = jsonRPCErrorData{raw: decoded.Data}
+	}
+	return nil
 }
 
 type JSONRPCFormatterResponse struct {

--- a/hyperf/jet/formatter.go
+++ b/hyperf/jet/formatter.go
@@ -104,7 +104,10 @@ func (e JSONRPCFormatterResponseError) MarshalJSON() ([]byte, error) {
 		if _, ok := e.Data.(json.Marshaler); ok {
 			data, err = json.Marshal(e.Data)
 		} else {
-			data, err = json.Marshal(e.Data.Error())
+			data, err = json.Marshal(e.Data)
+			if err == nil && bytes.Equal(data, []byte("{}")) {
+				data, err = json.Marshal(e.Data.Error())
+			}
 		}
 		if err != nil {
 			return nil, err

--- a/hyperf/jet/formatter_test.go
+++ b/hyperf/jet/formatter_test.go
@@ -99,10 +99,21 @@ func TestJSONRPCFormatterErrorResponse(t *testing.T) {
 		ID:      "request-id",
 		Code:    -32601,
 		Message: "method not found",
+		Err:     errors.New("upstream error"),
 	}
 
 	data, err := formatter.FormatResponse(nil, want)
 	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"result": null,
+		"id": "request-id",
+		"error": {
+			"code": -32601,
+			"message": "method not found",
+			"data": "upstream error"
+		}
+	}`, string(data))
 
 	response, err := formatter.ParseResponse(data)
 	assert.Nil(t, response)
@@ -111,7 +122,58 @@ func TestJSONRPCFormatterErrorResponse(t *testing.T) {
 	assert.Equal(t, want.ID, got.ID)
 	assert.Equal(t, want.Code, got.Code)
 	assert.Equal(t, want.Message, got.Message)
-	assert.NoError(t, got.Err)
+	require.Error(t, got.Err)
+	assert.Equal(t, "upstream error", got.Err.Error())
+}
+
+func TestJSONRPCFormatterStructuredErrorData(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+	data := []byte(`{
+		"jsonrpc": "2.0",
+		"id": "request-id",
+		"error": {
+			"code": -32603,
+			"message": "internal error",
+			"data": {"retryable": true}
+		}
+	}`)
+
+	response, err := formatter.ParseResponse(data)
+	assert.Nil(t, response)
+	var rpcErr *RPCResponseError
+	require.ErrorAs(t, err, &rpcErr)
+	require.Error(t, rpcErr.Err)
+	assert.JSONEq(t, `{"retryable":true}`, rpcErr.Err.Error())
+
+	encoded, err := formatter.FormatResponse(nil, rpcErr)
+	require.NoError(t, err)
+	var envelope JSONRPCFormatterResponse
+	require.NoError(t, json.Unmarshal(encoded, &envelope))
+	require.NotNil(t, envelope.Error)
+	require.Error(t, envelope.Error.Data)
+	assert.JSONEq(t, `{"retryable":true}`, envelope.Error.Data.Error())
+}
+
+func TestJSONRPCFormatterEmptyErrorData(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+	formatted, err := formatter.FormatResponse(nil, &RPCResponseError{
+		ID:      "request-id",
+		Code:    -32601,
+		Message: "method not found",
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, string(formatted), `"data"`)
+
+	for _, data := range []string{
+		`{"jsonrpc":"2.0","id":"request-id","error":{"code":-32601,"message":"method not found"}}`,
+		`{"jsonrpc":"2.0","id":"request-id","error":{"code":-32601,"message":"method not found","data":null}}`,
+	} {
+		response, err := formatter.ParseResponse([]byte(data))
+		assert.Nil(t, response)
+		var rpcErr *RPCResponseError
+		require.ErrorAs(t, err, &rpcErr)
+		assert.NoError(t, rpcErr.Err)
+	}
 }
 
 func TestJSONRPCFormatterResponseErrors(t *testing.T) {
@@ -125,4 +187,7 @@ func TestJSONRPCFormatterResponseErrors(t *testing.T) {
 	response, err := formatter.ParseResponse([]byte("not-json"))
 	assert.Nil(t, response)
 	require.Error(t, err)
+
+	var responseErr JSONRPCFormatterResponseError
+	require.Error(t, responseErr.UnmarshalJSON([]byte("not-json")))
 }

--- a/hyperf/jet/formatter_test.go
+++ b/hyperf/jet/formatter_test.go
@@ -21,6 +21,15 @@ func (e marshalError) MarshalJSON() ([]byte, error) {
 	return nil, e.err
 }
 
+type structuredError struct {
+	Reason    string `json:"reason"`
+	Retryable bool   `json:"retryable"`
+}
+
+func (e structuredError) Error() string {
+	return e.Reason
+}
+
 func TestRPCResponseError(t *testing.T) {
 	sentinel := errors.New("upstream error")
 	err := &RPCResponseError{
@@ -152,6 +161,27 @@ func TestJSONRPCFormatterStructuredErrorData(t *testing.T) {
 	require.NotNil(t, envelope.Error)
 	require.Error(t, envelope.Error.Data)
 	assert.JSONEq(t, `{"retryable":true}`, envelope.Error.Data.Error())
+}
+
+func TestJSONRPCFormatterStructuredError(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+
+	data, err := formatter.FormatResponse(nil, &RPCResponseError{
+		ID:      "request-id",
+		Code:    -32603,
+		Message: "internal error",
+		Err: structuredError{
+			Reason:    "busy",
+			Retryable: true,
+		},
+	})
+	require.NoError(t, err)
+
+	var envelope JSONRPCFormatterResponse
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	require.NotNil(t, envelope.Error)
+	require.Error(t, envelope.Error.Data)
+	assert.JSONEq(t, `{"reason":"busy","retryable":true}`, envelope.Error.Data.Error())
 }
 
 func TestJSONRPCFormatterEmptyErrorData(t *testing.T) {

--- a/hyperf/jet/formatter_test.go
+++ b/hyperf/jet/formatter_test.go
@@ -1,0 +1,128 @@
+package jet
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type marshalError struct {
+	err error
+}
+
+func (e marshalError) Error() string {
+	return e.err.Error()
+}
+
+func (e marshalError) MarshalJSON() ([]byte, error) {
+	return nil, e.err
+}
+
+func TestRPCResponseError(t *testing.T) {
+	sentinel := errors.New("upstream error")
+	err := &RPCResponseError{
+		ID:      "request-id",
+		Code:    -32603,
+		Message: "internal error",
+		Err:     sentinel,
+	}
+
+	assert.Equal(t, "code: -32603, message: internal error, error: upstream error", err.Error())
+}
+
+func TestJSONRPCFormatterKind(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+
+	assert.Equal(t, FormatterKindJSONRPC, formatter.Kind())
+	assert.Equal(t, FormatterKindJSONRPC, DefaultFormatter.Kind())
+}
+
+func TestJSONRPCFormatterRequest(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+	want := &RPCRequest{
+		ID:     "request-id",
+		Path:   "/users/find",
+		Params: json.RawMessage(`{"id":123}`),
+	}
+
+	data, err := formatter.FormatRequest(want)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"jsonrpc": "2.0",
+		"method": "/users/find",
+		"params": {"id": 123},
+		"id": "request-id"
+	}`, string(data))
+
+	got, err := formatter.ParseRequest(data)
+	require.NoError(t, err)
+	assert.Equal(t, want.ID, got.ID)
+	assert.Equal(t, want.Path, got.Path)
+	assert.JSONEq(t, string(want.Params), string(got.Params))
+}
+
+func TestJSONRPCFormatterRequestErrors(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+
+	data, err := formatter.FormatRequest(&RPCRequest{Params: json.RawMessage(`{`)})
+	assert.Nil(t, data)
+	require.Error(t, err)
+
+	request, err := formatter.ParseRequest([]byte("not-json"))
+	assert.Nil(t, request)
+	require.Error(t, err)
+}
+
+func TestJSONRPCFormatterSuccessResponse(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+	want := &RPCResponse{
+		ID:     "request-id",
+		Result: json.RawMessage(`{"name":"Alice"}`),
+	}
+
+	data, err := formatter.FormatResponse(want, nil)
+	require.NoError(t, err)
+
+	got, err := formatter.ParseResponse(data)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want.ID, got.ID)
+	assert.JSONEq(t, string(want.Result), string(got.Result))
+}
+
+func TestJSONRPCFormatterErrorResponse(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+	want := &RPCResponseError{
+		ID:      "request-id",
+		Code:    -32601,
+		Message: "method not found",
+	}
+
+	data, err := formatter.FormatResponse(nil, want)
+	require.NoError(t, err)
+
+	response, err := formatter.ParseResponse(data)
+	assert.Nil(t, response)
+	var got *RPCResponseError
+	require.ErrorAs(t, err, &got)
+	assert.Equal(t, want.ID, got.ID)
+	assert.Equal(t, want.Code, got.Code)
+	assert.Equal(t, want.Message, got.Message)
+	assert.NoError(t, got.Err)
+}
+
+func TestJSONRPCFormatterResponseErrors(t *testing.T) {
+	formatter := NewJSONRPCFormatter()
+	sentinel := errors.New("marshal response")
+
+	data, err := formatter.FormatResponse(nil, &RPCResponseError{Err: marshalError{err: sentinel}})
+	assert.Nil(t, data)
+	assert.ErrorIs(t, err, sentinel)
+
+	response, err := formatter.ParseResponse([]byte("not-json"))
+	assert.Nil(t, response)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
Fix JSON-RPC error data serialization in the Hyperf Jet formatter and add comprehensive formatter unit coverage.

## Changes
- serialize ordinary Go errors as JSON strings instead of empty objects
- parse string and structured JSON-RPC `data` values without failing on the `error` interface
- preserve structured error data when a parsed response is encoded again
- cover request, success response, error response, and malformed payload paths

## Motivation
- non-empty JSON-RPC error data was encoded as `Data: {}` and then failed to parse back into the Go `error` field
- formatter behavior previously lacked direct unit coverage

## Compatibility
- public fields and formatter method signatures remain unchanged
- missing or null error data continues to produce a nil underlying error
- the existing response envelope shape remains unchanged

## Testing
- `go test -race -coverprofile=coverage.out ./...` (94.0% module coverage; formatter functions 100%)
- `make lint/hyperf/jet`