### PR TITLE
test(syslog): complete handler unit coverage

### DIFF
--- a/log/slog/syslog/handler_test.go
+++ b/log/slog/syslog/handler_test.go
@@ -3,6 +3,7 @@
 package syslog
 
 import (
+	"bytes"
 	"errors"
 	"log/slog"
 	stdsyslog "log/syslog"
@@ -142,6 +143,16 @@ func TestWithFacilityMasksSeverityBits(t *testing.T) {
 	assert.Equal(t, stdsyslog.LOG_LOCAL0, cfg.facility)
 }
 
+func TestConfigOptions(t *testing.T) {
+	level := new(slog.LevelVar)
+	level.Set(slog.LevelWarn)
+	cfg := newConfig(nil, WithLevel(level), WithTag("fries"))
+
+	assert.Equal(t, stdsyslog.LOG_USER, cfg.facility)
+	assert.Same(t, level, cfg.level)
+	assert.Equal(t, "fries", cfg.tag)
+}
+
 func TestHandlerEnabledHonorsMinimumLevel(t *testing.T) {
 	writer := &recordingWriter{}
 	handler := NewHandler(writer, WithLevel(slog.LevelWarn))
@@ -177,6 +188,70 @@ func TestHandlerNoopsWhenWriterNil(t *testing.T) {
 	assert.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "ignored", 0)))
 }
 
+func TestHandlerClose(t *testing.T) {
+	t.Run("writer without close", func(t *testing.T) {
+		handler := NewHandler(&recordingWriter{})
+
+		require.NoError(t, handler.Close())
+	})
+
+	t.Run("writer close success", func(t *testing.T) {
+		writer := &closingWriter{recordingWriter: &recordingWriter{}}
+		handler := NewHandler(writer)
+
+		require.NoError(t, handler.Close())
+		assert.Equal(t, 1, writer.closeCalls)
+	})
+
+	t.Run("writer close error", func(t *testing.T) {
+		sentinel := errors.New("close failed")
+		writer := &closingWriter{
+			recordingWriter: &recordingWriter{},
+			closeErr:        sentinel,
+		}
+		handler := NewHandler(writer)
+
+		err := handler.Close()
+
+		assert.ErrorIs(t, err, sentinel)
+		assert.Equal(t, 1, writer.closeCalls)
+	})
+}
+
+func TestHandlerFormatsValueKinds(t *testing.T) {
+	writer := &recordingWriter{}
+	handler := NewHandler(writer)
+	record := slog.NewRecord(timeNow(), slog.LevelInfo, "values", 0)
+	record.AddAttrs(
+		slog.Uint64("uint", 42),
+		slog.Float64("float", 1.5),
+		slog.Bool("bool", true),
+		slog.Duration("duration", 2*time.Second),
+		slog.Time("time", timeNow()),
+		slog.Any("any", []int{1, 2}),
+	)
+
+	require.NoError(t, handler.Handle(t.Context(), record))
+
+	require.Len(t, writer.records, 1)
+	assert.Contains(t, writer.records[0].message, "uint=42")
+	assert.Contains(t, writer.records[0].message, "float=1.5")
+	assert.Contains(t, writer.records[0].message, "bool=true")
+	assert.Contains(t, writer.records[0].message, "duration=2s")
+	assert.Contains(t, writer.records[0].message, "time="+timeNow().Format(time.RFC3339))
+	assert.Contains(t, writer.records[0].message, "any=[1 2]")
+}
+
+func TestAppendAttrIgnoresEmptyAttributes(t *testing.T) {
+	var buf bytes.Buffer
+
+	appendAttr(&buf, nil, slog.Attr{})
+	appendAttr(&buf, nil, slog.String("", "value"))
+	appendAttr(&buf, nil, slog.Group("empty"))
+
+	assert.Empty(t, buf.String())
+}
+
 type recordedWrite struct {
 	priority string
 	message  string
@@ -185,6 +260,17 @@ type recordedWrite struct {
 type recordingWriter struct {
 	records []recordedWrite
 	err     error
+}
+
+type closingWriter struct {
+	*recordingWriter
+	closeErr   error
+	closeCalls int
+}
+
+func (w *closingWriter) Close() error {
+	w.closeCalls++
+	return w.closeErr
 }
 
 func (w *recordingWriter) Debug(message string) error {

--- a/log/slog/syslog/syslog_test.go
+++ b/log/slog/syslog/syslog_test.go
@@ -1,0 +1,43 @@
+//go:build !windows && !plan9
+
+package syslog
+
+import (
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDial(t *testing.T) {
+	listener, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, listener.Close())
+	})
+
+	handler, err := Dial("udp", listener.LocalAddr().String(), WithTag("fries-test"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, handler.Close())
+	})
+
+	require.NoError(t, handler.Handle(t.Context(), slog.NewRecord(timeNow(), slog.LevelInfo, "service started", 0)))
+	require.NoError(t, listener.SetReadDeadline(time.Now().Add(5*time.Second)))
+
+	message := make([]byte, 1024)
+	n, _, err := listener.ReadFrom(message)
+	require.NoError(t, err)
+	assert.Contains(t, string(message[:n]), "fries-test")
+	assert.Contains(t, string(message[:n]), "service started")
+}
+
+func TestDialReturnsConnectionError(t *testing.T) {
+	handler, err := Dial("invalid-network", "", WithTag("fries-test"))
+
+	assert.Nil(t, handler)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
Expand unit coverage for the slog syslog handler from 79.5% to 100% without changing production behavior.

## Changes
- Cover configuration options, handler closing, slog value formatting, and empty attributes
- Exercise successful and failed `Dial` calls using a local UDP listener
- Verify both closable and non-closable writer behavior

## Motivation
- Close the remaining service-free coverage gaps in the syslog module with focused regression tests

## Testing
- `go test -race -count=10 ./...`
- `go test -coverprofile=coverage.out ./...` (100.0% statements)
- `make lint/log/slog/syslog`