### PR TITLE
fix(udp): isolate messages and synchronize lifecycle

### DIFF
--- a/udp/server.go
+++ b/udp/server.go
@@ -1,6 +1,7 @@
 package udp
 
 import (
+	"bytes"
 	"context"
 	"log"
 	"net"
@@ -15,12 +16,21 @@ type Message struct {
 	Body []byte
 }
 
+func newMessage(conn net.PacketConn, addr net.Addr, body []byte) *Message {
+	return &Message{
+		Conn: conn,
+		Addr: addr,
+		Body: bytes.Clone(body),
+	}
+}
+
 type Server struct {
 	address string
 
 	bufSize int
 
-	conn net.PacketConn
+	connMu sync.Mutex
+	conn   net.PacketConn
 
 	handler func(message *Message)
 
@@ -87,29 +97,56 @@ func NewServer(address string, opts ...Option) *Server {
 }
 
 func (s *Server) Start(_ context.Context) (err error) {
-	s.conn, err = net.ListenPacket("udp", s.address)
+	conn, err := net.ListenPacket("udp", s.address)
 	if err != nil {
 		return err
 	}
+	s.connMu.Lock()
+	select {
+	case <-s.stoped:
+		s.connMu.Unlock()
+		_ = conn.Close()
+		return net.ErrClosed
+	default:
+		s.conn = conn
+		s.connMu.Unlock()
+	}
+	defer func() {
+		s.connMu.Lock()
+		if s.conn == conn {
+			s.conn = nil
+		}
+		s.connMu.Unlock()
+		_ = conn.Close()
+	}()
 
 	log.Printf("udp server: listening on %s\n", s.address)
 
 	go s.start()
+	return s.serve(conn)
+}
 
+func (s *Server) serve(conn net.PacketConn) error {
 	buf := make([]byte, s.bufSize)
-
 	for {
-		n, addr, err := s.conn.ReadFrom(buf)
+		n, addr, err := conn.ReadFrom(buf)
 		if err != nil {
 			s.stop()
 			return err
 		}
 
-		s.readChan <- &Message{
-			Conn: s.conn,
-			Addr: addr,
-			Body: buf[:n],
+		if err := s.enqueue(newMessage(conn, addr, buf[:n])); err != nil {
+			return err
 		}
+	}
+}
+
+func (s *Server) enqueue(message *Message) error {
+	select {
+	case s.readChan <- message:
+		return nil
+	case <-s.stoped:
+		return net.ErrClosed
 	}
 }
 
@@ -143,11 +180,15 @@ func (s *Server) Stop(_ context.Context) error {
 
 	s.stop()
 
-	if s.conn == nil {
+	s.connMu.Lock()
+	conn := s.conn
+	s.conn = nil
+	s.connMu.Unlock()
+	if conn == nil {
 		return nil
 	}
 
-	return s.conn.Close()
+	return conn.Close()
 }
 
 func (s *Server) stop() {

--- a/udp/server.go
+++ b/udp/server.go
@@ -3,6 +3,7 @@ package udp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log"
 	"net"
 	"sync"
@@ -15,6 +16,9 @@ type Message struct {
 	Addr net.Addr
 	Body []byte
 }
+
+// ErrAlreadyStarted is returned when a [Server] is already starting or running.
+var ErrAlreadyStarted = errors.New("udp: server already started")
 
 func newMessage(conn net.PacketConn, addr net.Addr, body []byte) *Message {
 	return &Message{
@@ -29,8 +33,10 @@ type Server struct {
 
 	bufSize int
 
-	connMu sync.Mutex
-	conn   net.PacketConn
+	connMu       sync.Mutex
+	conn         net.PacketConn
+	starting     bool
+	listenPacket func(network, address string) (net.PacketConn, error)
 
 	handler func(message *Message)
 
@@ -85,6 +91,7 @@ func NewServer(address string, opts ...Option) *Server {
 		bufSize:      1024, //nolint:mnd
 		readChanSize: 1024, //nolint:mnd
 		stoped:       make(chan struct{}),
+		listenPacket: net.ListenPacket,
 	}
 
 	for _, opt := range opts {
@@ -97,20 +104,34 @@ func NewServer(address string, opts ...Option) *Server {
 }
 
 func (s *Server) Start(_ context.Context) (err error) {
-	conn, err := net.ListenPacket("udp", s.address)
+	s.connMu.Lock()
+	if s.isStopped() {
+		s.connMu.Unlock()
+		return net.ErrClosed
+	}
+	if s.starting || s.conn != nil {
+		s.connMu.Unlock()
+		return ErrAlreadyStarted
+	}
+	s.starting = true
+	s.connMu.Unlock()
+
+	conn, err := s.listenPacket("udp", s.address)
+	s.connMu.Lock()
+	s.starting = false
+	if s.isStopped() {
+		s.connMu.Unlock()
+		if conn != nil {
+			_ = conn.Close()
+		}
+		return net.ErrClosed
+	}
 	if err != nil {
+		s.connMu.Unlock()
 		return err
 	}
-	s.connMu.Lock()
-	select {
-	case <-s.stoped:
-		s.connMu.Unlock()
-		_ = conn.Close()
-		return net.ErrClosed
-	default:
-		s.conn = conn
-		s.connMu.Unlock()
-	}
+	s.conn = conn
+	s.connMu.Unlock()
 	defer func() {
 		s.connMu.Lock()
 		if s.conn == conn {
@@ -195,4 +216,13 @@ func (s *Server) stop() {
 	s.stopedOnce.Do(func() {
 		close(s.stoped)
 	})
+}
+
+func (s *Server) isStopped() bool {
+	select {
+	case <-s.stoped:
+		return true
+	default:
+		return false
+	}
 }

--- a/udp/server_concurrency_test.go
+++ b/udp/server_concurrency_test.go
@@ -1,0 +1,103 @@
+package udp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMessageCopiesBody(t *testing.T) {
+	address := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12190}
+	body := []byte("first-packet")
+
+	message := newMessage(nil, address, body)
+	copy(body, "other-packet")
+
+	assert.Same(t, address, message.Addr)
+	assert.Equal(t, "first-packet", string(message.Body))
+}
+
+func TestServerStartAfterStopReturnsClosedError(t *testing.T) {
+	server := NewServer("127.0.0.1:0")
+	require.NoError(t, server.Stop(t.Context()))
+
+	err := server.Start(t.Context())
+
+	assert.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestServerStopIsIdempotent(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := NewServer("127.0.0.1:0")
+	server.conn = conn
+
+	require.NoError(t, server.Stop(t.Context()))
+	require.NoError(t, server.Stop(t.Context()))
+}
+
+func TestServerEnqueueReturnsClosedErrorAfterStop(t *testing.T) {
+	server := NewServer("127.0.0.1:0", WithReadChanSize(1))
+	server.readChan <- &Message{}
+	require.NoError(t, server.Stop(t.Context()))
+
+	err := server.enqueue(&Message{})
+
+	assert.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestServerServeStopsWhenReadQueueIsFull(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+	client, err := net.Dial("udp", conn.LocalAddr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	server := NewServer("127.0.0.1:0", WithReadChanSize(1))
+	server.readChan <- &Message{}
+	server.stop()
+	_, err = client.Write([]byte("content"))
+	require.NoError(t, err)
+
+	err = server.serve(conn)
+
+	assert.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestServerClearsConnectionWhenServeReturns(t *testing.T) {
+	server := NewServer(newUDPAddr(t))
+	t.Cleanup(func() {
+		require.NoError(t, server.Stop(t.Context()))
+	})
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- server.Start(t.Context())
+	}()
+
+	var conn net.PacketConn
+	require.Eventually(t, func() bool {
+		server.connMu.Lock()
+		defer server.connMu.Unlock()
+		conn = server.conn
+		return conn != nil
+	}, time.Second, time.Millisecond)
+	require.NoError(t, conn.Close())
+
+	select {
+	case err := <-startErr:
+		assert.ErrorIs(t, err, net.ErrClosed)
+	case <-time.After(time.Second):
+		require.FailNow(t, "server did not stop")
+	}
+	server.connMu.Lock()
+	defer server.connMu.Unlock()
+	assert.Nil(t, server.conn)
+}

--- a/udp/server_concurrency_test.go
+++ b/udp/server_concurrency_test.go
@@ -2,6 +2,7 @@ package udp
 
 import (
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,12 +22,78 @@ func TestNewMessageCopiesBody(t *testing.T) {
 }
 
 func TestServerStartAfterStopReturnsClosedError(t *testing.T) {
-	server := NewServer("127.0.0.1:0")
+	server := NewServer("invalid-address")
 	require.NoError(t, server.Stop(t.Context()))
 
 	err := server.Start(t.Context())
 
 	assert.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestServerRejectsConcurrentStart(t *testing.T) {
+	server := NewServer("127.0.0.1:0")
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- server.Start(t.Context())
+	}()
+
+	firstConn := waitForServerConnection(t, server)
+	t.Cleanup(func() {
+		_ = server.Stop(t.Context())
+		_ = firstConn.Close()
+	})
+	secondResult := make(chan error, 1)
+	go func() {
+		secondResult <- server.Start(t.Context())
+	}()
+
+	select {
+	case err := <-secondResult:
+		assert.ErrorIs(t, err, ErrAlreadyStarted)
+	case <-time.After(time.Second):
+		require.FailNow(t, "concurrent start did not return")
+	}
+	require.NoError(t, server.Stop(t.Context()))
+	select {
+	case err := <-firstResult:
+		assert.ErrorIs(t, err, net.ErrClosed)
+	case <-time.After(time.Second):
+		require.FailNow(t, "first start did not stop")
+	}
+}
+
+func TestServerStopWhileStarting(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	listenStarted := make(chan struct{})
+	releaseListen := make(chan struct{})
+	var releaseOnce sync.Once
+	server := NewServer("127.0.0.1:0")
+	server.listenPacket = func(string, string) (net.PacketConn, error) {
+		close(listenStarted)
+		<-releaseListen
+		return conn, nil
+	}
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseListen) })
+		_ = server.Stop(t.Context())
+		_ = conn.Close()
+	})
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- server.Start(t.Context())
+	}()
+	<-listenStarted
+
+	require.NoError(t, server.Stop(t.Context()))
+	releaseOnce.Do(func() { close(releaseListen) })
+
+	select {
+	case err := <-startResult:
+		assert.ErrorIs(t, err, net.ErrClosed)
+	case <-time.After(time.Second):
+		require.FailNow(t, "start did not stop")
+	}
 }
 
 func TestServerStopIsIdempotent(t *testing.T) {
@@ -82,13 +149,7 @@ func TestServerClearsConnectionWhenServeReturns(t *testing.T) {
 		startErr <- server.Start(t.Context())
 	}()
 
-	var conn net.PacketConn
-	require.Eventually(t, func() bool {
-		server.connMu.Lock()
-		defer server.connMu.Unlock()
-		conn = server.conn
-		return conn != nil
-	}, time.Second, time.Millisecond)
+	conn := waitForServerConnection(t, server)
 	require.NoError(t, conn.Close())
 
 	select {
@@ -100,4 +161,17 @@ func TestServerClearsConnectionWhenServeReturns(t *testing.T) {
 	server.connMu.Lock()
 	defer server.connMu.Unlock()
 	assert.Nil(t, server.conn)
+}
+
+func waitForServerConnection(t *testing.T, server *Server) net.PacketConn {
+	t.Helper()
+
+	var conn net.PacketConn
+	require.Eventually(t, func() bool {
+		server.connMu.Lock()
+		defer server.connMu.Unlock()
+		conn = server.conn
+		return conn != nil
+	}, time.Second, time.Millisecond)
+	return conn
 }

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -1,10 +1,12 @@
 package udp
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +63,53 @@ func TestServer(t *testing.T) {
 		}
 		return false
 	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestServerConfiguresReadChannelSize(t *testing.T) {
+	server := NewServer(
+		"127.0.0.1:0",
+		WithReadChanSize(8),
+		WithReadChanSize(0),
+	)
+
+	assert.Equal(t, 8, cap(server.readChan))
+}
+
+func TestServerStartReturnsListenError(t *testing.T) {
+	server := NewServer("invalid-address")
+
+	err := server.Start(t.Context())
+
+	require.Error(t, err)
+}
+
+func TestServerRecoversHandlerPanic(t *testing.T) {
+	sentinel := errors.New("handler panic")
+	message := &Message{Body: []byte("content")}
+	var recoveredMessage *Message
+	var recovered any
+	server := NewServer(
+		"127.0.0.1:0",
+		WithHandler(func(*Message) {
+			panic(sentinel)
+		}),
+		WithRecoveryHandler(func(message *Message, err any) {
+			recoveredMessage = message
+			recovered = err
+		}),
+	)
+
+	require.NotPanics(t, func() {
+		server.handle(message)
+	})
+	assert.Same(t, message, recoveredMessage)
+	assert.Equal(t, sentinel, recovered)
+}
+
+func TestServerStopBeforeStart(t *testing.T) {
+	server := NewServer("127.0.0.1:0")
+
+	require.NoError(t, server.Stop(t.Context()))
 }
 
 func newUDPAddr(t *testing.T) string {

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -78,9 +78,12 @@ func TestServerConfiguresReadChannelSize(t *testing.T) {
 func TestServerStartReturnsListenError(t *testing.T) {
 	server := NewServer("invalid-address")
 
-	err := server.Start(t.Context())
+	for range 2 {
+		err := server.Start(t.Context())
 
-	require.Error(t, err)
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrAlreadyStarted)
+	}
 }
 
 func TestServerRecoversHandlerPanic(t *testing.T) {


### PR DESCRIPTION
## Summary
Prevent UDP messages from sharing a mutable read buffer and make server startup and shutdown concurrency-safe.

## Changes
- Copy each datagram body before handing it to the asynchronous message handler
- Synchronize connection publication and removal across `Start` and `Stop`
- Reject overlapping starts with `ErrAlreadyStarted`
- Make repeated stops idempotent and reject starts after shutdown with `net.ErrClosed` before binding
- Let a blocked read-queue handoff exit when the server stops
- Expand UDP module statement coverage from 91.2% to 100%

## Motivation
- Reused read buffers could corrupt queued or actively handled message bodies
- Concurrent `Start` and `Stop` calls caused a confirmed data race and could leave a late-starting listener running
- Concurrent `Start` calls could orphan an overwritten listener
- A full read queue could prevent the server loop from completing shutdown

## Testing
- `go test -race -count=20 ./...`
- `go test -coverprofile=coverage.out ./...` (100.0% statements)
- `make lint/udp`

## Notes
- Each queued datagram now owns its body bytes, which adds one body-sized allocation per received packet in exchange for safe asynchronous handling.