### PR TITLE
feat(parallel): add nonblocking submission and typed futures

### DIFF
--- a/parallel/README.md
+++ b/parallel/README.md
@@ -114,6 +114,56 @@ must outlive a request, create an explicit task context, such as one derived
 with `context.WithoutCancel`, instead of using the request context directly.
 Task panics follow normal Go semantics and are not recovered by the pool.
 
+### Skip work when the pool is busy
+
+`TrySubmit` returns immediately with `ErrPoolFull` when the task cannot be
+accepted. Rejected tasks never run. With an unbuffered queue, submission succeeds
+only when a worker is ready to receive the task.
+
+```go
+_, err := pool.TrySubmit(taskContext, func(ctx context.Context) error {
+	return refreshCache(ctx, cacheKey)
+})
+if errors.Is(err, parallel.ErrPoolFull) {
+	return nil // Skip this optional refresh while the pool is busy.
+}
+if err != nil {
+	return err
+}
+```
+
+### Retrieve a typed result
+
+`SubmitValue` uses the same queue and backpressure as `Submit`, returning a
+`ValueFuture[T]` that carries the callback's value and error:
+
+```go
+future, err := parallel.SubmitValue(taskContext, pool,
+	func(ctx context.Context) (Profile, error) {
+		return loadProfile(ctx, userID)
+	},
+)
+if err != nil {
+	return err
+}
+
+// Other work can run before waiting for the result.
+profile, err := future.Wait(ctx)
+if err != nil {
+	return err
+}
+useProfile(profile)
+```
+
+Multiple callers can wait on the same future. A completed future preserves both
+the value and error, including values returned alongside an error. Canceling a
+wait returns the zero value and cancellation cause without canceling the task.
+If cancellation prevents the task from starting, its result is the zero value
+and the task context's cancellation cause. Referenced result data is shared;
+callers must synchronize mutations.
+
+### Shut down the pool
+
 Shut the pool down when its owner stops:
 
 ```go

--- a/parallel/doc.go
+++ b/parallel/doc.go
@@ -4,5 +4,6 @@
 // order-preserving concurrent mapping and filtering. Fail-fast helpers cancel
 // sibling work through context.Context, while MapResults supports best-effort
 // processing with one outcome per input value. Pool provides fixed long-lived
-// workers and bounded queueing for intermittent background work.
+// workers and bounded queueing for intermittent background work. [Pool.TrySubmit]
+// supports immediate rejection when busy, and [SubmitValue] provides typed futures.
 package parallel

--- a/parallel/errors.go
+++ b/parallel/errors.go
@@ -5,12 +5,14 @@ import "errors"
 var (
 	// ErrInvalidLimit indicates that a concurrency limit is not positive.
 	ErrInvalidLimit = errors.New("parallel: concurrency limit must be greater than zero")
-	// ErrNilTask indicates that a task passed to Run, RunLimit, Submit, or
-	// Execute is nil.
+	// ErrNilTask indicates that a task passed to [Run], [RunLimit], [Pool.Submit],
+	// [Pool.TrySubmit], or [Pool.Execute] is nil.
 	ErrNilTask = errors.New("parallel: task must not be nil")
-	// ErrNilFunc indicates that a callback passed to ForEach, Map, MapResults,
-	// or Filter is nil.
+	// ErrNilFunc indicates that a callback passed to [ForEach], [Map], [MapResults],
+	// [Filter], or [SubmitValue] is nil.
 	ErrNilFunc = errors.New("parallel: function must not be nil")
 	// ErrPoolClosed indicates that a pool no longer accepts tasks.
 	ErrPoolClosed = errors.New("parallel: pool is closed")
+	// ErrPoolFull indicates that [Pool.TrySubmit] could not immediately accept a task.
+	ErrPoolFull = errors.New("parallel: pool is full")
 )

--- a/parallel/pool.go
+++ b/parallel/pool.go
@@ -96,9 +96,9 @@ type poolTask struct {
 // long-lived workers and a bounded queue.
 //
 // A Pool must be shut down when it is no longer needed. Task lifetimes are
-// controlled by the contexts passed to Submit and Execute. Pool values must be
-// created by NewPool and must not be copied after first use; the zero value is
-// not valid.
+// controlled by the contexts passed to [Pool.Submit], [Pool.TrySubmit], and
+// [Pool.Execute]. Pool values must be created by [NewPool] and must not be copied
+// after first use; the zero value is not valid.
 type Pool struct {
 	tasks   chan poolTask
 	closing chan struct{}
@@ -141,6 +141,10 @@ func NewPool(workers int, options ...PoolOption) *Pool {
 // until a worker accepts the task, ctx is canceled, or the pool is shut down.
 // The same ctx is passed to task, so asynchronous callers must provide a
 // context whose lifetime is long enough for the task.
+//
+// Submit returns [ErrNilTask] if task is nil, [context.Cause] of ctx if submission
+// is canceled, or [ErrPoolClosed] if the pool stops accepting tasks. No future is
+// returned when submission fails.
 func (p *Pool) Submit(ctx context.Context, task Task) (*Future, error) {
 	if task == nil {
 		return nil, ErrNilTask
@@ -169,6 +173,38 @@ func (p *Pool) Submit(ctx context.Context, task Task) (*Future, error) {
 		return nil, ErrPoolClosed
 	case <-ctx.Done():
 		return nil, context.Cause(ctx)
+	}
+}
+
+// TrySubmit adds task to the pool without waiting for queue capacity.
+//
+// TrySubmit returns [ErrPoolFull] if the task cannot be accepted immediately.
+// With an unbuffered queue, a worker must be ready to receive the task.
+// Rejected tasks never run, and no future is returned for them.
+//
+// TrySubmit returns [ErrNilTask] if task is nil, [context.Cause] of ctx if ctx is
+// already canceled, or [ErrPoolClosed] if the pool is closed. As with [Pool.Submit],
+// ctx controls the accepted task's lifetime.
+func (p *Pool) TrySubmit(ctx context.Context, task Task) (*Future, error) {
+	if task == nil {
+		return nil, ErrNilTask
+	}
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil, ErrPoolClosed
+	}
+
+	future := newFuture()
+	select {
+	case p.tasks <- poolTask{ctx: ctx, task: task, future: future}:
+		return future, nil
+	default:
+		return nil, ErrPoolFull
 	}
 }
 

--- a/parallel/pool_test.go
+++ b/parallel/pool_test.go
@@ -3,6 +3,7 @@ package parallel_test
 import (
 	"context"
 	"errors"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -347,6 +348,91 @@ func TestPoolConcurrentSubmitAndShutdown(t *testing.T) {
 
 		require.NoError(t, result.future.Wait(t.Context()))
 	}
+}
+
+func TestPoolTrySubmitCapacity(t *testing.T) {
+	for _, size := range []int{0, 1} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			pool := requirePool(t, 1, parallel.WithQueueSize(size))
+			release := make(chan struct{})
+			started := make(chan struct{})
+			var releaseOnce sync.Once
+			unblock := func() { releaseOnce.Do(func() { close(release) }) }
+			t.Cleanup(func() {
+				unblock()
+				require.NoError(t, pool.Shutdown(context.WithoutCancel(t.Context())))
+			})
+			_, err := pool.Submit(t.Context(), func(context.Context) error {
+				close(started)
+				<-release
+
+				return nil
+			})
+			require.NoError(t, err)
+			<-started
+
+			wantErr := errors.New("accepted task failed")
+			var accepted *parallel.Future
+			if size > 0 {
+				accepted, err = pool.TrySubmit(t.Context(), func(context.Context) error { return wantErr })
+				require.NoError(t, err)
+			}
+
+			var called atomic.Bool
+			future, err := pool.TrySubmit(t.Context(), func(context.Context) error {
+				called.Store(true)
+
+				return nil
+			})
+			require.ErrorIs(t, err, parallel.ErrPoolFull)
+			assert.Nil(t, future)
+			unblock()
+			require.NoError(t, pool.Shutdown(t.Context()))
+			assert.False(t, called.Load())
+			if accepted != nil {
+				require.ErrorIs(t, accepted.Wait(t.Context()), wantErr)
+			}
+		})
+	}
+}
+
+func TestPoolTrySubmitValidation(t *testing.T) {
+	pool := requirePool(t, 1)
+	task := func(context.Context) error { return nil }
+	future, err := pool.TrySubmit(t.Context(), nil)
+	require.ErrorIs(t, err, parallel.ErrNilTask)
+	assert.Nil(t, future)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	wantErr := errors.New("stopped")
+	cancel(wantErr)
+	future, err = pool.TrySubmit(ctx, task)
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, future)
+	require.NoError(t, pool.Shutdown(t.Context()))
+	future, err = pool.TrySubmit(t.Context(), task)
+	require.ErrorIs(t, err, parallel.ErrPoolClosed)
+	assert.Nil(t, future)
+}
+
+func TestPoolConcurrentTrySubmitAndShutdown(t *testing.T) {
+	pool := requirePool(t, 4)
+	start := make(chan struct{})
+	var submitters sync.WaitGroup
+	for range 100 {
+		submitters.Go(func() {
+			<-start
+			future, err := pool.TrySubmit(t.Context(), func(context.Context) error { return nil })
+			if err != nil {
+				assert.True(t, errors.Is(err, parallel.ErrPoolClosed) || errors.Is(err, parallel.ErrPoolFull))
+
+				return
+			}
+			assert.NoError(t, future.Wait(t.Context()))
+		})
+	}
+	close(start)
+	require.NoError(t, pool.Shutdown(t.Context()))
+	submitters.Wait()
 }
 
 func requirePool(t *testing.T, workers int, options ...parallel.PoolOption) *parallel.Pool {

--- a/parallel/value.go
+++ b/parallel/value.go
@@ -1,0 +1,75 @@
+package parallel
+
+import (
+	"context"
+	"fmt"
+)
+
+// ValueFuture represents the eventual value and error of a task accepted by a [Pool].
+//
+// A ValueFuture supports concurrent and repeated waits. Values are shared, not
+// copied deeply; callers must synchronize mutations to referenced data.
+//
+// ValueFuture values are created by [SubmitValue]; the zero value is not valid.
+type ValueFuture[T any] struct {
+	future *Future
+	value  T
+}
+
+// Done returns a channel that is closed when the task finishes.
+func (f *ValueFuture[T]) Done() <-chan struct{} {
+	return f.future.Done()
+}
+
+// Wait waits for the task to finish or ctx to be canceled.
+//
+// When the task finishes, Wait returns its value and error, including a value
+// returned alongside an error. A completed task's result takes precedence over
+// cancellation of ctx.
+//
+// If ctx is canceled while the task is still running, Wait returns the zero
+// value of T and [context.Cause] of ctx. Canceling ctx stops only this wait;
+// it does not cancel the task.
+func (f *ValueFuture[T]) Wait(ctx context.Context) (T, error) {
+	err := f.future.Wait(ctx)
+	select {
+	case <-f.Done():
+		return f.value, f.future.err
+	default:
+		var zero T
+
+		return zero, err
+	}
+}
+
+// SubmitValue submits fn to pool and returns a future once the task is accepted.
+//
+// Submission applies the same backpressure as [Pool.Submit]. The supplied ctx
+// controls the task's lifetime, including time spent waiting in the queue.
+// If the task is canceled before starting, its future returns the zero value of
+// T and the cancellation cause.
+//
+// SubmitValue returns an error wrapping [ErrNilFunc] if fn is nil. Otherwise,
+// submission errors are returned as documented by [Pool.Submit]. No future is
+// returned when submission fails.
+//
+// The pool must be non-nil and created by [NewPool].
+func SubmitValue[T any](ctx context.Context, pool *Pool, fn func(context.Context) (T, error)) (*ValueFuture[T], error) {
+	if fn == nil {
+		return nil, fmt.Errorf("%w: SubmitValue", ErrNilFunc)
+	}
+
+	result := &ValueFuture[T]{}
+	future, err := pool.Submit(ctx, func(ctx context.Context) error {
+		value, err := fn(ctx)
+		result.value = value
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	result.future = future
+
+	return result, nil
+}

--- a/parallel/value_test.go
+++ b/parallel/value_test.go
@@ -1,0 +1,96 @@
+package parallel_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/go-fries/fries/parallel/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitValueConcurrentWaits(t *testing.T) {
+	pool := requirePool(t, 1)
+	release := make(chan struct{})
+	wantErr := errors.New("partial result")
+	future, err := parallel.SubmitValue(t.Context(), pool, func(context.Context) (string, error) {
+		<-release
+
+		return "value", wantErr
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	waitErr := errors.New("wait stopped")
+	cancel(waitErr)
+	value, err := future.Wait(ctx)
+	require.ErrorIs(t, err, waitErr)
+	assert.Empty(t, value)
+
+	var waiters sync.WaitGroup
+	for range 20 {
+		waiters.Go(func() {
+			value, err := future.Wait(t.Context())
+			assert.ErrorIs(t, err, wantErr)
+			assert.Equal(t, "value", value)
+		})
+	}
+	close(release)
+	waiters.Wait()
+	<-future.Done()
+	value, err = future.Wait(ctx)
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, "value", value)
+	require.NoError(t, pool.Shutdown(t.Context()))
+}
+
+func TestSubmitValueQueuedCancellation(t *testing.T) {
+	pool := requirePool(t, 1)
+	release := make(chan struct{})
+	started := make(chan struct{})
+	_, err := pool.Submit(t.Context(), func(context.Context) error {
+		close(started)
+		<-release
+
+		return nil
+	})
+	require.NoError(t, err)
+	<-started
+	ctx, cancel := context.WithCancelCause(t.Context())
+	future, err := parallel.SubmitValue(ctx, pool, func(context.Context) (int, error) {
+		t.Error("canceled queued callback ran")
+
+		return 42, nil
+	})
+	require.NoError(t, err)
+	wantErr := errors.New("task stopped")
+	cancel(wantErr)
+	close(release)
+	value, err := future.Wait(t.Context())
+	require.ErrorIs(t, err, wantErr)
+	assert.Zero(t, value)
+	require.NoError(t, pool.Shutdown(t.Context()))
+}
+
+func TestSubmitValueValidationAndSuccess(t *testing.T) {
+	pool := requirePool(t, 1)
+	fn := func(context.Context) (int, error) { return 42, nil }
+	future, err := parallel.SubmitValue[int](t.Context(), pool, nil)
+	require.ErrorIs(t, err, parallel.ErrNilFunc)
+	assert.Nil(t, future)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	future, err = parallel.SubmitValue(ctx, pool, fn)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, future)
+	future, err = parallel.SubmitValue(t.Context(), pool, fn)
+	require.NoError(t, err)
+	value, err := future.Wait(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, 42, value)
+	require.NoError(t, pool.Shutdown(t.Context()))
+	future, err = parallel.SubmitValue(t.Context(), pool, fn)
+	require.ErrorIs(t, err, parallel.ErrPoolClosed)
+	assert.Nil(t, future)
+}


### PR DESCRIPTION
## Summary
Add nonblocking task submission and typed asynchronous results to the parallel worker pool.

## Changes
- Add `Pool.TrySubmit` and `ErrPoolFull` to reject work immediately when queue capacity is unavailable; rejected tasks never run.
- Add `SubmitValue` and `ValueFuture[T]` with `Done` and concurrent, repeatable `Wait` calls. Submission uses the pool's existing backpressure.
- Preserve callback values returned alongside errors. Canceling a wait does not cancel the task; tasks canceled before starting return a zero value and the cancellation cause.
- Document the APIs with Go Doc links and README examples, including task lifetimes and shared result data.
- Cover queue capacity, validation, concurrent submission and shutdown, queued cancellation, and concurrent result waits in tests alongside their implementation files.

## Motivation
- Allow optional background work to skip submission when the pool is busy.
- Retrieve typed asynchronous results without caller-managed channels or shared variables.

## Testing
- `make test/parallel ARGS=-race` — passed.
- `make lint/parallel` — passed.
- `git diff --check` — passed.
- Inspected `go doc -all .` output in the parallel module.