### PR TITLE
feat(parallel): add bounded concurrent stream mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and internal development tools are not included.
 
 | Family | Modules | Description |
 | --- | --- | --- |
-| Core | [`fries`](https://pkg.go.dev/github.com/go-fries/fries/v4)<br>[`errors`](https://pkg.go.dev/github.com/go-fries/fries/errors/v4)<br>[`parallel`](https://pkg.go.dev/github.com/go-fries/fries/parallel/v4)<br>[`constraints`](https://pkg.go.dev/github.com/go-fries/fries/constraints/v4)<br>[`capability`](https://pkg.go.dev/github.com/go-fries/fries/capability/v4) | Release metadata, shared error helpers, parallel processing utilities, generic constraints, and capability contracts. |
+| Core | [`fries`](https://pkg.go.dev/github.com/go-fries/fries/v4)<br>[`errors`](https://pkg.go.dev/github.com/go-fries/fries/errors/v4)<br>[`parallel`](https://pkg.go.dev/github.com/go-fries/fries/parallel/v4)<br>[`constraints`](https://pkg.go.dev/github.com/go-fries/fries/constraints/v4)<br>[`capability`](https://pkg.go.dev/github.com/go-fries/fries/capability/v4) | Release metadata, shared error helpers, parallel batch and stream processing, generic constraints, and capability contracts. |
 | Batcher | [`batcher`](https://pkg.go.dev/github.com/go-fries/fries/batcher/v4) | Size- and time-triggered batching with a bounded queue, serial processing, explicit flushing, and graceful shutdown. |
 | Cache | [`cache`](https://pkg.go.dev/github.com/go-fries/fries/cache/v4)<br>[`cache/redis`](https://pkg.go.dev/github.com/go-fries/fries/cache/redis/v4) | Cache abstractions and a Redis-backed store. |
 | Crontab | [`crontab`](https://pkg.go.dev/github.com/go-fries/fries/crontab/v4) | Adapts go-cron schedulers to the Kratos server lifecycle. |

--- a/parallel/README.md
+++ b/parallel/README.md
@@ -1,6 +1,6 @@
 # Parallel
 
-`parallel` provides small, context-aware helpers for concurrent batch work.
+`parallel` provides small, context-aware helpers for concurrent batch and stream work.
 It propagates errors and cancellation, supports explicit concurrency limits,
 and provides an optional fixed-worker pool for intermittent background work.
 
@@ -83,6 +83,94 @@ activeUsers, err := parallel.Filter(ctx, 8, users,
 	},
 )
 ```
+
+## Process streaming inputs
+
+Use `MapStream` when inputs arrive over time or results should be consumed as
+they become available. It starts a fixed number of workers and returns a stream
+of indexed, per-item results:
+
+```go
+input := make(chan int64)
+stream, err := parallel.MapStream(ctx, 8, input,
+	func(ctx context.Context, id int64) (Profile, error) {
+		return loadProfile(ctx, id)
+	},
+)
+if err != nil {
+	return err
+}
+defer stream.Close()
+
+go func() {
+	defer close(input)
+	for _, id := range userIDs {
+		select {
+		case input <- id:
+		case <-stream.Context().Done():
+			return
+		}
+	}
+}()
+
+for result := range stream.Results() {
+	if result.Err != nil {
+		log.Printf("input %d failed: %v", result.Index, result.Err)
+		continue
+	}
+	useProfile(result.Value)
+}
+
+if err := stream.Wait(ctx); err != nil {
+	return err
+}
+```
+
+Results are delivered as workers make them available, without input-order
+sorting. `Index` is the zero-based input receive position. A slow earlier input
+does not hold back a ready result from another worker. Concurrently ready
+results have no deterministic ordering.
+
+Each worker receives another input only after handing off its previous result.
+The result channel is unbuffered and there is no internal prefetch queue, so a
+slow consumer slows input consumption. At most the concurrency limit's worth of
+items are being received, processed, or delivered inside the stream. Producer
+buffers and data retained by callbacks or consumers are additional.
+
+Callback errors are included in individual results, alongside any returned
+value, and other inputs continue processing. `Wait` returns nil after normal
+completion even if some callbacks failed. Parent cancellation or an early
+`Close` is reported as the stream's cancellation cause. An already canceled
+parent context, a non-positive limit, a nil input, or a nil callback causes
+construction to fail before any worker starts.
+
+### Stop consumption early
+
+When enough results have arrived, call `Close`, or return from a function with
+`defer stream.Close()` registered. Breaking out of the result loop alone does
+not cancel the stream.
+
+`Close` cancels the shared stream context and waits for internal workers. It
+unblocks input reception and result delivery, but running callbacks still need
+to observe their context and return. Callbacks must not synchronously call
+`Close` or `Wait` on their own stream. Panics follow normal Go semantics and are
+not recovered.
+
+Producers should select on `stream.Context().Done()` while sending, as shown
+above. The caller owns the input channel and any producer goroutines: the stream
+neither closes that channel nor waits for those goroutines. Join the producer
+separately when its resource cleanup must finish before returning.
+
+On cancellation, received inputs may have no delivered result; the stream does
+not synthesize results for unread inputs. Already delivered results remain
+usable. Inputs and results are not deep-copied, so referenced data requires
+appropriate synchronization if mutated.
+
+`Wait` observes completion and does not drain results. Consume results or cancel
+the stream before waiting indefinitely. Its context controls only that wait;
+canceling it does not cancel processing. The shared stream context is also
+canceled on normal completion, so use `Wait` with an independent context to
+obtain the terminal status. Repeated waits return the same terminal result.
 
 ## Reuse fixed workers
 

--- a/parallel/doc.go
+++ b/parallel/doc.go
@@ -1,4 +1,4 @@
-// Package parallel provides context-aware helpers for concurrent batch work.
+// Package parallel provides context-aware helpers for concurrent batch and stream work.
 //
 // It supports unbounded and bounded task execution, concurrent iteration, and
 // order-preserving concurrent mapping and filtering. Fail-fast helpers cancel
@@ -6,4 +6,6 @@
 // processing with one outcome per input value. Pool provides fixed long-lived
 // workers and bounded queueing for intermittent background work. [Pool.TrySubmit]
 // supports immediate rejection when busy, and [SubmitValue] provides typed futures.
+// [MapStream] processes channel inputs with bounded concurrency, per-item results,
+// and cancellation shared with producers through [Stream.Context].
 package parallel

--- a/parallel/errors.go
+++ b/parallel/errors.go
@@ -9,10 +9,12 @@ var (
 	// [Pool.TrySubmit], or [Pool.Execute] is nil.
 	ErrNilTask = errors.New("parallel: task must not be nil")
 	// ErrNilFunc indicates that a callback passed to [ForEach], [Map], [MapResults],
-	// [Filter], or [SubmitValue] is nil.
+	// [Filter], [SubmitValue], or [MapStream] is nil.
 	ErrNilFunc = errors.New("parallel: function must not be nil")
 	// ErrPoolClosed indicates that a pool no longer accepts tasks.
 	ErrPoolClosed = errors.New("parallel: pool is closed")
 	// ErrPoolFull indicates that [Pool.TrySubmit] could not immediately accept a task.
 	ErrPoolFull = errors.New("parallel: pool is full")
+	// ErrNilInput indicates that [MapStream] received a nil input channel.
+	ErrNilInput = errors.New("parallel: input channel must not be nil")
 )

--- a/parallel/example_test.go
+++ b/parallel/example_test.go
@@ -1,0 +1,114 @@
+package parallel_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-fries/fries/parallel/v4"
+)
+
+func ExampleMapStream() {
+	ctx := context.Background()
+	input := make(chan int)
+	stream, err := parallel.MapStream(ctx, 2, input, func(_ context.Context, value int) (int, error) {
+		return value * value, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer stream.Close()
+
+	go func() {
+		defer close(input)
+		for _, value := range []int{1, 2, 3} {
+			select {
+			case input <- value:
+			case <-stream.Context().Done():
+				return
+			}
+		}
+	}()
+
+	// Results may arrive out of order. Index identifies each input position.
+	squares := make([]int, 3)
+	for result := range stream.Results() {
+		if result.Err != nil {
+			panic(result.Err)
+		}
+		squares[result.Index] = result.Value
+	}
+	if err := stream.Wait(ctx); err != nil {
+		panic(err)
+	}
+	fmt.Println(squares)
+	// Output: [1 4 9]
+}
+
+func ExampleStream_Close() {
+	ctx := context.Background()
+	input := make(chan int)
+	stream, err := parallel.MapStream(ctx, 1, input, func(_ context.Context, value int) (int, error) {
+		return value, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer stream.Close()
+
+	producerDone := make(chan struct{})
+	go func() {
+		defer close(producerDone)
+		defer close(input)
+		for value := 0; ; value++ {
+			select {
+			case input <- value:
+			case <-stream.Context().Done():
+				return
+			}
+		}
+	}()
+
+	result := <-stream.Results()
+	fmt.Println("first:", result.Value)
+	stream.Close()
+	<-producerDone // The caller owns and joins its producer.
+	fmt.Println("canceled:", errors.Is(stream.Wait(ctx), context.Canceled))
+	// Output:
+	// first: 0
+	// canceled: true
+}
+
+func ExampleStream_Wait() {
+	ctx := context.Background()
+	input := make(chan int, 3)
+	for _, value := range []int{1, 2, 3} {
+		input <- value
+	}
+	close(input)
+	stream, err := parallel.MapStream(ctx, 2, input, func(_ context.Context, value int) (int, error) {
+		if value == 2 {
+			return 0, errors.New("item failed")
+		}
+
+		return value, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer stream.Close()
+
+	succeeded, failed := 0, 0
+	for result := range stream.Results() {
+		if result.Err != nil {
+			failed++
+		} else {
+			succeeded++
+		}
+	}
+	fmt.Println("succeeded:", succeeded, "failed:", failed)
+	fmt.Println("stream error:", stream.Wait(ctx))
+	// Output:
+	// succeeded: 2 failed: 1
+	// stream error: <nil>
+}

--- a/parallel/stream.go
+++ b/parallel/stream.go
@@ -1,0 +1,200 @@
+package parallel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// StreamResult contains the outcome of processing one stream input.
+type StreamResult[T any] struct {
+	// Index is the zero-based position in the stream's input receive order.
+	Index int
+	// Value is the callback result, including a value returned alongside an error.
+	Value T
+	// Err is the callback error for this input, or nil on success.
+	Err error
+}
+
+// Stream delivers results from concurrent processing of channel inputs.
+//
+// A Stream must be created by [MapStream] and must not be copied after first use;
+// its zero value is not valid. Call [Stream.Close] when stopping consumption
+// early. The input channel remains owned by its producer.
+//
+// Stream methods are safe for concurrent use. Multiple receivers of Results
+// share the same channel and divide results between them; results are not
+// broadcast. Values are not deep-copied, so callers must synchronize mutations
+// to referenced data.
+type Stream[T any] struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	results chan StreamResult[T]
+	done    chan struct{}
+	err     error
+}
+
+// MapStream starts at most limit concurrent callbacks consuming input.
+// Results are delivered as workers make them available, without preserving input
+// order. Each result's index identifies its input receive position.
+//
+// A callback error is included in its [StreamResult] and does not cancel other
+// callbacks or become the stream's terminal error. Results are unbuffered: each
+// worker receives another input only after delivering its previous result. The
+// stream holds at most limit in-flight inputs or results, excluding caller-owned
+// buffers and data retained by callbacks.
+//
+// Closing input ends the stream after all received inputs have been processed
+// and their results delivered. Canceling ctx or calling [Stream.Close] stops
+// receiving and delivering; some received inputs may have no delivered result.
+// Callbacks must observe their context and return promptly on cancellation.
+// They must not synchronously call Close or Wait on their own stream. Panics
+// follow normal Go semantics and are not recovered.
+//
+// MapStream returns an error wrapping [ErrInvalidLimit] if limit is not positive,
+// an error wrapping [ErrNilFunc] if fn is nil, [ErrNilInput] if input is nil, or
+// the cancellation cause if ctx is already canceled. The ctx must not be nil.
+func MapStream[T, R any](
+	ctx context.Context,
+	limit int,
+	input <-chan T,
+	fn func(context.Context, T) (R, error),
+) (*Stream[R], error) {
+	if err := validateLimit(limit); err != nil {
+		return nil, err
+	}
+	if fn == nil {
+		return nil, fmt.Errorf("%w: MapStream", ErrNilFunc)
+	}
+	if input == nil {
+		return nil, ErrNilInput
+	}
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
+	}
+
+	streamContext, cancel := context.WithCancel(ctx)
+	stream := &Stream[R]{
+		ctx:     streamContext,
+		cancel:  cancel,
+		results: make(chan StreamResult[R]),
+		done:    make(chan struct{}),
+	}
+	source := &streamInput[T]{values: input, gate: make(chan struct{}, 1)}
+	var workers sync.WaitGroup
+	for range limit {
+		workers.Go(func() {
+			for {
+				value, index, ok := source.receive(streamContext)
+				if !ok || context.Cause(streamContext) != nil {
+					return
+				}
+				result, err := fn(streamContext, value)
+				select {
+				case stream.results <- StreamResult[R]{Index: index, Value: result, Err: err}:
+				case <-streamContext.Done():
+					return
+				}
+			}
+		})
+	}
+	go func() {
+		workers.Wait()
+		stream.err = context.Cause(streamContext)
+		cancel()
+		close(stream.results)
+		close(stream.done)
+	}()
+
+	return stream, nil
+}
+
+// Context returns the context used by callbacks.
+//
+// It is canceled by [Stream.Close], parent cancellation, or normal completion.
+// Producers can select on its Done channel to stop sending when consumption
+// ends. Use [Stream.Wait] to distinguish normal completion from cancellation.
+func (s *Stream[T]) Context() context.Context {
+	return s.ctx
+}
+
+// Results returns the unbuffered result channel, closed when all workers exit.
+// Callback errors appear in individual results. Use [Stream.Wait] after consuming
+// results to obtain the terminal status.
+func (s *Stream[T]) Results() <-chan StreamResult[T] {
+	return s.results
+}
+
+// Close cancels the stream and waits for its workers to return.
+//
+// Close is safe to call repeatedly or concurrently. It unblocks workers waiting
+// for input or result delivery, but still waits for running callbacks. It does
+// not close the input channel or wait for caller-owned producers. Those producers
+// can use [Stream.Context] to observe cancellation.
+func (s *Stream[T]) Close() {
+	s.cancel()
+	<-s.done
+}
+
+// Wait waits for the stream to finish or ctx to be canceled.
+//
+// On normal completion, Wait returns nil even if individual callbacks failed.
+// If the stream was canceled, Wait returns its cancellation cause. Closing an
+// unfinished stream with [Stream.Close] causes Wait to return [context.Canceled].
+// The terminal result is fixed at completion and can be read multiple times.
+//
+// Canceling ctx stops only this wait, returning [context.Cause] of ctx. An already
+// completed stream's result takes precedence over cancellation of the wait.
+// The ctx must not be nil. Results must be consumed, or the stream canceled,
+// before Wait can complete; Wait does not drain results on behalf of the caller.
+func (s *Stream[T]) Wait(ctx context.Context) error {
+	select {
+	case <-s.done:
+		return s.err
+	default:
+	}
+	select {
+	case <-s.done:
+		return s.err
+	case <-ctx.Done():
+		select {
+		case <-s.done:
+			return s.err
+		default:
+			return context.Cause(ctx)
+		}
+	}
+}
+
+type streamInput[T any] struct {
+	gate   chan struct{}
+	values <-chan T
+	next   int
+}
+
+func (s *streamInput[T]) receive(ctx context.Context) (T, int, bool) {
+	// Receiving and assigning the index must be one operation. Assigning an
+	// atomic index after an independent receive could reorder input positions.
+	var zero T
+	select {
+	case s.gate <- struct{}{}:
+		defer func() { <-s.gate }()
+	case <-ctx.Done():
+		return zero, 0, false
+	}
+	if context.Cause(ctx) != nil {
+		return zero, 0, false
+	}
+	select {
+	case value, ok := <-s.values:
+		if !ok {
+			return zero, 0, false
+		}
+		index := s.next
+		s.next++
+
+		return value, index, true
+	case <-ctx.Done():
+		return zero, 0, false
+	}
+}

--- a/parallel/stream_test.go
+++ b/parallel/stream_test.go
@@ -1,0 +1,339 @@
+package parallel_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/go-fries/fries/parallel/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapStreamPreservesInputIndexesAndItemErrors(t *testing.T) {
+	const count = 100
+	input := make(chan int, count)
+	for i := range count {
+		input <- i
+	}
+	close(input)
+	wantErr := errors.New("item failed")
+	stream := newTestStream(t, 8, input, func(_ context.Context, value int) (int, error) {
+		if value%7 == 0 {
+			return value * 2, wantErr
+		}
+
+		return value * 2, nil
+	})
+	seen := make(map[int]bool, count)
+	for result := range stream.Results() {
+		require.GreaterOrEqual(t, result.Index, 0)
+		require.Less(t, result.Index, count)
+		assert.False(t, seen[result.Index], "duplicate index %d", result.Index)
+		seen[result.Index] = true
+		assert.Equal(t, result.Index*2, result.Value)
+		if result.Index%7 == 0 {
+			assert.ErrorIs(t, result.Err, wantErr)
+		} else {
+			assert.NoError(t, result.Err)
+		}
+	}
+	require.NoError(t, stream.Wait(t.Context()))
+	assert.Len(t, seen, count)
+}
+
+func TestMapStreamDeliversWithoutWaitingForEarlierInputs(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		input := make(chan int, 2)
+		input <- 0
+		input <- 1
+		close(input)
+		release := make(chan struct{})
+		stream := newTestStream(t, 2, input, func(ctx context.Context, value int) (int, error) {
+			if value == 0 {
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return 0, context.Cause(ctx)
+				}
+			}
+
+			return value, nil
+		})
+		synctest.Wait()
+		first := <-stream.Results()
+		assert.Equal(t, parallel.StreamResult[int]{Index: 1, Value: 1}, first)
+		close(release)
+		second := <-stream.Results()
+		assert.Equal(t, parallel.StreamResult[int]{Index: 0, Value: 0}, second)
+		_, ok := <-stream.Results()
+		assert.False(t, ok)
+		require.NoError(t, stream.Wait(t.Context()))
+	})
+}
+
+func TestMapStreamBoundsConcurrency(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const limit = 4
+		input := make(chan int, 20)
+		for i := range 20 {
+			input <- i
+		}
+		close(input)
+		release := make(chan struct{})
+		var active atomic.Int32
+		stream := newTestStream(t, limit, input, func(ctx context.Context, value int) (int, error) {
+			n := active.Add(1)
+			defer active.Add(-1)
+			assert.LessOrEqual(t, n, int32(limit))
+			select {
+			case <-release:
+				return value, nil
+			case <-ctx.Done():
+				return 0, context.Cause(ctx)
+			}
+		})
+		synctest.Wait()
+		assert.Equal(t, int32(limit), active.Load())
+		close(release)
+		count := 0
+		for range stream.Results() {
+			count++
+		}
+		require.NoError(t, stream.Wait(t.Context()))
+		assert.Equal(t, 20, count)
+		assert.Zero(t, active.Load())
+	})
+}
+
+func TestMapStreamBackpressureBoundsInputConsumption(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const limit = 3
+		input := make(chan int, 20)
+		for i := range 20 {
+			input <- i
+		}
+		var called atomic.Int32
+		stream := newTestStream(t, limit, input, func(_ context.Context, value int) (int, error) {
+			called.Add(1)
+
+			return value, nil
+		})
+		synctest.Wait()
+		assert.Equal(t, int32(limit), called.Load())
+		assert.Len(t, input, 20-limit)
+		<-stream.Results()
+		synctest.Wait()
+		assert.Equal(t, int32(limit+1), called.Load())
+		assert.Len(t, input, 20-limit-1)
+		stream.Close()
+		require.ErrorIs(t, stream.Wait(t.Context()), context.Canceled)
+		_, ok := <-stream.Results()
+		assert.False(t, ok)
+		// The caller still owns the unconsumed input and its channel.
+		assert.Len(t, input, 20-limit-1)
+		close(input)
+	})
+}
+
+func TestMapStreamEmptyInputCompletesNormally(t *testing.T) {
+	input := make(chan int)
+	close(input)
+	stream := newTestStream(t, 4, input, func(context.Context, int) (int, error) {
+		t.Error("callback invoked for an empty input")
+
+		return 0, nil
+	})
+	_, ok := <-stream.Results()
+	assert.False(t, ok)
+	require.NoError(t, stream.Wait(t.Context()))
+	assert.ErrorIs(t, context.Cause(stream.Context()), context.Canceled)
+	stream.Close()
+	require.NoError(t, stream.Wait(t.Context()))
+}
+
+func TestStreamCloseUnblocksIdleReceivers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		input := make(chan int)
+		stream := newTestStream(t, 8, input, func(context.Context, int) (int, error) {
+			t.Error("callback invoked without an input")
+
+			return 0, nil
+		})
+		synctest.Wait()
+		stream.Close()
+		require.ErrorIs(t, stream.Wait(t.Context()), context.Canceled)
+		_, ok := <-stream.Results()
+		assert.False(t, ok)
+		select {
+		case <-input:
+			t.Fatal("stream closed the producer's input channel")
+		default:
+		}
+		close(input)
+	})
+}
+
+func TestStreamCloseWaitsForRunningCallbacks(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		input := make(chan int, 1)
+		input <- 1
+		release := make(chan struct{})
+		canceled := make(chan struct{})
+		stream := newTestStream(t, 1, input, func(ctx context.Context, value int) (int, error) {
+			<-ctx.Done()
+			close(canceled)
+			<-release
+
+			return value, context.Cause(ctx)
+		})
+		var once sync.Once
+		unblock := func() { once.Do(func() { close(release) }) }
+		t.Cleanup(unblock)
+		synctest.Wait()
+		closed := make(chan struct{})
+		go func() {
+			stream.Close()
+			close(closed)
+		}()
+		<-canceled
+		synctest.Wait()
+		select {
+		case <-closed:
+			t.Fatal("Close returned before the callback exited")
+		default:
+		}
+		unblock()
+		<-closed
+		require.ErrorIs(t, stream.Wait(t.Context()), context.Canceled)
+		close(input)
+	})
+}
+
+func TestStreamContextStopsProducerOnEarlyClose(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		input := make(chan int)
+		stream := newTestStream(t, 2, input, func(_ context.Context, value int) (int, error) {
+			return value, nil
+		})
+		producerDone := make(chan struct{})
+		go func() {
+			defer close(producerDone)
+			defer close(input)
+			for i := 0; ; i++ {
+				select {
+				case input <- i:
+				case <-stream.Context().Done():
+					return
+				}
+			}
+		}()
+		<-stream.Results()
+		stream.Close()
+		<-producerDone
+		require.ErrorIs(t, stream.Wait(t.Context()), context.Canceled)
+	})
+}
+
+func TestStreamWaitCancellationDoesNotCancelProcessing(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		input := make(chan int, 1)
+		input <- 42
+		close(input)
+		stream := newTestStream(t, 1, input, func(_ context.Context, value int) (int, error) {
+			return value, nil
+		})
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		require.ErrorIs(t, stream.Wait(ctx), context.DeadlineExceeded)
+		assert.NoError(t, context.Cause(stream.Context()))
+		assert.Equal(t, 42, (<-stream.Results()).Value)
+		require.NoError(t, stream.Wait(t.Context()))
+		require.NoError(t, stream.Wait(ctx))
+		stream.Close()
+		require.NoError(t, stream.Wait(ctx))
+	})
+}
+
+func TestStreamPreservesParentCancellationCause(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		input := make(chan int, 1)
+		input <- 1
+		var called atomic.Bool
+		stream, err := parallel.MapStream(ctx, 2, input, func(ctx context.Context, value int) (int, error) {
+			called.Store(true)
+			<-ctx.Done()
+
+			return value, context.Cause(ctx)
+		})
+		require.NoError(t, err)
+		t.Cleanup(stream.Close)
+		synctest.Wait()
+		require.True(t, called.Load())
+		wantErr := errors.New("source stopped")
+		cancel(wantErr)
+		require.ErrorIs(t, stream.Wait(t.Context()), wantErr)
+		require.ErrorIs(t, context.Cause(stream.Context()), wantErr)
+		_, ok := <-stream.Results()
+		assert.False(t, ok)
+		close(input)
+	})
+}
+
+func TestStreamConcurrentCloseAndWait(t *testing.T) {
+	input := make(chan int)
+	stream := newTestStream(t, 8, input, func(_ context.Context, value int) (int, error) { return value, nil })
+	start := make(chan struct{})
+	var callers sync.WaitGroup
+	for range 20 {
+		callers.Go(func() {
+			<-start
+			stream.Close()
+		})
+		callers.Go(func() {
+			<-start
+			assert.ErrorIs(t, stream.Wait(t.Context()), context.Canceled)
+		})
+	}
+	close(start)
+	callers.Wait()
+	close(input)
+}
+
+func TestMapStreamValidatesInputs(t *testing.T) {
+	fn := func(_ context.Context, value int) (int, error) { return value, nil }
+	input := make(chan int)
+	close(input)
+	for _, limit := range []int{0, -1} {
+		stream, err := parallel.MapStream(t.Context(), limit, input, fn)
+		require.ErrorIs(t, err, parallel.ErrInvalidLimit)
+		assert.Nil(t, stream)
+	}
+	stream, err := parallel.MapStream[int, int](t.Context(), 1, input, nil)
+	require.ErrorIs(t, err, parallel.ErrNilFunc)
+	assert.Nil(t, stream)
+	stream, err = parallel.MapStream(t.Context(), 1, nil, fn)
+	require.ErrorIs(t, err, parallel.ErrNilInput)
+	assert.Nil(t, stream)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	wantErr := errors.New("already stopped")
+	cancel(wantErr)
+	stream, err = parallel.MapStream(ctx, 1, input, fn)
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, stream)
+}
+
+func newTestStream[T, R any](t *testing.T, limit int, input <-chan T, fn func(context.Context, T) (R, error)) *parallel.Stream[R] {
+	t.Helper()
+	stream, err := parallel.MapStream(t.Context(), limit, input, fn)
+	require.NoError(t, err)
+	t.Cleanup(stream.Close)
+
+	return stream
+}


### PR DESCRIPTION
## Summary
Extend `parallel` with generic, bounded processing of channel inputs so callers can produce inputs and consume results incrementally.

## Changes
- Add `MapStream`, `Stream[T]`, and `StreamResult[T]` with input receive indexes and per-item values/errors. Callback failures do not cancel sibling work or become terminal stream errors.
- Deliver results without input-order sorting through an unbuffered channel. Each worker accepts another input only after delivering its previous result, bounding internal in-flight work by the concurrency limit.
- Add `Results`, `Context`, repeatable `Close`, and context-aware `Wait`. Producers can share cancellation through the stream context; input channels and producer goroutines remain caller-owned.
- Preserve parent cancellation causes, distinguish normal completion from cancellation, and allow consumers to stop early. Cancellation may omit undelivered results; closing waits for running callbacks to return.
- Add Go Doc, runnable examples, and tests for indexing, out-of-order delivery, concurrency limits, backpressure, item errors, cancellation, and concurrent close/wait calls.

## Motivation
- Process large or ongoing inputs without first collecting an entire slice.
- Make backpressure and producer/consumer shutdown explicit and reusable.

## Testing
- `make test/parallel ARGS='-race -cover'` — passed; parallel module statement coverage: 96.0%.
- `make build/parallel` — passed.
- `make lint` — passed across the repository.
- `git diff --cached --check` — passed.
- Reviewed `go doc -all .` output in the parallel module.