### PR TITLE
feat(debounce): add context-aware trailing-edge debouncer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ and internal development tools are not included.
 | Config | [`config`](https://pkg.go.dev/github.com/go-fries/fries/config/v4) | Type-safe configuration propagation through `context.Context`. |
 | Chi | [`chi`](https://pkg.go.dev/github.com/go-fries/fries/chi/v4) | A Chi-based HTTP server adapter. |
 | CloudEvents | [`cloudevents/protocol/amqp091`](https://pkg.go.dev/github.com/go-fries/fries/cloudevents/protocol/amqp091/v4)<br>[`cloudevents/eventdispatcher`](https://pkg.go.dev/github.com/go-fries/fries/cloudevents/eventdispatcher/v4) | AMQP 0.9.1 transport and event dispatching for CloudEvents. |
+| Debounce | [`debounce`](https://pkg.go.dev/github.com/go-fries/fries/debounce/v4) | Trailing-edge debouncing with latest-value replacement, serial handlers, explicit flushing, and cancellation. |
 | Env | [`env`](https://pkg.go.dev/github.com/go-fries/fries/env/v4) | Utilities for representing and propagating application environments. |
 | Encrypter | [`encrypter`](https://pkg.go.dev/github.com/go-fries/fries/encrypter/v4) | AES-CTR string encryption and decryption helpers. |
 | Ent | [`ent`](https://pkg.go.dev/github.com/go-fries/fries/ent/v4)<br>[`ent/multidriver`](https://pkg.go.dev/github.com/go-fries/fries/ent/multidriver/v4) | Ent integrations for logging and routing operations across multiple drivers. |

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,6 +39,7 @@ fixes:
   - github.com/go-fries/fries/capability/v4::capability/
   - github.com/go-fries/fries/parallel/v4::parallel/
   - github.com/go-fries/fries/crontab/v4::crontab/
+  - github.com/go-fries/fries/debounce/v4::debounce/
   - github.com/go-fries/fries/encrypter/v4::encrypter/
   - github.com/go-fries/fries/ent/v4::ent/
   - github.com/go-fries/fries/ent/multidriver/v4::ent/multidriver/

--- a/debounce/README.md
+++ b/debounce/README.md
@@ -1,0 +1,145 @@
+# Debounce
+
+`debounce` retains the latest value and invokes a handler after triggers have
+been quiet for a configured interval. One worker serializes handler calls.
+
+For a 500 ms delay:
+
+```text
+  0 ms  Trigger("a")    -> due at 500 ms
+200 ms  Trigger("ab")   -> due at 700 ms
+400 ms  Trigger("abc")  -> due at 900 ms
+900 ms  handler("abc")
+```
+
+Continuous triggers keep postponing execution. Each debouncer manages one
+latest-value slot; use separate instances for independent actions, such as
+saving different drafts.
+
+## Installation
+
+```bash
+go get github.com/go-fries/fries/debounce/v4
+```
+
+## Save the latest value
+
+Create a debouncer with a processing context that covers its lifetime:
+
+```go
+saver, err := debounce.New(ctx, 500*time.Millisecond,
+	func(ctx context.Context, content string) error {
+		return repository.SaveDraft(ctx, draftID, content)
+	},
+	debounce.WithOnError(func(err error) {
+		log.Printf("save draft: %v", err)
+	}),
+)
+if err != nil {
+	return err
+}
+defer saver.Close()
+```
+
+Whenever the content changes, trigger a save:
+
+```go
+if err := saver.Trigger(content); err != nil {
+	return err
+}
+```
+
+`Trigger` returns once the value is stored. It replaces the previous pending
+value and restarts the delay. Success means acceptance, not that the value has
+been saved; another trigger can replace it before execution.
+
+Handler calls never overlap. Triggers received during a running handler form
+the next invocation. If that invocation's quiet interval has already elapsed
+when the handler finishes, it can start immediately. Otherwise it waits for the
+remaining interval. Handler execution and scheduling can add latency.
+
+Values are not deep-copied. Synchronize mutations to maps, slices, pointers, or
+other referenced data that a handler may read after submission.
+
+## Save immediately
+
+Use `Flush` when a user explicitly saves or before closing the debouncer:
+
+```go
+if err := saver.Flush(waitContext); err != nil {
+	return err
+}
+```
+
+`Flush` freezes the latest pending value and schedules it without the remaining
+quiet interval. It waits for that invocation and its error callback. Later
+triggers form a new pending value and cannot replace the frozen one.
+
+If there is no pending value, `Flush` waits for an existing frozen or running
+invocation, or returns nil if idle. It returns the selected handler's error;
+errors from already completed invocations are not replayed. Concurrent flushes
+may wait for the same invocation and receive the same result.
+
+The debouncer holds at most one running value, one frozen value, and one
+replaceable pending value. If another frozen invocation already occupies the
+slot and a newer value is pending, `Flush` first waits for that frozen invocation
+to finish, then captures the latest available pending value. During this
+admission wait, pending values may still be replaced or processed by the worker.
+
+Canceling the flush context ends only admission or waiting. An already frozen
+invocation continues with the processing context provided to `New`. The result
+of an invocation already completed while waiting takes precedence over wait
+cancellation. Nil contexts are rejected with `ErrInvalidContext`.
+
+## Handle errors
+
+`WithOnError` reports every handler error, including failures from invocations
+initiated by `Flush`. It does not run for successful calls or for values that
+were discarded without invoking the handler.
+
+Handler failures do not stop later invocations and are not automatically
+retried. Register `WithOnError` to observe background failures; without it,
+handler errors are available only to flush callers waiting for that invocation.
+
+The error callback runs on the worker, so `Flush` and `Close` wait for it to
+finish. Handlers and error callbacks may call `Trigger`, but must not
+synchronously call `Flush` or `Close` on their own debouncer. Panics follow
+normal Go semantics and are not recovered.
+
+## Close
+
+```go
+saver.Close()
+```
+
+`Close` rejects new triggers and flushes, discards pending and frozen values,
+cancels the processing context, and waits for the running handler and worker.
+It is safe to call repeatedly or concurrently. Handlers must observe their
+context and return promptly for closure to finish promptly.
+
+To preserve the final pending value, flush while the processing context is still
+active, then close:
+
+```go
+err := saver.Flush(waitContext)
+saver.Close()
+return err
+```
+
+Canceling the context supplied to `New` also starts closure. A handler already
+selected by the worker counts as running and may receive a canceled context.
+Flush callers waiting on a frozen invocation discarded by closure receive
+`ErrClosed`. Flush callers waiting on a running invocation receive that handler's
+result, unless their own wait context ends first.
+
+The debouncer owns no persistent storage. Closing a debouncer is a cancellation
+operation; processing the final value is an explicit `Flush` operation.
+
+## Configuration
+
+`New` requires a positive delay, a non-nil handler, and a non-nil, active context.
+Invalid arguments return `ErrInvalidDelay`, `ErrNilHandler`, `ErrInvalidContext`,
+or the context's cancellation cause before starting a worker.
+
+`WithOnError` is optional. Options are applied in order; the last callback wins.
+A nil callback disables notifications, and nil options are ignored.

--- a/debounce/config.go
+++ b/debounce/config.go
@@ -1,0 +1,38 @@
+package debounce
+
+type config struct {
+	onError func(error)
+}
+
+// Option configures a [Debouncer].
+type Option interface {
+	apply(*config)
+}
+
+type optionFunc func(*config)
+
+func (f optionFunc) apply(c *config) {
+	f(c)
+}
+
+// WithOnError sets a callback invoked whenever the handler returns an error.
+// A nil callback disables error notifications, which is the default.
+//
+// The callback runs synchronously on the worker, including for calls initiated
+// by [Debouncer.Flush]. Flush and [Debouncer.Close] wait for it to return.
+// It may call [Debouncer.Trigger] but must not synchronously call Flush or Close
+// on its own debouncer. Panics are not recovered.
+func WithOnError(fn func(error)) Option {
+	return optionFunc(func(c *config) { c.onError = fn })
+}
+
+func newConfig(options ...Option) config {
+	var c config
+	for _, option := range options {
+		if option != nil {
+			option.apply(&c)
+		}
+	}
+
+	return c
+}

--- a/debounce/config_test.go
+++ b/debounce/config_test.go
@@ -1,0 +1,57 @@
+package debounce_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-fries/fries/debounce/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValidatesInputs(t *testing.T) {
+	handler := func(context.Context, int) error { return nil }
+	var nilContext context.Context
+	d, err := debounce.New(nilContext, time.Second, handler)
+	require.ErrorIs(t, err, debounce.ErrInvalidContext)
+	assert.Nil(t, d)
+	ctx, cancel := context.WithCancelCause(t.Context())
+	wantErr := errors.New("already stopped")
+	cancel(wantErr)
+	d, err = debounce.New(ctx, time.Second, handler)
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, d)
+	for _, delay := range []time.Duration{0, -time.Second} {
+		d, err = debounce.New(t.Context(), delay, handler)
+		require.ErrorIs(t, err, debounce.ErrInvalidDelay)
+		assert.Nil(t, d)
+	}
+	d, err = debounce.New[int](t.Context(), time.Second, nil)
+	require.ErrorIs(t, err, debounce.ErrNilHandler)
+	assert.Nil(t, d)
+}
+
+func TestOptionsUseLastErrorCallback(t *testing.T) {
+	wantErr := errors.New("save failed")
+	var received error
+	d := newDebouncer(t, time.Hour, func(context.Context, int) error { return wantErr },
+		debounce.WithOnError(func(error) { t.Error("replaced error callback ran") }),
+		nil,
+		debounce.WithOnError(func(err error) { received = err }),
+	)
+	require.NoError(t, d.Trigger(1))
+	require.ErrorIs(t, d.Flush(t.Context()), wantErr)
+	assert.ErrorIs(t, received, wantErr)
+}
+
+func TestNilErrorCallbackDisablesNotifications(t *testing.T) {
+	wantErr := errors.New("save failed")
+	d := newDebouncer(t, time.Hour, func(context.Context, int) error { return wantErr },
+		debounce.WithOnError(func(error) { t.Error("disabled error callback ran") }),
+		debounce.WithOnError(nil),
+	)
+	require.NoError(t, d.Trigger(1))
+	require.ErrorIs(t, d.Flush(t.Context()), wantErr)
+}

--- a/debounce/debouncer.go
+++ b/debounce/debouncer.go
@@ -1,0 +1,246 @@
+package debounce
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Handler processes the latest value selected by a [Debouncer].
+//
+// Calls are serial and receive the context derived from the one supplied to
+// [New]. A handler should return promptly when its context is canceled. It may
+// call [Debouncer.Trigger], but must not synchronously call [Debouncer.Flush] or
+// [Debouncer.Close] on its own debouncer. Panics follow normal Go semantics.
+type Handler[T any] func(context.Context, T) error
+
+// Debouncer delays processing until triggers have been quiet for a full interval.
+//
+// A Debouncer is safe for concurrent use. It must be created by [New], must not
+// be copied after first use, and must be closed when no longer needed. Its zero
+// value is not valid. Values are not deep-copied; callers must synchronize
+// mutations to referenced data that might be read by a handler.
+//
+// One worker processes invocations serially. Internally, at most one value can
+// be running, one frozen by a flush, and one pending replacement. Handler errors
+// do not stop subsequent invocations; use [WithOnError] to observe background
+// failures.
+type Debouncer[T any] struct {
+	ctx     context.Context
+	cancel  context.CancelFunc
+	delay   time.Duration
+	handler Handler[T]
+	config  config
+	wake    chan struct{}
+	done    chan struct{}
+
+	mu      sync.Mutex
+	closed  bool
+	pending *invocation[T]
+	ready   *invocation[T]
+	running *invocation[T]
+}
+
+// New starts a trailing-edge debouncer with the given delay and handler.
+//
+// Each [Debouncer.Trigger] restarts the delay for the replaceable pending value.
+// Canceling ctx closes the debouncer, discards values not yet selected for
+// execution, and cancels the running handler's context. Use [Debouncer.Close]
+// to wait for cleanup.
+//
+// New returns [ErrInvalidContext] for a nil ctx, its cancellation cause if ctx
+// is already canceled, [ErrInvalidDelay] for a non-positive delay, or
+// [ErrNilHandler] for a nil handler. No worker starts on failure. Nil options
+// are ignored.
+func New[T any](ctx context.Context, delay time.Duration, handler Handler[T], options ...Option) (*Debouncer[T], error) {
+	if err := validateContext(ctx); err != nil {
+		return nil, err
+	}
+	if delay <= 0 {
+		return nil, ErrInvalidDelay
+	}
+	if handler == nil {
+		return nil, ErrNilHandler
+	}
+
+	processingContext, cancel := context.WithCancel(ctx)
+	d := &Debouncer[T]{
+		ctx:     processingContext,
+		cancel:  cancel,
+		delay:   delay,
+		handler: handler,
+		config:  newConfig(options...),
+		wake:    make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	stopCancellation := context.AfterFunc(processingContext, d.stop)
+	go func() {
+		defer stopCancellation()
+		d.run()
+		d.stop()
+		close(d.done)
+	}()
+
+	return d, nil
+}
+
+// Trigger replaces the pending value and restarts its quiet interval.
+//
+// Trigger returns once the value is stored, without waiting for the handler.
+// A later trigger can replace it before execution. Triggers during a running
+// handler form the next invocation and never start an overlapping handler.
+// A value already frozen by [Debouncer.Flush] is not replaced.
+//
+// Trigger returns [ErrClosed] if the debouncer is closed or its processing
+// context has been canceled. Concurrent triggers are ordered by acceptance.
+func (d *Debouncer[T]) Trigger(value T) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || context.Cause(d.ctx) != nil {
+		return ErrClosed
+	}
+	if d.pending == nil {
+		d.pending = &invocation[T]{done: make(chan struct{})}
+	}
+	d.pending.value = value
+	d.pending.due = time.Now().Add(d.delay)
+	d.notify()
+
+	return nil
+}
+
+// Flush freezes the latest pending value for execution without its remaining delay.
+// It waits for that invocation and its error callback, returning the handler error.
+//
+// Later triggers cannot replace a frozen value or postpone its execution. If a
+// previous flush already occupies the frozen slot and a newer value is pending,
+// Flush waits for that invocation to finish before capturing the latest pending
+// value. Pending values can still be replaced during this admission wait.
+//
+// With no pending value, Flush waits for the existing frozen or running
+// invocation. If idle, it returns nil. Concurrent flushes may share a result.
+// Completed errors are not replayed; use [WithOnError] for background failures.
+//
+// Canceling ctx stops only admission or waiting, returning [context.Cause] of
+// ctx. An already frozen invocation continues using the processing context.
+// A completed result takes precedence over cancellation while waiting. A nil
+// ctx returns [ErrInvalidContext]. A closed debouncer or an invocation discarded
+// by [Debouncer.Close] returns [ErrClosed].
+func (d *Debouncer[T]) Flush(ctx context.Context) error {
+	if err := validateContext(ctx); err != nil {
+		return err
+	}
+	for {
+		call, retry, err := d.selectFlush()
+		if err != nil || call == nil {
+			return err
+		}
+		if err := wait(ctx, call.done); err != nil {
+			return err
+		}
+		if !retry {
+			return call.err
+		}
+		if err := context.Cause(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+// Close stops accepting triggers, discards pending and frozen values, and waits
+// for the running invocation and worker to exit.
+//
+// Close cancels the processing context but still waits for a running handler and
+// its error callback to return. Values already selected by the worker count as
+// running. Call Flush before Close when the final pending value must be processed.
+// Close is safe to call repeatedly or concurrently.
+func (d *Debouncer[T]) Close() {
+	d.stop()
+	<-d.done
+}
+
+func (d *Debouncer[T]) selectFlush() (*invocation[T], bool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || context.Cause(d.ctx) != nil {
+		return nil, false, ErrClosed
+	}
+	if d.ready != nil {
+		return d.ready, d.pending != nil, nil
+	}
+	if d.pending != nil {
+		d.ready, d.pending = d.pending, nil
+		d.notify()
+
+		return d.ready, false, nil
+	}
+
+	return d.running, false, nil
+}
+
+func (d *Debouncer[T]) stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return
+	}
+	d.closed = true
+	d.cancel()
+	if d.pending != nil {
+		d.pending.complete(ErrClosed)
+		d.pending = nil
+	}
+	if d.ready != nil {
+		d.ready.complete(ErrClosed)
+		d.ready = nil
+	}
+	d.notify()
+}
+
+func (d *Debouncer[T]) notify() {
+	select {
+	case d.wake <- struct{}{}:
+	default:
+	}
+}
+
+func validateContext(ctx context.Context) error {
+	if ctx == nil {
+		return ErrInvalidContext
+	}
+
+	return context.Cause(ctx)
+}
+
+type invocation[T any] struct {
+	value T
+	due   time.Time
+	done  chan struct{}
+	err   error
+}
+
+func (c *invocation[T]) complete(err error) {
+	var zero T
+	c.value = zero
+	c.err = err
+	close(c.done)
+}
+
+func wait(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	default:
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		select {
+		case <-done:
+			return nil
+		default:
+			return context.Cause(ctx)
+		}
+	}
+}

--- a/debounce/debouncer_test.go
+++ b/debounce/debouncer_test.go
@@ -1,0 +1,362 @@
+package debounce_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/go-fries/fries/debounce/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlushExecutesLatestValueOnce(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Hour, func(_ context.Context, value int) error {
+			calls <- value
+
+			return nil
+		})
+		require.NoError(t, d.Flush(t.Context()))
+		require.NoError(t, d.Trigger(1))
+		require.NoError(t, d.Trigger(2))
+		require.NoError(t, d.Flush(t.Context()))
+		require.Len(t, calls, 1)
+		assert.Equal(t, 2, <-calls)
+		time.Sleep(2 * time.Hour)
+		synctest.Wait()
+		require.NoError(t, d.Flush(t.Context()))
+		assert.Empty(t, calls)
+	})
+}
+
+func TestFlushFreezesValueBeforeLaterTriggers(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		calls := make(chan int, 10)
+		wantErr := errors.New("frozen save failed")
+		d := newDebouncer(t, time.Hour, func(_ context.Context, value int) error {
+			calls <- value
+			if value == 1 {
+				<-release
+			}
+			if value == 2 {
+				return wantErr
+			}
+
+			return nil
+		})
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		first := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(2))
+		frozen := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(3))
+		unblock()
+		require.NoError(t, <-first)
+		require.ErrorIs(t, <-frozen, wantErr)
+		synctest.Wait()
+		require.Len(t, calls, 2)
+		assert.Equal(t, 1, <-calls)
+		assert.Equal(t, 2, <-calls)
+		require.NoError(t, d.Flush(t.Context()))
+		assert.Equal(t, 3, <-calls)
+	})
+}
+
+func TestConcurrentFlushesShareRunningResult(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		wantErr := errors.New("save failed")
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Hour, func(_ context.Context, value int) error {
+			calls <- value
+			<-release
+
+			return wantErr
+		})
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		first := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		second := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		assert.Empty(t, first)
+		assert.Empty(t, second)
+		unblock()
+		require.ErrorIs(t, <-first, wantErr)
+		require.ErrorIs(t, <-second, wantErr)
+		assert.Len(t, calls, 1)
+	})
+}
+
+func TestFlushWaitsForAdmissionBeforeCapturingLatest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		firstRelease := make(chan struct{})
+		secondRelease := make(chan struct{})
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Hour, func(_ context.Context, value int) error {
+			calls <- value
+			switch value {
+			case 1:
+				<-firstRelease
+			case 2:
+				<-secondRelease
+			}
+
+			return nil
+		})
+		unblockFirst := releaseOnCleanup(t, firstRelease)
+		unblockSecond := releaseOnCleanup(t, secondRelease)
+		require.NoError(t, d.Trigger(1))
+		first := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(2))
+		second := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		shared := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(3))
+		third := flushAsync(t, t.Context(), d)
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		canceled := flushAsync(t, ctx, d)
+		synctest.Wait()
+		waitErr := errors.New("admission wait stopped")
+		cancel(waitErr)
+		require.ErrorIs(t, <-canceled, waitErr)
+		require.NoError(t, d.Trigger(4))
+		unblockFirst()
+		require.NoError(t, <-first)
+		synctest.Wait()
+		assert.Empty(t, third)
+		unblockSecond()
+		require.NoError(t, <-second)
+		require.NoError(t, <-shared)
+		require.NoError(t, <-third)
+		require.Len(t, calls, 3)
+		assert.Equal(t, 1, <-calls)
+		assert.Equal(t, 2, <-calls)
+		assert.Equal(t, 4, <-calls)
+	})
+}
+
+func TestCanceledFlushPreservesFrozenInvocation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Hour, func(ctx context.Context, value int) error {
+			if value == 1 {
+				<-release
+			}
+			assert.NoError(t, context.Cause(ctx))
+			calls <- value
+
+			return nil
+		})
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		first := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(2))
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		second := flushAsync(t, ctx, d)
+		synctest.Wait()
+		wantErr := errors.New("flush wait stopped")
+		cancel(wantErr)
+		require.ErrorIs(t, <-second, wantErr)
+		unblock()
+		require.NoError(t, <-first)
+		synctest.Wait()
+		require.Len(t, calls, 2)
+		assert.Equal(t, 1, <-calls)
+		assert.Equal(t, 2, <-calls)
+	})
+}
+
+func TestFlushAndCloseWaitForErrorCallback(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		wantErr := errors.New("save failed")
+		d := newDebouncer(t, time.Hour, func(context.Context, int) error { return wantErr },
+			debounce.WithOnError(func(err error) {
+				assert.ErrorIs(t, err, wantErr)
+				<-release
+			}),
+		)
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		flushed := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		closed := make(chan struct{})
+		go func() {
+			d.Close()
+			close(closed)
+		}()
+		synctest.Wait()
+		assert.Empty(t, flushed)
+		select {
+		case <-closed:
+			t.Fatal("Close returned before the error callback finished")
+		default:
+		}
+		unblock()
+		require.ErrorIs(t, <-flushed, wantErr)
+		<-closed
+	})
+}
+
+func TestCloseDiscardsPendingAndFrozenValues(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Hour, func(ctx context.Context, value int) error {
+			calls <- value
+			<-ctx.Done()
+			<-release
+
+			return context.Cause(ctx)
+		})
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		first := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(2))
+		second := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(3))
+		closed := make(chan struct{})
+		go func() {
+			d.Close()
+			close(closed)
+		}()
+		synctest.Wait()
+		require.ErrorIs(t, <-second, debounce.ErrClosed)
+		require.ErrorIs(t, d.Trigger(4), debounce.ErrClosed)
+		require.ErrorIs(t, d.Flush(t.Context()), debounce.ErrClosed)
+		select {
+		case <-closed:
+			t.Fatal("Close returned before the handler exited")
+		default:
+		}
+		unblock()
+		<-closed
+		require.ErrorIs(t, <-first, context.Canceled)
+		require.Len(t, calls, 1)
+		assert.Equal(t, 1, <-calls)
+		d.Close()
+	})
+}
+
+func TestParentCancellationStopsProcessing(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancelCause(t.Context())
+		defer cancel(nil)
+		calls := make(chan int, 10)
+		d, err := debounce.New(ctx, time.Hour, func(ctx context.Context, value int) error {
+			calls <- value
+			<-ctx.Done()
+
+			return context.Cause(ctx)
+		})
+		require.NoError(t, err)
+		t.Cleanup(d.Close)
+		require.NoError(t, d.Trigger(1))
+		first := flushAsync(t, t.Context(), d)
+		synctest.Wait()
+		require.NoError(t, d.Trigger(2))
+		wantErr := errors.New("application stopped")
+		cancel(wantErr)
+		require.ErrorIs(t, <-first, wantErr)
+		d.Close()
+		require.ErrorIs(t, d.Trigger(3), debounce.ErrClosed)
+		assert.Len(t, calls, 1)
+	})
+}
+
+func TestFlushValidatesContextWithoutConsumingPendingValue(t *testing.T) {
+	calls := make(chan int, 1)
+	d := newDebouncer(t, time.Hour, func(_ context.Context, value int) error {
+		calls <- value
+
+		return nil
+	})
+	require.NoError(t, d.Trigger(1))
+	var nilContext context.Context
+	require.ErrorIs(t, d.Flush(nilContext), debounce.ErrInvalidContext)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, d.Flush(ctx), context.Canceled)
+	require.NoError(t, d.Flush(t.Context()))
+	assert.Equal(t, 1, <-calls)
+}
+
+func TestConcurrentTriggerFlushAndClose(t *testing.T) {
+	var values []int
+	d := newDebouncer(t, time.Hour, func(_ context.Context, value int) error {
+		values = append(values, value)
+
+		return nil
+	})
+	require.NoError(t, d.Trigger(-1))
+	require.NoError(t, d.Flush(t.Context()))
+	start := make(chan struct{})
+	var callers sync.WaitGroup
+	for i := range 100 {
+		callers.Go(func() {
+			<-start
+			err := d.Trigger(i)
+			assert.True(t, err == nil || errors.Is(err, debounce.ErrClosed))
+			err = d.Flush(t.Context())
+			assert.True(t, err == nil || errors.Is(err, debounce.ErrClosed))
+		})
+	}
+	for range 10 {
+		callers.Go(func() {
+			<-start
+			d.Close()
+		})
+	}
+	close(start)
+	callers.Wait()
+	d.Close()
+	seen := make(map[int]bool, len(values))
+	for _, value := range values {
+		assert.False(t, seen[value], "duplicate invocation for %d", value)
+		seen[value] = true
+	}
+	assert.True(t, seen[-1])
+}
+
+func newDebouncer[T any](t *testing.T, delay time.Duration, handler debounce.Handler[T], options ...debounce.Option) *debounce.Debouncer[T] {
+	t.Helper()
+	d, err := debounce.New(t.Context(), delay, handler, options...)
+	require.NoError(t, err)
+	t.Cleanup(d.Close)
+
+	return d
+}
+
+func releaseOnCleanup(t *testing.T, release chan struct{}) func() {
+	t.Helper()
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+
+	return unblock
+}
+
+func flushAsync[T any](t *testing.T, ctx context.Context, d *debounce.Debouncer[T]) <-chan error {
+	t.Helper()
+	result := make(chan error, 1)
+	go func() { result <- d.Flush(ctx) }()
+
+	return result
+}

--- a/debounce/doc.go
+++ b/debounce/doc.go
@@ -1,0 +1,7 @@
+// Package debounce provides context-aware, trailing-edge debouncing.
+//
+// [Debouncer.Trigger] retains the latest value until a quiet interval elapses.
+// [Debouncer.Flush] forces pending work and [Debouncer.Close] cancels work that
+// has not started. A single worker serializes handlers, and [WithOnError] reports
+// asynchronous handler failures.
+package debounce

--- a/debounce/errors.go
+++ b/debounce/errors.go
@@ -1,0 +1,15 @@
+package debounce
+
+import "errors"
+
+var (
+	// ErrInvalidDelay indicates that [New] received a non-positive delay.
+	ErrInvalidDelay = errors.New("debounce: delay must be positive")
+	// ErrNilHandler indicates that [New] received a nil handler.
+	ErrNilHandler = errors.New("debounce: handler must not be nil")
+	// ErrInvalidContext indicates that a nil context was supplied.
+	ErrInvalidContext = errors.New("debounce: context must not be nil")
+	// ErrClosed indicates that a debouncer is closed or an invocation was
+	// discarded before starting because the debouncer closed.
+	ErrClosed = errors.New("debounce: closed")
+)

--- a/debounce/example_test.go
+++ b/debounce/example_test.go
@@ -1,0 +1,77 @@
+package debounce_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-fries/fries/debounce/v4"
+)
+
+func Example() {
+	ctx := context.Background()
+	saver, err := debounce.New(ctx, time.Hour, func(_ context.Context, content string) error {
+		fmt.Println("saved:", content)
+
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer saver.Close()
+
+	for _, content := range []string{"你", "你好", "你好呀"} {
+		if err := saver.Trigger(content); err != nil {
+			panic(err)
+		}
+	}
+	// Save now, rather than waiting for the quiet interval.
+	if err := saver.Flush(ctx); err != nil {
+		panic(err)
+	}
+	// Output: saved: 你好呀
+}
+
+func ExampleDebouncer_Close() {
+	ctx := context.Background()
+	calls := 0
+	d, err := debounce.New(ctx, time.Hour, func(context.Context, string) error {
+		calls++
+
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	if err := d.Trigger("discard this pending value"); err != nil {
+		panic(err)
+	}
+	d.Close()
+	fmt.Println("handler calls:", calls)
+	fmt.Println("closed:", errors.Is(d.Trigger("another value"), debounce.ErrClosed))
+	// Output:
+	// handler calls: 0
+	// closed: true
+}
+
+func ExampleWithOnError() {
+	ctx := context.Background()
+	d, err := debounce.New(ctx, time.Hour,
+		func(context.Context, string) error { return errors.New("storage unavailable") },
+		debounce.WithOnError(func(err error) {
+			fmt.Println("handler error:", err)
+		}),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer d.Close()
+	if err := d.Trigger("draft"); err != nil {
+		panic(err)
+	}
+	fmt.Println("flush:", d.Flush(ctx))
+	// Output:
+	// handler error: storage unavailable
+	// flush: storage unavailable
+}

--- a/debounce/go.mod
+++ b/debounce/go.mod
@@ -1,0 +1,7 @@
+module github.com/go-fries/fries/debounce/v4
+
+go 1.26.0
+
+require github.com/stretchr/testify v1.12.1
+
+require go.yaml.in/yaml/v3 v3.0.5 // indirect

--- a/debounce/go.sum
+++ b/debounce/go.sum
@@ -1,0 +1,4 @@
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
+go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/debounce/version.go
+++ b/debounce/version.go
@@ -1,0 +1,6 @@
+package debounce
+
+// Version returns the current release version of this package.
+func Version() string {
+	return "4.1.0"
+}

--- a/debounce/version_test.go
+++ b/debounce/version_test.go
@@ -1,0 +1,20 @@
+package debounce_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-fries/fries/debounce/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var versionRegex = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+	`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+	`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+	`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+func TestVersionSemver(t *testing.T) {
+	version := debounce.Version()
+
+	assert.NotNil(t, versionRegex.FindStringSubmatch(version), "version is not semver: %s", version)
+}

--- a/debounce/worker.go
+++ b/debounce/worker.go
@@ -1,0 +1,68 @@
+package debounce
+
+import (
+	"context"
+	"time"
+)
+
+func (d *Debouncer[T]) run() {
+	timer := time.NewTimer(d.delay)
+	timer.Stop()
+	defer timer.Stop()
+	for {
+		call, delay, closed := d.next()
+		if closed {
+			return
+		}
+		if call != nil {
+			d.execute(call)
+
+			continue
+		}
+		timer.Stop()
+		var tick <-chan time.Time
+		if delay > 0 {
+			timer.Reset(delay)
+			tick = timer.C
+		}
+		select {
+		case <-d.wake:
+		case <-tick:
+		case <-d.ctx.Done():
+			d.stop()
+		}
+	}
+}
+
+func (d *Debouncer[T]) next() (*invocation[T], time.Duration, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || context.Cause(d.ctx) != nil {
+		return nil, 0, true
+	}
+	if d.ready != nil {
+		d.running, d.ready = d.ready, nil
+
+		return d.running, 0, false
+	}
+	if d.pending == nil {
+		return nil, 0, false
+	}
+	if remaining := time.Until(d.pending.due); remaining > 0 {
+		return nil, remaining, false
+	}
+	d.running, d.pending = d.pending, nil
+
+	return d.running, 0, false
+}
+
+func (d *Debouncer[T]) execute(call *invocation[T]) {
+	err := d.handler(d.ctx, call.value)
+	if err != nil && d.config.onError != nil {
+		d.config.onError(err)
+	}
+	d.mu.Lock()
+	call.complete(err)
+	d.running = nil
+	d.mu.Unlock()
+}

--- a/debounce/worker_test.go
+++ b/debounce/worker_test.go
@@ -1,0 +1,214 @@
+package debounce_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/go-fries/fries/debounce/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkerTrailingEdgeAndReuse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan string, 10)
+		d := newDebouncer(t, 500*time.Millisecond, func(_ context.Context, value string) error {
+			calls <- value
+
+			return nil
+		})
+		time.Sleep(10 * time.Second)
+		synctest.Wait()
+		assert.Empty(t, calls)
+		require.NoError(t, d.Trigger("你"))
+		time.Sleep(200 * time.Millisecond)
+		require.NoError(t, d.Trigger("你好"))
+		time.Sleep(200 * time.Millisecond)
+		require.NoError(t, d.Trigger("你好呀"))
+		time.Sleep(499 * time.Millisecond)
+		synctest.Wait()
+		assert.Empty(t, calls)
+		time.Sleep(time.Millisecond)
+		synctest.Wait()
+		require.Len(t, calls, 1)
+		assert.Equal(t, "你好呀", <-calls)
+		time.Sleep(10 * time.Second)
+		synctest.Wait()
+		assert.Empty(t, calls)
+		require.NoError(t, d.Trigger(""))
+		time.Sleep(500 * time.Millisecond)
+		synctest.Wait()
+		require.Len(t, calls, 1)
+		assert.Empty(t, <-calls)
+	})
+}
+
+func TestWorkerContinuousTriggersPostponeExecution(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan int, 10)
+		d := newDebouncer(t, 100*time.Millisecond, func(_ context.Context, value int) error {
+			calls <- value
+
+			return nil
+		})
+		for i := range 10 {
+			require.NoError(t, d.Trigger(i))
+			time.Sleep(99 * time.Millisecond)
+			synctest.Wait()
+			assert.Empty(t, calls)
+		}
+		time.Sleep(time.Millisecond)
+		synctest.Wait()
+		require.Len(t, calls, 1)
+		assert.Equal(t, 9, <-calls)
+	})
+}
+
+func TestWorkerTimerRestartsAfterFlush(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Second, func(_ context.Context, value int) error {
+			calls <- value
+
+			return nil
+		})
+		require.NoError(t, d.Trigger(1))
+		time.Sleep(600 * time.Millisecond)
+		require.NoError(t, d.Flush(t.Context()))
+		assert.Equal(t, 1, <-calls)
+		require.NoError(t, d.Trigger(2))
+		time.Sleep(400 * time.Millisecond)
+		synctest.Wait()
+		assert.Empty(t, calls)
+		time.Sleep(600 * time.Millisecond)
+		synctest.Wait()
+		require.Len(t, calls, 1)
+		assert.Equal(t, 2, <-calls)
+	})
+}
+
+func TestWorkerCoalescesTriggersDuringExecution(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan int, 10)
+		release := make(chan struct{})
+		var active atomic.Int32
+		d := newDebouncer(t, 100*time.Millisecond, func(_ context.Context, value int) error {
+			assert.Equal(t, int32(1), active.Add(1))
+			defer active.Add(-1)
+			calls <- value
+			if value == 1 {
+				<-release
+			}
+
+			return nil
+		})
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+		assert.Equal(t, 1, <-calls)
+		require.NoError(t, d.Trigger(2))
+		time.Sleep(50 * time.Millisecond)
+		require.NoError(t, d.Trigger(3))
+		time.Sleep(100 * time.Millisecond)
+		synctest.Wait()
+		assert.Empty(t, calls)
+		unblock()
+		synctest.Wait()
+		require.Len(t, calls, 1)
+		assert.Equal(t, 3, <-calls)
+		assert.Zero(t, active.Load())
+	})
+}
+
+func TestWorkerRetainsDeadlineAcrossRunningHandler(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan int, 10)
+		release := make(chan struct{})
+		d := newDebouncer(t, time.Second, func(_ context.Context, value int) error {
+			calls <- value
+			if value == 1 {
+				<-release
+			}
+
+			return nil
+		})
+		unblock := releaseOnCleanup(t, release)
+		require.NoError(t, d.Trigger(1))
+		time.Sleep(time.Second)
+		synctest.Wait()
+		assert.Equal(t, 1, <-calls)
+		require.NoError(t, d.Trigger(2))
+		time.Sleep(400 * time.Millisecond)
+		unblock()
+		time.Sleep(599 * time.Millisecond)
+		synctest.Wait()
+		assert.Empty(t, calls)
+		time.Sleep(time.Millisecond)
+		synctest.Wait()
+		require.Len(t, calls, 1)
+		assert.Equal(t, 2, <-calls)
+	})
+}
+
+func TestWorkerReportsBackgroundErrorsAndContinues(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		wantErr := errors.New("save failed")
+		reported := make(chan error, 10)
+		calls := make(chan int, 10)
+		d := newDebouncer(t, time.Second, func(_ context.Context, value int) error {
+			calls <- value
+			if value == 1 {
+				return wantErr
+			}
+
+			return nil
+		}, debounce.WithOnError(func(err error) { reported <- err }))
+		require.NoError(t, d.Trigger(1))
+		time.Sleep(time.Second)
+		synctest.Wait()
+		require.Len(t, reported, 1)
+		require.ErrorIs(t, <-reported, wantErr)
+		require.NoError(t, d.Flush(t.Context())) // Historical errors are not replayed.
+		require.NoError(t, d.Trigger(2))
+		time.Sleep(time.Second)
+		synctest.Wait()
+		assert.Empty(t, reported)
+		require.Len(t, calls, 2)
+		assert.Equal(t, 1, <-calls)
+		assert.Equal(t, 2, <-calls)
+	})
+}
+
+func TestWorkerCallbacksCanTriggerNextInvocation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		calls := make(chan int, 10)
+		wantErr := errors.New("retry explicitly")
+		var d *debounce.Debouncer[int]
+		d = newDebouncer(t, time.Second, func(_ context.Context, value int) error {
+			calls <- value
+			switch value {
+			case 1:
+				assert.NoError(t, d.Trigger(2))
+			case 2:
+				return wantErr
+			}
+
+			return nil
+		}, debounce.WithOnError(func(err error) {
+			assert.ErrorIs(t, err, wantErr)
+			assert.NoError(t, d.Trigger(3))
+		}))
+		require.NoError(t, d.Trigger(1))
+		for expected := 1; expected <= 3; expected++ {
+			time.Sleep(time.Second)
+			synctest.Wait()
+			require.Len(t, calls, 1)
+			assert.Equal(t, expected, <-calls)
+		}
+	})
+}

--- a/versions.yaml
+++ b/versions.yaml
@@ -37,6 +37,9 @@ module-sets:
       - github.com/go-fries/fries/cloudevents/protocol/amqp091/v4
       - github.com/go-fries/fries/cloudevents/eventdispatcher/v4
 
+      # Debounce
+      - github.com/go-fries/fries/debounce/v4
+
       # Env
       - github.com/go-fries/fries/env/v4
 


### PR DESCRIPTION
## Summary
Add a generic, context-aware `debounce` module for processing the latest value after a quiet interval.

## Changes
- Add `New`, `Trigger`, `Flush`, `Close`, and `WithOnError`, with serial handler execution and bounded retained values.
- Restart the quiet interval on each trigger; triggers during execution coalesce into the next invocation.
- Freeze pending values for explicit flushing so later triggers cannot replace them. When the frozen slot is occupied, additional flushes wait before capturing the latest pending value. Flush cancellation only ends waiting; handler errors are returned for the selected invocation and reported through the optional error callback.
- Close on explicit shutdown or parent-context cancellation, discard work that has not started, and wait for the running handler and error callback. Call `Flush` before `Close` to process the final pending value.
- Add Go Doc, usage examples, deterministic timing and concurrency tests, and module release/catalog/coverage registration.

## Motivation
Provide a reusable primitive for coalescing frequent updates, such as draft saves and configuration reloads, while making flushing, background errors, and cancellation explicit.

## Testing
- `make test/debounce ARGS='-race -cover'` — passed; 97.9% statement coverage.
- `make lint/debounce` — passed.
- `make build/debounce test/. verify-mods` — passed.
- `make lint` — passed across the repository.
- `gofmt -l debounce` and `git diff --check` — clean.